### PR TITLE
Only define repository dependencies if they haven't been already.

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -79,6 +79,18 @@ _swift_autoconfiguration = repository_rule(
     implementation=_swift_autoconfiguration_impl,
 )
 
+def _maybe(repo_rule, name, **kwargs):
+  """Executes the given repository rule if it hasn't been executed already.
+
+  Args:
+    repo_rule: The repository rule to be executed (e.g.,
+        `native.git_repository`.)
+    name: The name of the repository to be defined by the rule.
+    **kwargs: Additional arguments passed directly to the repository rule.
+  """
+  if name not in native.existing_rules():
+    repo_rule(name = name, **kwargs)
+
 def swift_rules_dependencies():
   """Fetches repositories that are dependencies of the `rules_swift` workspace.
 
@@ -86,13 +98,15 @@ def swift_rules_dependencies():
   dependencies of the Swift rules are downloaded and that they are isolated from
   changes to those dependencies.
   """
-  native.git_repository(
+  _maybe(
+      native.git_repository,
       name = "bazel_skylib",
       remote = "https://github.com/bazelbuild/bazel-skylib.git",
       tag = "0.4.0",
   )
 
-  native.new_http_archive(
+  _maybe(
+      native.new_http_archive,
       name = "com_github_apple_swift_swift_protobuf",
       urls = ["https://github.com/apple/swift-protobuf/archive/1.0.3.zip"],
       strip_prefix = "swift-protobuf-1.0.3/",
@@ -100,7 +114,8 @@ def swift_rules_dependencies():
       build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_swift_protobuf/BUILD.overlay",
   )
 
-  native.http_archive(
+  _maybe(
+      native.http_archive,
       name = "com_google_protobuf",
       # v3.5.1, latest as of 2018-01-11
       urls = ["https://codeload.github.com/google/protobuf/zip/106ffc04be1abf3ff3399f54ccf149815b287dd9"],
@@ -108,6 +123,7 @@ def swift_rules_dependencies():
       type = "zip",
   )
 
-  _swift_autoconfiguration(
+  _maybe(
+      _swift_autoconfiguration,
       name = "build_bazel_rules_swift_local_config",
   )


### PR DESCRIPTION
This will improve the situation if multiple repositories define the
same dependencies (such as someone depending on rules_apple and
rules_swift, and then rules_apple also itself depending on
rules_swift). It does not address the situation where the same
dependency is used but with different versions; Bazel does not have
a great answer to this at this moment, as far as I know.