### PR TITLE
Migrate to new style ctx.actions.args.

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -224,7 +224,7 @@ def _compile_as_objects(
 
   compile_args = actions.args()
   compile_args.add("-emit-object")
-  compile_args.add(compile_reqs.args)
+  compile_args.add_all(compile_reqs.args)
   compile_args.add("-emit-module-path")
   compile_args.add(out_module)
 
@@ -617,7 +617,7 @@ def _invoke_swiftc(
       execution_requirements or {}, toolchain.execution_requirements)
 
   toolchain_args = actions.args()
-  toolchain_args.add(toolchain.swiftc_copts)
+  toolchain_args.add_all(toolchain.swiftc_copts)
 
   run_with_optional_wrapper(
       actions=actions,


### PR DESCRIPTION
Eventually --incompatible_disallow_old_style_args_add will be flipped, making old style use an error.

The new API encourages efficiency by trying to make common use cases convenient and elegant. Some functionality has been moved around and renamed, some functionality is new.

List of changes that have been used in the migration:

* Key-value overloads are used over multiple calls or formats. This ensures your command line arguments are kept together in code, and is efficient.

Instead of:
  args.add("--output")
  args.add(output)
or
  args.add(["--output", output])
or (still acceptable but not preferred)
  args.add(output, format="--output=%s")
or (worst, inefficient, creates and retains redundant strings)
  args.add("--output=%s" % output.path)
use:
  args.add("--output", output)

* args.add_all and args.add_joined replaces list/depset functionality in args.add. This change is made for clarity of parameter documentation, since certain parameters only make sense in certain modes. This is a breaking change after --incompatible_disallow_old_style_args_add.

Instead of:
  args.add(my_depset)
use:
  args.add_all(my_depset)

Instead of:
  args.add(my_depset, join_with=',')
use:
  args.add_joined(my_depset, join_with=',')

These new functions accept key-values where appropriate:
  args.add_all("--inputs", inputs)
  args.add_joined("--classpath", classpath, join_with=":")

* map_fn is replaced by map_each. map_each receives each item in turn and must return a string, None (to filter an item), or a list of strings. This change enables performance optimizations.

Before:
  def _short_paths(files):
    return [f.short_path for f in files]
  args.add(inputs, map_fn=_short_paths)

After:
  def _short_path(f):
    return f.short_path
  args.add_all(inputs, map_each=_short_path)

Filter example:
  def _java_file_or_none(f):
    return f.path if f.basename.endswith('.java') else None
  args.add_all("--java_files", srcs, map_each=_java_file_or_none)

* formatting the final join result is added to add_joined

  args.add_joined(inputs, join_with=",", format_joined="-params:%s")

PiperOrigin-RevId: 200466420