### PR TITLE
Migrate to new style ctx.actions.args.

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -80,7 +80,7 @@ def _swift_binary_test_impl(ctx):
         deps=ctx.attr.deps,
         objc_fragment=objc_fragment,
     )
-    link_args.add(compile_results.linker_flags)
+    link_args.add_all(compile_results.linker_flags)
     objects_to_link.extend(compile_results.output_objects)
     additional_inputs_to_linker = (
         compile_results.compile_inputs + compile_results.linker_inputs)
@@ -96,8 +96,8 @@ def _swift_binary_test_impl(ctx):
         hasattr(cc_common, "mostly_static_link_options")):
       # We only do this for non-Xcode toolchains at this time.
       features = ctx.features
-      link_args.add(find_cpp_toolchain(ctx).link_options_do_not_use)
-      link_args.add(cc_common.mostly_static_link_options(
+      link_args.add_all(find_cpp_toolchain(ctx).link_options_do_not_use)
+      link_args.add_all(cc_common.mostly_static_link_options(
           ctx.fragments.cpp,
           toolchain.cc_toolchain_info.provider,
           features,


### PR DESCRIPTION
Eventually --incompatible_disallow_old_style_args_add will be flipped, making old style use an error.

The new API encourages efficiency by trying to make common use cases convenient and elegant. Some functionality has been moved around and renamed, some functionality is new.

List of changes that have been used in the migration:

* Key-value overloads are used over multiple calls or formats. This ensures your command line arguments are kept together in code, and is efficient.

Instead of:
  args.add("--output")
  args.add(output)
or
  args.add(["--output", output])
or (still acceptable but not preferred)
  args.add(output, format="--output=%s")
or (worst, inefficient, creates and retains redundant strings)
  args.add("--output=%s" % output.path)
use:
  args.add("--output", output)

* args.add_all and args.add_joined replaces list/depset functionality in args.add. This change is made for clarity of parameter documentation, since certain parameters only make sense in certain modes. This is a breaking change after --incompatible_disallow_old_style_args_add.

Instead of:
  args.add(my_depset)
use:
  args.add_all(my_depset)

Instead of:
  args.add(my_depset, join_with=',')
use:
  args.add_joined(my_depset, join_with=',')

These new functions accept key-values where appropriate:
  args.add_all("--inputs", inputs)
  args.add_joined("--classpath", classpath, join_with=":")

* map_fn is replaced by map_each. map_each receives each item in turn and must return a string, None (to filter an item), or a list of strings. This change enables performance optimizations.

Before:
  def _short_paths(files):
    return [f.short_path for f in files]
  args.add(inputs, map_fn=_short_paths)

After:
  def _short_path(f):
    return f.short_path
  args.add_all(inputs, map_each=_short_path)

Filter example:
  def _java_file_or_none(f):
    return f.path if f.basename.endswith('.java') else None
  args.add_all("--java_files", srcs, map_each=_java_file_or_none)

* formatting the final join result is added to add_joined

  args.add_joined(inputs, join_with=",", format_joined="-params:%s")

PiperOrigin-RevId: 200853097