### PR TITLE
Fix module name derivation

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -571,7 +571,8 @@ def _derive_module_name(*args):
     fail("derive_module_name may only be called with a single argument of " +
          "type 'Label' or two arguments of type 'str'")
 
-  package_part = package.lstrip("//").replace("/", "_").replace("-", "_")
+  package_part = (package.lstrip("//")
+    .replace("/", "_").replace("-", "_").replace(".", "_"))
   name_part = name.replace("-", "_")
   if package_part:
     return package_part + "_" + name_part


### PR DESCRIPTION
Module names cannot contain "."

```
  (cd /private/var/tmp/_bazel_aamand/6e9e094d4711fb7bbf6e809ecba4fd6c/execroot/co_znly_protodefs && \
  exec env - \
    APPLE_SDK_PLATFORM=iPhoneSimulator \
    APPLE_SDK_VERSION_OVERRIDE=11.3 \
    XCODE_VERSION_OVERRIDE=9.3.0 \
  bazel-out/host/bin/external/bazel_tools/tools/objc/xcrunwrapper swiftc -target x86_64-apple-ios11.3 -sdk __BAZEL_XCODE_SDKROOT__ -F __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks -emit-object -output-file-map bazel-out/darwin-fastbuild/bin/external/gogo_special_proto/github.com/gogo/protobuf/gogoproto/gogoproto.output_file_map.json -emit-module-path bazel-out/darwin-fastbuild/bin/external/gogo_special_proto/github.com/gogo/protobuf/gogoproto/github.com_gogo_protobuf_gogoproto_gogoproto.swiftmodule -emit-object -module-name github.com_gogo_protobuf_gogoproto_gogoproto -Onone -DDEBUG -gline-tables-only -I bazel-out/darwin-fastbuild/bin/external/com_github_apple_swift_swift_protobuf -I bazel-out/darwin-fastbuild/bin/external/com_google_protobuf -Ibazel-out/darwin-fastbuild/bin -Xcc -iquote -Xcc . -Xcc '-fmodule-map-file=bazel-out/darwin-fastbuild/bin/external/com_github_apple_swift_swift_protobuf/SwiftProtobuf.modulemaps/module.modulemap' -Xcc '-fmodule-map-file=bazel-out/darwin-fastbuild/bin/external/com_google_protobuf/descriptor_proto.modulemaps/module.modulemap' -Xcc -O0 -Xcc '-DDEBUG=1' bazel-out/darwin-fastbuild/bin/external/gogo_special_proto/github.com/gogo/protobuf/gogoproto/gogoproto.protoc_gen_swift/github.com/gogo/protobuf/gogoproto/gogo.pb.swift -parse-as-library -emit-objc-header-path bazel-out/darwin-fastbuild/bin/external/gogo_special_proto/github.com/gogo/protobuf/gogoproto/gogoproto-Swift.h)

Use --sandbox_debug to see verbose messages from the sandbox
<unknown>:0: error: module name "github.com_gogo_protobuf_gogoproto_gogoproto" is not a valid identifier
Target //protomodels:protomodels_swift_proto failed to build
```