### PR TITLE
Add support for force loading libraries

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -610,6 +610,7 @@ def _compile_as_library(
         toolchain,
         additional_inputs = [],
         allow_testing = True,
+        alwayslink = False,
         cc_libs = [],
         configuration = None,
         copts = [],
@@ -648,6 +649,8 @@ def _compile_as_library(
           referenced in compiler flags.
       allow_testing: Indicates whether the module should be compiled with testing
           enabled (only when the compilation mode is `fastbuild` or `dbg`).
+      alwayslink: Indicates whether the module should be always be linked into
+          any binaries that link it
       cc_libs: Additional `cc_library` targets whose static libraries should be
           merged into the resulting archive.
       configuration: The default configuration from which certain compilation
@@ -714,7 +717,8 @@ def _compile_as_library(
 
     if not library_name:
         library_name = label.name
-    out_archive = derived_files.static_archive(actions, link_name = library_name)
+    out_archive = derived_files.static_archive(actions, alwayslink,
+                                               link_name = library_name)
 
     # Register the compilation actions to get an object file (.o) for the Swift
     # code, along with its swiftmodule and swiftdoc.
@@ -1035,6 +1039,14 @@ The name of the library that should be linked to targets that depend on this
 library. Supports auto-linking.
 """,
                 mandatory = False,
+            ),
+            "alwayslink": attr.bool(
+                default = False,
+                doc = """
+If true, any direct or indirect binary that depends on this rule will link in
+all the object files archived in the static library, even if some contain no
+symbols referenced by the binary.
+"""
             ),
             # TODO(b/77853138): Remove once the Apple rules support bundling from
             # `data`.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -266,6 +266,9 @@ def new_objc_provider(
     if linkopts:
         objc_provider_args["linkopt"] = depset(direct = linkopts)
 
+    if static_archive.basename.endswith(".lo"):
+        objc_provider_args["force_load_library"] = depset(direct = [static_archive])
+
     # In addition to the generated header's module map, we must re-propagate the direct deps'
     # Objective-C module maps to dependents, because those Swift modules still need to see them. We
     # need to construct a new transitive objc provider to get the correct strict propagation
@@ -395,7 +398,7 @@ def register_autolink_extract_action(
         swift_tool = "swift-autolink-extract",
     )
 
-def swift_library_output_map(name, module_link_name):
+def swift_library_output_map(name, alwayslink, module_link_name):
     """Returns the dictionary of implicit outputs for a `swift_library`.
 
     This function is used to specify the `outputs` of the `swift_library` rule; as such, its
@@ -409,8 +412,9 @@ def swift_library_output_map(name, module_link_name):
         The implicit outputs dictionary for a `swift_library`.
     """
     lib_name = module_link_name if module_link_name else name
+    extension = "lo" if alwayslink else "a"
     return {
-        "archive": "lib{}.a".format(lib_name),
+        "archive": "lib{}.{}".format(lib_name, extension),
     }
 
 def write_objc_header_module_map(

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -213,18 +213,21 @@ def _reexport_modules_src(actions, target_name):
     """
     return actions.declare_file("{}_exports.swift".format(target_name))
 
-def _static_archive(actions, link_name):
+def _static_archive(actions, alwayslink, link_name):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
       actions: The context's actions object.
+      alwayslink: Whether to always link all object files from the archive,
+          even if they aren't referenced.
       link_name: The name of the library being built, without a `lib` prefix or
           file extension.
 
     Returns:
       The declared `File`.
     """
-    return actions.declare_file("lib{}.a".format(link_name))
+    extension = "lo" if alwayslink else "a"
+    return actions.declare_file("lib{}.{}".format(link_name, extension))
 
 def _swiftc_output_file_map(actions, target_name):
     """Declares a file for the JSON-formatted output map for a compilation action.

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -53,6 +53,7 @@ def _swift_library_impl(ctx):
         swift_fragment = ctx.fragments.swift,
         toolchain = toolchain,
         additional_inputs = ctx.files.swiftc_inputs,
+        alwayslink = ctx.attr.alwayslink,
         cc_libs = ctx.attr.cc_libs,
         copts = copts,
         configuration = ctx.configuration,


### PR DESCRIPTION
ld doesn't have an -ObjC type flag for Swift. Because of this there are
common cases you can get in to that require the library to be force
loaded by any dependents.

This patch relies on the existing force_load_library behavior from the
ObjCProvider https://docs.bazel.build/versions/master/skylark/lib/ObjcProvider.html#force_load_library

More details: https://bugs.swift.org/browse/SR-6004

Once some fix for https://github.com/bazelbuild/rules_swift/pull/38 is merged, we can also add this there.