### PR TITLE
Get linker options from the C++ toolchain for Xcode builds when possi…

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -52,7 +52,6 @@ load(
     "merge_swift_clang_module_infos",
 )
 load(":swift_cc_libs_aspect.bzl", "swift_cc_libs_excluding_directs_aspect")
-load(":utils.bzl", "get_optionally")
 load("@bazel_skylib//:lib.bzl", "dicts", "partial")
 
 # The compilation modes supported by Bazel.
@@ -707,12 +706,14 @@ def _compile_as_library(
     for target in cc_libs:
         cc_lib_files.extend([f for f in target.files if f.basename.endswith(".a")])
 
+    if toolchain.system_name == "darwin" or not toolchain.cc_toolchain_info:
+        ar_executable = None
+    else:
+        ar_executable = toolchain.cc_toolchain_info.ar_executable
+
     register_static_archive_action(
         actions = actions,
-        ar_executable = get_optionally(
-            toolchain,
-            "cc_toolchain_info.ar_executable",
-        ),
+        ar_executable = ar_executable,
         libraries = cc_lib_files,
         mnemonic = "SwiftArchive",
         objects = compile_results.output_objects,

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -76,7 +76,7 @@ def register_link_action(
 
     deps_libraries = []
     for dep in deps:
-      deps_libraries.extend(collect_link_libraries(dep))
+        deps_libraries.extend(collect_link_libraries(dep))
 
     libraries = depset(transitive = deps_libraries + stamp_lib_depsets, order = "topological")
     link_input_depsets = [
@@ -99,12 +99,6 @@ def register_link_action(
 
     link_input_args.add_all(objects)
     link_input_args.add_all(libraries, map_each = _link_library_map_fn)
-
-    # TODO(b/70228246): Also support fully-dynamic mode.
-    if toolchain.cc_toolchain_info:
-        link_input_args.add("-static-libgcc")
-        link_input_args.add("-lrt")
-        link_input_args.add("-ldl")
 
     all_linkopts = depset(
         direct = expanded_linkopts,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -55,21 +55,28 @@ def _default_linker_opts(
         runtime libraries.
     """
 
-    # TODO(#8): Support statically linking the Swift runtime. Until then, the
-    # partial's arguments are ignored to avoid Skylark lint errors.
-    _ignore = (is_static, is_test)
+    _ignore = is_test
+
+    # TODO(#8): Support statically linking the Swift runtime.
     platform_lib_dir = "{toolchain_root}/lib/swift/{os}".format(
         os = os,
         toolchain_root = toolchain_root,
     )
 
-    return [
+    linkopts = [
         "-fuse-ld={}".format(cc_toolchain.ld_executable),
         "-L{}".format(platform_lib_dir),
         "-Wl,-rpath,{}".format(platform_lib_dir),
         "-lm",
         "-lstdc++",
+        "-lrt",
+        "-ldl",
     ]
+
+    if is_static:
+        linkopts.append("-static-libgcc")
+
+    return linkopts
 
 def _modified_action_args(action_args, toolchain_tools):
     """Updates an argument dictionary with values from a toolchain.


### PR DESCRIPTION
…ble.

This was previously only done for Linux toolchains, but the distinctions between apple_binary (which uses CROSSTOOL to link) and swift_binary (which doesn't fully use CROSSTOOL, yet) were causing problems for Apple targets under some circumstances (for example, test binaries and their bundle loaders).

PiperOrigin-RevId: 206822105