### PR TITLE
Allow toolchains to specify default enabled/disabled features.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -103,18 +103,19 @@ def collect_transitive_compile_inputs(args, deps, direct_defines = []):
 def declare_compile_outputs(
         actions,
         copts,
-        features,
         srcs,
-        target_name):
+        target_name,
+        index_while_building = False):
     """Declares output files (and optional output file map) for a compile action.
 
     Args:
         actions: The object used to register actions.
         copts: The flags that will be passed to the compile action, which are scanned to determine
             whether a single frontend invocation will be used or not.
-        features: Features that are enabled for the target being built.
         srcs: The list of source files that will be compiled.
         target_name: The name (excluding package path) of the target being built.
+        index_while_building: If `True`, a tree artifact will be declared to hold Clang index store
+            data and the relevant option will be added during compilation to generate the indexes.
 
     Returns:
         A `struct` containing the following fields:
@@ -185,10 +186,10 @@ def declare_compile_outputs(
     args = ["-output-file-map", output_map_file]
     output_groups = {}
 
-    # Configure index-while-building if the feature is enabled. IDEs and other indexing tools can
-    # enable this feature on the command line during a build and then access the index store
-    # artifacts that are produced.
-    if "swift.index_while_building" in features:
+    # Configure index-while-building if requested. IDEs and other indexing tools can enable this
+    # feature on the command line during a build and then access the index store artifacts that are
+    # produced.
+    if index_while_building:
         index_store_dir = derived_files.indexstore_directory(actions, target_name = target_name)
         other_outputs.append(index_store_dir)
         args.extend(["-index-store-path", index_store_dir.path])

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -1,0 +1,49 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for working with Bazel features."""
+
+def is_feature_enabled(feature, feature_configuration):
+    """Returns a value indicating whether the given feature is enabled.
+
+    This function scans the user-provided feature lists with those defined by the toolchain.
+    User-provided features always take precedence, so the user can force-enable a feature `"foo"`
+    that has been disabled by default by the toolchain if they explicitly write `features = ["foo"]`
+    in their target/package or pass `--features=foo` on the command line. Likewise, the user can
+    force-disable a feature `"foo"` that has been enabled by default by the toolchain if they
+    explicitly write `features = ["-foo"]` in their target/package or pass `--features=-foo` on the
+    command line.
+
+    If a feature is present in both the `features` and `disabled_features` lists, then disabling
+    takes precedence. Bazel should prevent this case from ever occurring when it evaluates the set
+    of features to pass to the rule context, however.
+
+    Args:
+        feature: The feature to be tested.
+        feature_configuration: A value returned by `swift_common.configure_features` that specifies
+            the enabled and disabled features of a particular target.
+
+    Returns:
+        `True` if the feature is explicitly enabled, or `False` if it is either explicitly disabled
+        or not found in any of the feature lists.
+    """
+    if feature in feature_configuration.unsupported_features:
+        return False
+    if feature in feature_configuration.requested_features:
+        return True
+    if feature in feature_configuration.toolchain.unsupported_features:
+        return False
+    if feature in feature_configuration.toolchain.requested_features:
+        return True
+    return False

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -25,7 +25,6 @@ def register_link_action(
         clang_executable,
         deps,
         expanded_linkopts,
-        features,
         inputs,
         mnemonic,
         objects,
@@ -46,7 +45,6 @@ def register_link_action(
         deps: A list of `deps` representing additional libraries that will be passed to the linker.
         expanded_linkopts: A list of strings representing options passed to the linker. Any
             `$(location ...)` placeholders are assumed to have already been expanded.
-        features: The list of features that are set on the target being linked.
         inputs: A `depset` containing additional inputs to the link action, such as those used in
             `$(location ...)` substitution, or libraries that need to be linked.
         mnemonic: The mnemonic printed by Bazel when the action executes.
@@ -64,9 +62,6 @@ def register_link_action(
         clang_executable = "clang"
 
     common_args = actions.args()
-    if "llvm_lld" in features:
-        common_args.add("-fuse-ld=lld")
-
     common_args.add_all(_coverage_linkopts(configuration))
 
     if toolchain.stamp:

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -215,6 +215,15 @@ linking binaries with this toolchain.
 `String`. The object file format of the platform that the toolchain is targeting. The currently
 supported values are `"elf"` and `"macho"`.
 """,
+        "requested_features": """
+`List` of `string`s. Features that should be implicitly enabled by default for targets built using
+this toolchain, unless overridden by the user by listing their negation in the `features` attribute
+of a target/package or in the `--features` command line flag.
+
+These features determine various compilation and debugging behaviors of the Swift build rules, and
+they are also passed to the C++ APIs used when linking (so features defined in CROSSTOOL may be used
+here).
+""",
         "requires_autolink_extract": """
 `Boolean`. `True` if the toolchain requires autolink-extract jobs to be invoked to determine which
 imported libraries must be passed to the linker.
@@ -246,6 +255,15 @@ binaries with this toolchain.
 """,
         "system_name": """
 `String`. The name of the operating system that the toolchain is targeting.
+""",
+        "unsupported_features": """
+`List` of `string`s. Features that should be implicitly disabled by default for targets built using
+this toolchain, unless overridden by the user by listing them in the `features` attribute of a
+target/package or in the `--features` command line flag.
+
+These features determine various compilation and debugging behaviors of the Swift build rules, and
+they are also passed to the C++ APIs used when linking (so features defined in CROSSTOOL may be used
+here).
 """,
     },
 )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -37,6 +37,12 @@ def _swift_library_impl(ctx):
     toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
     objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
 
+    feature_configuration = swift_common.configure_features(
+        toolchain = toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     compile_results = swift_common.compile_as_library(
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
@@ -52,7 +58,7 @@ def _swift_library_impl(ctx):
         configuration = ctx.configuration,
         defines = ctx.attr.defines,
         deps = ctx.attr.deps,
-        features = ctx.attr.features,
+        feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
         library_name = library_name,
         linkopts = linkopts,

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -53,6 +53,13 @@ following dependencies instead:\n\n""".format(
         output = reexport_src,
     )
 
+    toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    feature_configuration = swift_common.configure_features(
+        toolchain = toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
     compile_results = swift_common.compile_as_library(
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
@@ -64,8 +71,8 @@ following dependencies instead:\n\n""".format(
         toolchain = ctx.attr._toolchain[SwiftToolchainInfo],
         configuration = ctx.configuration,
         deps = ctx.attr.deps,
+        feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
-        features = ctx.attr.features,
     )
 
     return compile_results.providers + [

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -406,6 +406,12 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         # action.
         compile_deps = deps + aspect_ctx.attr._proto_support
 
+        feature_configuration = swift_common.configure_features(
+            toolchain = toolchain,
+            requested_features = aspect_ctx.features + ["swift.no_generated_header"],
+            unsupported_features = aspect_ctx.disabled_features,
+        )
+
         compile_results = swift_common.compile_as_library(
             actions = aspect_ctx.actions,
             bin_dir = aspect_ctx.bin_dir,
@@ -418,7 +424,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             allow_testing = False,
             configuration = aspect_ctx.configuration,
             deps = compile_deps,
-            features = aspect_ctx.features + ["swift.no_generated_header"],
+            feature_configuration = feature_configuration,
             genfiles_dir = aspect_ctx.genfiles_dir,
             # Prevent conflicts with C++ protos in the same output directory, which
             # use the `lib{name}.a` pattern. This will produce `lib{name}.swift.a`

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -167,6 +167,7 @@ def _swift_toolchain_impl(ctx):
             implicit_deps = [],
             linker_opts_producer = linker_opts_producer,
             object_format = "elf",
+            requested_features = ctx.features,
             requires_autolink_extract = True,
             root_dir = toolchain_root,
             stamp = ctx.attr.stamp,
@@ -179,6 +180,7 @@ def _swift_toolchain_impl(ctx):
             supports_response_files = False,
             swiftc_copts = [],
             system_name = ctx.attr.os,
+            unsupported_features = ctx.disabled_features,
         ),
     ]
 

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -346,6 +346,7 @@ def _xcode_swift_toolchain_impl(ctx):
             implicit_deps = [],
             linker_opts_producer = linker_opts_producer,
             object_format = "macho",
+            requested_features = ctx.features,
             requires_autolink_extract = False,
             requires_workspace_relative_module_maps = False,
             root_dir = None,
@@ -359,6 +360,7 @@ def _xcode_swift_toolchain_impl(ctx):
             supports_response_files = False,
             swiftc_copts = swiftc_copts,
             system_name = "darwin",
+            unsupported_features = ctx.disabled_features,
         ),
     ]
 


### PR DESCRIPTION
Allow toolchains to specify default enabled/disabled features.

This is the first part of a refactoring that will restate support for things like debug prefix map and response files as Bazel features instead of separate fields in the provider, which keeps the provider from becoming bloated and also gives users some finer control if needed.