### PR TITLE
Enable whole module optimization for opt builds

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -296,7 +296,7 @@ def _compilation_mode_copts(allow_testing, compilation_mode, wants_dsyms = False
     # compilation modes given in the Bazel documentation.
     flags = []
     if compilation_mode == "opt":
-        flags += ["-O", "-DNDEBUG"]
+        flags += ["-O", "-DNDEBUG", "-whole-module-optimization"]
     elif compilation_mode in ("dbg", "fastbuild"):
         if allow_testing:
             flags.append("-enable-testing")


### PR DESCRIPTION
Follow up to https://github.com/bazelbuild/rules_swift/issues/46#issuecomment-424074965. This enables `-whole-module-optimization` for `opt` builds, which matches Xcode/Apple behavior.