### PR TITLE
Add wrapper scripts for swift/swiftc.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -23,43 +23,34 @@ load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def run_toolchain_action(actions, toolchain, **kwargs):
-    """Equivalent to `actions.run`, but for tools in the Swift toolchain.
+    """Equivalent to `actions.run`, but respecting toolchain settings.
 
-    This function applies the toolchain's environment and execution requirements
-    and also wraps the command in a wrapper executable if the toolchain requires
-    it (for example, `xcrun` on Darwin).
+    This function applies the toolchain's environment and execution requirements and also wraps the
+    command in a wrapper executable if the toolchain requires it (for example, `xcrun` on Darwin).
 
-    If the `executable` argument is a simple basename (such as "swiftc") and the
-    toolchain has an explicit root directory, then it is modified to be relative
-    to the toolchain's `bin` directory. Otherwise, if it is an absolute path, a
-    relative path with multiple path components, or a `File` object, then it is
-    executed as-is.
+    If the `executable` argument is a simple basename and the toolchain has an explicit root
+    directory, then it is modified to be relative to the toolchain's `bin` directory. Otherwise,
+    if it is an absolute path, a relative path with multiple path components, or a `File` object,
+    then it is executed as-is.
 
     Args:
       actions: The `Actions` object with which to register actions.
-      toolchain: The `SwiftToolchainInfo` provider that prescribes the action's
-          requirements.
+      toolchain: The `SwiftToolchainInfo` provider that prescribes the action's requirements.
       **kwargs: Additional arguments to `actions.run`.
     """
     modified_args = dict(kwargs)
 
     executable = modified_args.get("executable")
-    if (type(executable) == type("") and "/" not in executable and
-        toolchain.root_dir):
-        modified_args["executable"] = paths.join(
-            toolchain.root_dir,
-            "bin",
-            executable,
-        )
+    if (type(executable) == type("") and "/" not in executable and toolchain.root_dir):
+        modified_args["executable"] = paths.join(toolchain.root_dir, "bin", executable)
 
     partial.call(toolchain.action_registrars.run, actions, **modified_args)
 
 def run_toolchain_shell_action(actions, toolchain, **kwargs):
     """Equivalent to `actions.run_shell`, but respecting toolchain settings.
 
-    This function applies the toolchain's environment and execution requirements
-    and also wraps the command in a wrapper executable if the toolchain requires
-    it (for example, `xcrun` on Darwin).
+    This function applies the toolchain's environment and execution requirements and also wraps the
+    command in a wrapper executable if the toolchain requires it (for example, `xcrun` on Darwin).
 
     Args:
       actions: The `Actions` object with which to register actions.
@@ -68,3 +59,35 @@ def run_toolchain_shell_action(actions, toolchain, **kwargs):
       **kwargs: Additional arguments to `actions.run_shell`.
     """
     partial.call(toolchain.action_registrars.run_shell, actions, **kwargs)
+
+def run_toolchain_swift_action(actions, swift_tool, toolchain, **kwargs):
+    """Executes a Swift toolchain tool using its wrapper.
+
+    This function applies the toolchain's environment and execution requirements and wraps the
+    command in a toolchain-specific wrapper if necessary (for example, `xcrun` on Darwin) and in
+    additional pre- and post-processing to handle certain tasks like debug prefix remapping and
+    module cache health.
+
+    If the `swift_tool` argument is a simple basename and the toolchain has an explicit root
+    directory, then it is modified to be relative to the toolchain's `bin` directory. Otherwise,
+    if it is an absolute path, a relative path with multiple path components, or a `File` object,
+    then it is executed as-is.
+
+    Args:
+      actions: The `Actions` object with which to register actions.
+      swift_tool: The name of the Swift tool to invoke.
+      toolchain: The `SwiftToolchainInfo` provider that prescribes the action's requirements.
+      **kwargs: Additional arguments to `actions.run`.
+    """
+    if "executable" in kwargs:
+        fail("run_toolchain_swift_action does not support 'executable'. " +
+             "Use 'swift_tool' instead.")
+
+    modified_args = dict(kwargs)
+
+    if ("/" not in swift_tool and toolchain.root_dir):
+        modified_args["swift_tool"] = paths.join(toolchain.root_dir, "bin", swift_tool)
+    else:
+        modified_args["swift_tool"] = swift_tool
+
+    partial.call(toolchain.action_registrars.run_swift, actions, **modified_args)

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -14,7 +14,7 @@
 
 """Implementation of compilation logic for Swift."""
 
-load(":actions.bzl", "run_toolchain_action")
+load(":actions.bzl", "run_toolchain_swift_action")
 load(":deps.bzl", "collect_link_libraries")
 load(":derived_files.bzl", "derived_files")
 load(
@@ -385,14 +385,14 @@ def register_autolink_extract_action(
     tool_args.add_all(objects)
     tool_args.add("-o", output)
 
-    run_toolchain_action(
+    run_toolchain_swift_action(
         actions = actions,
         toolchain = toolchain,
         arguments = [tool_args],
-        executable = "swift-autolink-extract",
         inputs = objects,
         mnemonic = "SwiftAutolinkExtract",
         outputs = [output],
+        swift_tool = "swift-autolink-extract",
     )
 
 def swift_library_output_map(name, module_link_name):

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -14,7 +14,7 @@
 
 """Functions relating to debugging support during compilation and linking."""
 
-load(":actions.bzl", "run_toolchain_action")
+load(":actions.bzl", "run_toolchain_swift_action")
 load(":derived_files.bzl", "derived_files")
 load(":providers.bzl", "SwiftToolchainInfo")
 
@@ -113,12 +113,12 @@ def _register_modulewrap_action(
     tool_args.add(swiftmodule)
     tool_args.add("-o", object)
 
-    run_toolchain_action(
+    run_toolchain_swift_action(
         actions = actions,
         toolchain = toolchain,
         arguments = [tool_args],
-        executable = "swift",
         inputs = [swiftmodule],
         mnemonic = "SwiftModuleWrap",
         outputs = [object],
+        swift_tool = "swift",
     )

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -54,6 +54,13 @@ SWIFT_FEATURE_NO_GENERATED_HEADER = "swift.no_generated_header"
 # present.
 SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 
+# If enabled, Swift compilation actions will use the same global Clang module cache used by
+# Objective-C compilation actions. This is disabled by default because under some circumstances
+# Clang module cache corruption can cause the Swift compiler to crash (sometimes when switching
+# configurations or syncing a repository), but disabling it also causes a noticeable build time
+# regression so it can be explicitly re-enabled by users who are not affected by those crashes.
+SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
+
 # If enabled, actions invoking the Swift driver or frontend may write argument lists into response
 # files (i.e., "@args.txt") to avoid passing command lines that exceed the system limit. Toolchains
 # typically set this automatically if using a sufficiently recent version of Swift (4.2 or higher).

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -88,6 +88,7 @@ def _swift_linking_rule_impl(
             additional_input_depsets = [depset(direct = additional_inputs)],
             configuration = ctx.configuration,
             deps = ctx.attr.deps,
+            genfiles_dir = ctx.genfiles_dir,
             objc_fragment = objc_fragment,
         )
         link_args.add_all(compile_results.linker_flags)

--- a/swift/internal/wrappers.bzl
+++ b/swift/internal/wrappers.bzl
@@ -1,0 +1,25 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attributes for Swift tool wrapper executables used by the toolchains."""
+
+SWIFT_TOOL_WRAPPER_ATTRIBUTES = {
+    "_swift_wrapper": attr.label(
+        cfg = "host",
+        default = Label(
+            "@build_bazel_rules_swift//tools/wrappers:swift_wrapper",
+        ),
+        executable = True,
+    ),
+}

--- a/tools/wrappers/BUILD
+++ b/tools/wrappers/BUILD
@@ -1,8 +1,14 @@
 licenses(["notice"])
 
 sh_binary(
-    name = "xcrunwrapper",
-    srcs = ["xcrunwrapper.sh"],
+    name = "bazel_xcode_wrapper",
+    srcs = ["bazel_xcode_wrapper.sh"],
+    visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "swift_wrapper",
+    srcs = ["swift_wrapper.sh"],
     visibility = ["//visibility:public"],
 )
 

--- a/tools/wrappers/bazel_xcode_wrapper.sh
+++ b/tools/wrappers/bazel_xcode_wrapper.sh
@@ -15,14 +15,16 @@
 # limitations under the License.
 
 # SYNOPSIS
-#   Invokes `xcrun`, replacing any special Bazel placeholder strings in the
-#   argument list or in params files with their actual values.
+#   Replaces special Bazel placeholder strings in the argument list or in
+#   params files with their actual values.
 #
 # USAGE
-#   xcrunwrapper.sh <arguments...>
+#   bazel_xcode_wrapper <executable> <arguments...>
 #
 # ARGUMENTS
-#   arguments...: Arguments passed directly to `xcrun`.
+#   executable: The actual executable to launch.
+#   arguments...: Arguments that are processed and then passed to the
+#     executable.
 
 set -eu
 
@@ -50,7 +52,7 @@ function rewrite_argument {
 function rewrite_params_file {
   PARAMSFILE="$1"
   if grep -qe '__BAZEL_XCODE_\(DEVELOPER_DIR\|SDKROOT\)__' "$PARAMSFILE" ; then
-    NEWFILE="$(mktemp "${TMPDIR%/}/xcrunwrapper_params.XXXXXXXXXX")"
+    NEWFILE="$(mktemp "${TMPDIR%/}/bazel_xcode_wrapper_params.XXXXXXXXXX")"
     sed \
         -e "s#__BAZEL_XCODE_DEVELOPER_DIR__#$WRAPPER_DEVDIR#g" \
         -e "s#__BAZEL_XCODE_SDKROOT__#$SDKROOT#g" \
@@ -97,4 +99,4 @@ done
 
 # We can't use `exec` here because we need to make sure the `trap` runs
 # afterward.
-/usr/bin/xcrun "$TOOLNAME" "${ARGS[@]}"
+"$TOOLNAME" "${ARGS[@]}"

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# SYNOPSIS
+#   Invokes a Swift tool, adding custom pre- and post-invocation behavior
+#   needed by the Bazel build rules.
+#
+#   This script recognizes special arguments of the form
+#   `-Xwrapped-swift=<arg>` to enable special behaviors. These arguments must
+#   be passed directly on the command line; for performance reasons this script
+#   does not process params files. Arguments of this form are consumed entirely
+#   by this wrapper and are not passed down to the Swift tool (however, they
+#   may add normal arguments that would be passed).
+#
+# USAGE
+#   swift_wrapper <executable> <arguments...>
+#
+# ARGUMENTS
+#   executable: The executable to invoke. This should be a tool in the Swift
+#       toolchain, or a similar invocation (like `xcrun` followed by a Swift
+#       tool).
+#   arguments...: Arguments that are either processed by the wrapper or passed
+#       directly to the underlying Swift tool.
+#
+#   The following wrapper-specific arguments are supported:
+#
+#   -Xwrapped-swift=-ephemeral-module-cache
+#       When specified, the wrapper will create a new temporary directory, pass
+#       that to the Swift compiler using `-module-cache-path`, and then delete
+#       the directory afterwards. This should resolve issues where the module
+#       cache state is not refreshed correctly in all situations, which
+#       sometimes results in hard-to-diagnose crashes in `swiftc`.
+
+set -eu
+
+# Called when the wrapper exits (normally or abnormally) to clean up any
+# temporary state.
+function cleanup {
+  if [[ -n "$MODULE_CACHE_DIR" ]] ; then
+    rm -rf "$MODULE_CACHE_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
+TOOLNAME="$1"
+shift
+
+TMPDIR="${TMPDIR:-/tmp}"
+MODULE_CACHE_DIR=
+
+# Process the argument list.
+ARGS=()
+for ARG in "$@" ; do
+  case "$ARG" in
+  -Xwrapped-swift=-ephemeral-module-cache)
+    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
+    ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")
+    ;;
+  *)
+    ARGS+=("$ARG")
+    ;;
+  esac
+done
+
+# Invoke the underlying command with the modified arguments. We don't use
+# `exec` here beause we need the cleanup trap to run after execution.
+"$TOOLNAME" "${ARGS[@]}"


### PR DESCRIPTION
Add wrapper scripts for swift/swiftc.

Currently, only wrapper_swiftc is used; it provides an option to use an ephemeral
module cache directory in an attempt to get rid of flakiness with the default
module cache that causes compiler crashes after some configuration changes or
repository syncs.