### PR TITLE
Use basename for macOS test bundle binaries

### DIFF
--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -26,7 +26,7 @@ set -eu
 BINARY="$TEST_SRCDIR/$TEST_WORKSPACE/%binary%"
 BUNDLE_DIR="$(dirname "$BINARY")/$(basename "$BINARY").xctest"
 mkdir -p "$BUNDLE_DIR/Contents/MacOS"
-ln -s "$BINARY" "$BUNDLE_DIR/Contents/MacOS/"
+ln -sf "$BINARY" "$BUNDLE_DIR/Contents/MacOS/"
 
 # TODO(allevato): Support Bazel's --test_filter.
 exec xcrun xctest -XCTest All "$BUNDLE_DIR"

--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -24,7 +24,7 @@ set -eu
 # Create the .xctest bundle and copy the binary into it (a requirement of the
 # `xctest` tool).
 BINARY="$TEST_SRCDIR/$TEST_WORKSPACE/%binary%"
-BUNDLE_DIR="$(dirname "$BINARY").xctest"
+BUNDLE_DIR="$(dirname "$BINARY")/$(basename "$BINARY").xctest"
 mkdir -p "$BUNDLE_DIR/Contents/MacOS"
 ln -s "$BINARY" "$BUNDLE_DIR/Contents/MacOS/"
 


### PR DESCRIPTION
When using swift_test on macOS, the resulting bundle must have this
layout: `foo.xctest/Contents/MacOS/foo`. Previously using `dirname` to
create the `.xctest` directory resulted in the parent directory of the
module, which doesn't necessarily match the binary's name.