### PR TITLE
Support linking objc_framework dependencies

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -22,7 +22,7 @@ load(
     "SwiftInfo",
     "SwiftToolchainInfo",
 )
-load(":utils.bzl", "collect_transitive")
+load(":utils.bzl", "collect_transitive", "objc_provider_framework_name")
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
@@ -347,7 +347,7 @@ def objc_compile_requirements(args, deps, objc_fragment):
             "-Xfrontend",
             [
                 "-disable-autolink-framework",
-                _objc_provider_framework_name(framework),
+                objc_provider_framework_name(framework),
             ],
         ))
 
@@ -559,14 +559,3 @@ def _safe_int(s):
         if s[i] < "0" or s[i] > "9":
             return None
     return int(s)
-
-def _objc_provider_framework_name(path):
-    """Returns the name of the framework from an `objc` provider path.
-
-    Args:
-        path: A path that came from an `objc` provider.
-
-    Returns:
-        A string containing the name of the framework (e.g., `Foo` for `Foo.framework`).
-    """
-    return path.rpartition("/")[2].partition(".")[0]

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -109,3 +109,14 @@ def owner_relative_path(file):
         )
     else:
         return paths.relativize(file.short_path, package)
+
+def objc_provider_framework_name(path):
+    """Returns the name of the framework from an `objc` provider path.
+
+    Args:
+        path: A path that came from an `objc` provider.
+
+    Returns:
+        A string containing the name of the framework (e.g., `Foo` for `Foo.framework`).
+    """
+    return path.rpartition("/")[2].partition(".")[0]


### PR DESCRIPTION
Previously if you depended on a objc_framework rule and attempted to
link a binary, it would fail because the paths to the binaries you
depended on where not passed to the linker.