### PR TITLE
Remove "requires-darwin" requirement for Swift proto generating action.

### DIFF
--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -215,9 +215,6 @@ def _register_pbswift_generate_action(
     actions.run(
         arguments = [mkdir_args, protoc_executable_args, protoc_args],
         executable = mkdir_and_run,
-        # TODO(b/79093417): Remove the Darwin requirement when we're building the
-        # generator on Linux.
-        execution_requirements = {"requires-darwin": ""},
         inputs = depset(
             direct = additional_command_inputs,
             transitive = [transitive_descriptor_sets],


### PR DESCRIPTION
Remove "requires-darwin" requirement for Swift proto generating action.