### PR TITLE
Don't add duplicate -emit-object flag

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -1220,7 +1220,6 @@ def _swiftc_command_line_and_inputs(
 
     all_deps = deps + toolchain.implicit_deps
 
-    args.add("-emit-object")
     args.add("-module-name")
     args.add(module_name)
 


### PR DESCRIPTION
Don't add duplicate -emit-object flag

The `-emit-object` flag was being added twice to `compile_args`. Once directly, and another time via `_swiftc_command_line_and_inputs()`. This removes the one being added in `_swiftc_command_line_and_inputs()`.