### PR TITLE
Migrate single_file to allow_single_file

### DIFF
--- a/swift/internal/swift_c_module.bzl
+++ b/swift/internal/swift_c_module.bzl
@@ -73,13 +73,12 @@ module target depend on that.
             providers = [["cc"]],
         ),
         "module_map": attr.label(
-            allow_files = True,
+            allow_single_file = True,
             doc = """
 The module map file that should be loaded to import the C library dependency
 into Swift.
 """,
             mandatory = True,
-            single_file = True,
         ),
     },
     doc = """


### PR DESCRIPTION
single_file is deprecated, this came up when testing with
`--all_incompatible_changes`