### PR TITLE
Add support for force loading libraries

### DIFF
--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -213,18 +213,22 @@ def _reexport_modules_src(actions, target_name):
     """
     return actions.declare_file("{}_exports.swift".format(target_name))
 
-def _static_archive(actions, link_name):
+def _static_archive(actions, alwayslink, link_name):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
       actions: The context's actions object.
+      alwayslink: Indicates whether the object files in the library should always
+          be always be linked into any binaries that depend on it, even if some
+          contain no symbols referenced by the binary.
       link_name: The name of the library being built, without a `lib` prefix or
           file extension.
 
     Returns:
       The declared `File`.
     """
-    return actions.declare_file("lib{}.a".format(link_name))
+    extension = "lo" if alwayslink else "a"
+    return actions.declare_file("lib{}.{}".format(link_name, extension))
 
 def _swiftc_output_file_map(actions, target_name):
     """Declares a file for the JSON-formatted output map for a compilation action.

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -53,6 +53,7 @@ def _swift_library_impl(ctx):
         swift_fragment = ctx.fragments.swift,
         toolchain = toolchain,
         additional_inputs = ctx.files.swiftc_inputs,
+        alwayslink = ctx.attr.alwayslink,
         cc_libs = ctx.attr.cc_libs,
         copts = copts,
         configuration = ctx.configuration,


### PR DESCRIPTION
Add support for force loading libraries

ld doesn't have an -ObjC type flag for Swift. Because of this there are
common cases you can get in to that require the library to be force
loaded by any dependents.

This patch relies on the existing force_load_library behavior from the
ObjCProvider https://docs.bazel.build/versions/master/skylark/lib/ObjcProvider.html#force_load_library

More details: https://bugs.swift.org/browse/SR-6004

Once some fix for https://github.com/bazelbuild/rules_swift/pull/38 is merged, we can also add this there.