### PR TITLE
Generate module maps for direct `cc_library` deps.

### DIFF
--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -1,9 +1,4 @@
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
-    "swift_c_module",
-    "swift_library",
-)
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
 
 licenses(["notice"])
 
@@ -19,28 +14,21 @@ cc_library(
     name = "c_counter",
     srcs = ["c_counter.cc"],
     hdrs = ["c_counter.h"],
+    tags = ["swift_module=CCounter"],
     deps = [":counter"],
 )
 
-# 3. Since `cc_library` targets don't write out module maps that are compatible
-# with Swift imports, we provide our own and wrap the original library in a new
-# target.
-swift_c_module(
-    name = "counter_module",
-    module_map = "module.modulemap",
-    deps = [":c_counter"],
-)
-
-# 4. The Swift library then depends on the module and imports it in its Swift
-# code.
+# 3. The Swift library then depends on the `cc_library`. This causes a
+# Swift-compatible module map to be created for the `cc_library` so that the
+# Swift code can import it.
 swift_library(
     name = "swift_counter",
     srcs = ["Counter.swift"],
     module_name = "Counter",
-    deps = [":counter_module"],
+    deps = [":c_counter"],
 )
 
-# 5. Finally, this binary is a straightforward target with no surprises. It just
+# 4. Finally, this binary is a straightforward target with no surprises. It just
 # imports the Swift `Counter` module above.
 swift_binary(
     name = "c_from_swift",

--- a/examples/xplatform/c_from_swift/module.modulemap
+++ b/examples/xplatform/c_from_swift/module.modulemap
@@ -1,3 +1,0 @@
-module CCounter {
-    header "c_counter.h"
-}

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -17,20 +17,21 @@
 load(":providers.bzl", "SwiftClangModuleInfo", "SwiftInfo")
 load(":swift_cc_libs_aspect.bzl", "swift_cc_libs_aspect")
 
-SWIFT_COMMON_RULE_ATTRS = {
-    "data": attr.label_list(
-        allow_files = True,
-        doc = """
+def swift_common_rule_attrs(additional_deps_aspects = []):
+    return {
+        "data": attr.label_list(
+            allow_files = True,
+            doc = """
 The list of files needed by this target at runtime.
 
 Files and targets named in the `data` attribute will appear in the `*.runfiles`
 area of this target, if it has one. This may include data files needed by a
 binary or library, or other programs needed by it.
 """,
-    ),
-    "deps": attr.label_list(
-        aspects = [swift_cc_libs_aspect],
-        doc = """
+        ),
+        "deps": attr.label_list(
+            aspects = [swift_cc_libs_aspect] + additional_deps_aspects,
+            doc = """
 A list of targets that are dependencies of the target being built, which will be
 linked into that target. Allowed kinds of dependencies are:
 
@@ -43,11 +44,11 @@ targets (or anything propagating the `apple_common.Objc` provider) are allowed
 as dependencies. On platforms that do not support Objective-C interop (such as
 Linux), those dependencies will be **ignored.**
 """,
-        providers = [
-            [SwiftClangModuleInfo],
-            [SwiftInfo],
-            [apple_common.Objc],
-            ["cc"],
-        ],
-    ),
-}
+            providers = [
+                [SwiftClangModuleInfo],
+                [SwiftInfo],
+                [apple_common.Objc],
+                ["cc"],
+            ],
+        ),
+    }

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -142,7 +142,7 @@ def _intermediate_object_file(actions, target_name, src):
     )
 
 def _module_map(actions, target_name):
-    """Declares the module map for the generated Objective-C header of a target.
+    """Declares the module map for the generated C or Objective-C header of a target.
 
     Args:
       actions: The context's actions object.

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -19,6 +19,7 @@ load(":derived_files.bzl", "derived_files")
 load(":features.bzl", "SWIFT_FEATURE_BUNDLED_XCTESTS", "is_feature_enabled")
 load(":linking.bzl", "register_link_action")
 load(":providers.bzl", "SwiftBinaryInfo", "SwiftToolchainInfo")
+load(":swift_c_module_aspect.bzl", "swift_c_module_aspect")
 load(":utils.bzl", "expand_locations")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:partial.bzl", "partial")
@@ -281,7 +282,7 @@ def _swift_test_impl(ctx):
 
 swift_binary = rule(
     attrs = dicts.add(
-        swift_common.compilation_attrs(),
+        swift_common.compilation_attrs(additional_deps_aspects = [swift_c_module_aspect]),
         {
             "linkopts": attr.string_list(
                 doc = """
@@ -325,7 +326,7 @@ instead of `swift_binary`.
 
 swift_test = rule(
     attrs = dicts.add(
-        swift_common.compilation_attrs(),
+        swift_common.compilation_attrs(additional_deps_aspects = [swift_c_module_aspect]),
         {
             "linkopts": attr.string_list(
                 doc = """

--- a/swift/internal/swift_c_module_aspect.bzl
+++ b/swift/internal/swift_c_module_aspect.bzl
@@ -1,0 +1,181 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generates Swift-compatible module maps for direct C dependencies of Swift targets."""
+
+load(":api.bzl", "swift_common")
+load(":derived_files.bzl", "derived_files")
+load(":features.bzl", "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD", "is_feature_enabled")
+load(":providers.bzl", "SwiftClangModuleInfo", "SwiftToolchainInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _explicit_module_name(tags):
+    """Returns an explicit module name specified by a tag of the form `"swift_module=Foo"`.
+
+    Since tags are unprocessed strings, nothing prevents the `swift_module` tag from being listed
+    multiple times on the same target with different values. For this reason, the aspect uses the
+    _last_ occurrence that it finds in the list.
+
+    Args:
+        tags: The list of tags from the `cc_library` target to which the aspect is being applied.
+
+    Returns:
+        The desired module name if it was present in `tags`, or `None`.
+    """
+    module_name = None
+    for tag in tags:
+        if tag.startswith("swift_module="):
+            _, _, module_name = tag.partition("=")
+    return module_name
+
+def _header_path(file, module_map, workspace_relative):
+    """Returns the path to a header file as it should be written into the module map.
+
+    Args:
+        file: A `File` representing the header whose path should be returned.
+        module_map: A `File` representing the module map being written, which is used during path
+            relativization if necessary.
+        workspace_relative: A Boolean value indicating whether the path should be
+            workspace-relative or module-map-relative.
+
+    Returns:
+        The path to the header file, relative to either the workspace or the module map as
+        requested.
+    """
+
+    # If the module map is workspace-relative, then the file's path is what we want.
+    if workspace_relative:
+        return file.path
+
+    # Otherwise, since the module map is generated, we need to get the full path to it rather than
+    # just its short path (that is, the path starting with bazel-out/). Then, we can simply walk up
+    # the same number of parent directories as there are path segments, and append the header
+    # file's path to that.
+    num_segments = len(paths.dirname(module_map.path).split("/"))
+    return ("../" * num_segments) + file.path
+
+def _write_module_map(
+        actions,
+        module_map,
+        module_name,
+        hdrs = [],
+        textual_hdrs = [],
+        workspace_relative = False):
+    """Writes the content of the module map to a file.
+
+    Args:
+        actions: The actions object from the aspect context.
+        module_map: A `File` representing the module map being written.
+        module_name: The name of the module being generated.
+        hdrs: The value of `attr.hdrs` for the target being written (which is a list of targets
+            that are either source files or generated files).
+        textual_hdrs: The value of `attr.textual_hdrs` for the target being written (which is a
+            list of targets that are either source files or generated files).
+        workspace_relative: A Boolean value indicating whether the path should be
+            workspace-relative or module-map-relative.
+    """
+    content = "module {} {{\n".format(module_name)
+
+    # TODO(allevato): Should we consider moving this to an external tool to avoid the analysis time
+    # expansion of these depsets? We're doing this in the initial version because these sets tend
+    # to be very small.
+    for target in hdrs:
+        content += "".join([
+            '    header "{}"\n'.format(_header_path(header, module_map, workspace_relative))
+            for header in target.files.to_list()
+        ])
+    for target in textual_hdrs:
+        content += "".join([
+            '    textual header "{}"\n'.format(_header_path(header, module_map, workspace_relative))
+            for header in target.files.to_list()
+        ])
+    content += "    export *\n"
+    content += "}\n"
+
+    actions.write(output = module_map, content = content)
+
+def _swift_c_module_aspect_impl(target, aspect_ctx):
+    # Do nothing if the target already propagates `SwiftClangModuleInfo`.
+    if SwiftClangModuleInfo in target:
+        return []
+
+    attr = aspect_ctx.rule.attr
+
+    # If there's an explicit module name, use it; otherwise, auto-derive one using the usual
+    # derivation logic for Swift targets.
+    module_name = _explicit_module_name(attr.tags)
+    if not module_name:
+        if "/" in target.label.name or "+" in target.label.name:
+            return []
+        module_name = swift_common.derive_module_name(target.label)
+
+    # Determine if the toolchain requires module maps to use workspace-relative paths or not.
+    toolchain = aspect_ctx.attr._toolchain_for_aspect[SwiftToolchainInfo]
+    feature_configuration = swift_common.configure_features(
+        toolchain,
+        requested_features = aspect_ctx.features,
+        unsupported_features = aspect_ctx.disabled_features,
+    )
+    workspace_relative = is_feature_enabled(
+        SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
+        feature_configuration,
+    )
+
+    # It's not great to depend on the rule name directly, but we need to access the exact `hdrs`
+    # and `textual_hdrs` attributes (which may not be propagated distinctly by a provider) and
+    # also make sure that we don't pick up rules like `objc_library` which already handle module
+    # map generation.
+    if aspect_ctx.rule.kind == "cc_library":
+        module_map = derived_files.module_map(aspect_ctx.actions, target.label.name)
+        _write_module_map(
+            actions = aspect_ctx.actions,
+            hdrs = attr.hdrs,
+            module_map = module_map,
+            module_name = module_name,
+            textual_hdrs = attr.textual_hdrs,
+            workspace_relative = workspace_relative,
+        )
+
+        return [SwiftClangModuleInfo(
+            transitive_compile_flags = depset(
+                direct = ["-I{}".format(include) for include in attr.includes],
+            ),
+            transitive_defines = depset(direct = attr.defines),
+            transitive_headers = depset(transitive = (
+                [target.files for target in attr.hdrs] +
+                [target.files for target in attr.textual_hdrs]
+            )),
+            transitive_modulemaps = depset(direct = [module_map]),
+        )]
+
+    # TODO(b/118311259): Figure out how to handle transitive dependencies, in case a C-only
+    # module incldues headers from another C-only module. We currently have a lot of targets with
+    # labels that clash when mangled into a Swift module name, so we need to figure out how to
+    # handle those (either by adding the `swift_module` tag to them, or opting them in some other
+    # way).
+    return []
+
+swift_c_module_aspect = aspect(
+    attrs = swift_common.toolchain_attrs(toolchain_attr_name = "_toolchain_for_aspect"),
+    doc = """
+Generates Swift-compatible module maps for direct `cc_library` dependencies.
+
+The modules generated by this aspect have names that are automatically derived from the label of
+the `cc_library` target, using the same logic used to derive the module names for Swift targets.
+
+This aspect is an implementation detail of the Swift build rules and is not meant to be attached
+to other rules or run independently.
+""",
+    implementation = _swift_c_module_aspect_impl,
+)

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -15,7 +15,7 @@
 """Implementation of the `swift_import` rule."""
 
 load(":api.bzl", "swift_common")
-load(":attrs.bzl", "SWIFT_COMMON_RULE_ATTRS")
+load(":attrs.bzl", "swift_common_rule_attrs")
 load(":providers.bzl", "SwiftClangModuleInfo", "merge_swift_clang_module_infos")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
@@ -51,7 +51,7 @@ def _swift_import_impl(ctx):
 
 swift_import = rule(
     attrs = dicts.add(
-        SWIFT_COMMON_RULE_ATTRS,
+        swift_common_rule_attrs(),
         {
             "archives": attr.label_list(
                 allow_empty = False,

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -17,6 +17,7 @@
 load(":api.bzl", "swift_common")
 load(":compiling.bzl", "swift_library_output_map")
 load(":providers.bzl", "SwiftToolchainInfo")
+load(":swift_c_module_aspect.bzl", "swift_c_module_aspect")
 load(":utils.bzl", "expand_locations")
 
 def _swift_library_impl(ctx):
@@ -91,7 +92,7 @@ def _swift_library_impl(ctx):
     )
 
 swift_library = rule(
-    attrs = swift_common.library_rule_attrs(),
+    attrs = swift_common.library_rule_attrs(additional_deps_aspects = [swift_c_module_aspect]),
     doc = """
 Compiles and links Swift code into a static library and Swift module.
 """,


### PR DESCRIPTION
Generate module maps for direct `cc_library` deps.

RELNOTES: The Swift build rules now automatically generate Swift-compatible
module maps for any `cc_library` targets that are direct dependencies of a
Swift target so that C definitions in those libraries can be imported.

By default, the module name will be derived from the `cc_library` target
label using the same logic used for Swift targets. This can be overridden
by specifying `tags = ["swift_module=Foo"]` on the `cc_library`,
replacing `Foo` with the desired module name.