### PR TITLE
Merge list and depset without plus

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -94,7 +94,9 @@ def _swift_linking_rule_impl(
         )
         link_args.add_all(compile_results.linker_flags)
         objects_to_link.extend(compile_results.output_objects)
-        additional_inputs_to_linker = compile_results.compile_inputs + compile_results.linker_inputs
+        additional_inputs_to_linker = depset(
+            direct = compile_results.compile_inputs.to_list() + compile_results.linker_inputs,
+        )
 
         dicts.add(additional_output_groups, compile_results.output_groups)
         compilation_providers.append(


### PR DESCRIPTION
Previously using `depset + list` was supported, with
`--all_incompatible_changes` in 0.19.0 it isn't anymore. Instead we need
to construct a new depset passing both.

We should possibly pass `compile_results.linker_inputs` in the `transitive =` part of this constructor, but it seems like we can't avoid calling `to_list` on the direct `compile_inputs` either way