### PR TITLE
Update Travis to use Bazel 0.19; Update protobut to 3.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       dist: trusty
       sudo: required
       env:
-        - BAZEL=0.16.0 SWIFT_VERSION=4.1.2 CC=clang TARGETS="//examples/... -//examples/apple/..."
+        - BAZEL=0.19.0 SWIFT_VERSION=4.1.2 CC=clang TARGETS="//examples/... -//examples/apple/..."
     - os: linux
       dist: trusty
       sudo: required
@@ -26,7 +26,7 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       env:
-        - BAZEL=0.16.0 TARGETS=//examples/...
+        - BAZEL=0.19.0 TARGETS=//examples/...
     - os: osx
       osx_image: xcode9.4
       env:

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -129,9 +129,9 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_google_protobuf",
-        # v3.5.1, latest as of 2018-01-11
-        urls = ["https://codeload.github.com/google/protobuf/zip/106ffc04be1abf3ff3399f54ccf149815b287dd9"],
-        strip_prefix = "protobuf-106ffc04be1abf3ff3399f54ccf149815b287dd9",
+        # v3.6.1, latest as of 2018-10-31
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.zip"],
+        strip_prefix = "protobuf-3.6.1",
         type = "zip",
     )
 


### PR DESCRIPTION
Update to Travis use Bazel 0.19. This supersedes #63.