### PR TITLE
Add alwayslink support for swift_test & binary

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -182,8 +182,8 @@ def _link_framework_map_fn(framework_dir):
 def _darwin_link_library_map_fn(lib):
     """Maps a library to the appropriate flags to link them.
 
-    This function handles `alwayslink` (.lo) libraries correctly by surrounding them with
-    the appropriate arguments for the platform's linker.
+    This function handles `alwayslink` (.lo) libraries correctly by passing them with
+    `-force_load`.
 
     Args:
         lib: A `File`, passed in when the calling `Args` object is ready to map it to an argument.
@@ -200,7 +200,7 @@ def _linux_link_library_map_fn(lib):
     """Maps a library to the appropriate flags to link them.
 
     This function handles `alwayslink` (.lo) libraries correctly by surrounding them with
-    the appropriate arguments for the platform's linker.
+    `--(no-)whole-archive`.
 
     Args:
         lib: A `File`, passed in when the calling `Args` object is ready to map it to an argument.


### PR DESCRIPTION
Previously I added support to alwayslink libraries when they were
eventually linked into an Objective-C rule. This doesn't apply for
swift_test and swift_binary rules. This is useful for sharing rules
between macOS and Linux where you alwayslink a library.