### PR TITLE
Ensure that headers from transitive dependencies are passed as action inputs when exposing a `cc_library` to Swift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ This repository contains rules for [Bazel](https://bazel.build) that can be
 used to build Swift libraries and executables for Apple platforms (iOS, macOS,
 tvOS, and watchOS) and Linux.
 
-NOTE: The build rules in this repository are intended to replace the
-`swift_library` rule that is currently housed in
-[bazelbuild/rules_apple](https://github.com/bazelbuild/rules_apple).
-
 ## Reference Documentation
 
 [Click here](https://github.com/bazelbuild/rules_swift/tree/master/doc/index.md)
@@ -23,7 +19,7 @@ repository.
 
 ## Compatibility
 
-These rules have been verified to work with **Bazel 0.16.0.**
+These rules have been verified to work with **Bazel 0.19.0.**
 
 ## Quick Setup
 
@@ -51,7 +47,7 @@ rules you wish to depend on:
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.0",
+    tag = "0.4.0",
 )
 
 load(

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -262,6 +262,11 @@ def _swift_test_impl(ctx):
         additional_test_outputs = []
         executable = binary
 
+    test_environment = dicts.add(
+        toolchain.action_environment,
+        {"TEST_BINARIES_FOR_LLVM_COV": binary.short_path},
+    )
+
     # TODO(b/79527231): Replace `instrumented_files` with a declared provider when it is available.
     return struct(
         instrumented_files = struct(
@@ -277,9 +282,13 @@ def _swift_test_impl(ctx):
                     collect_data = True,
                     collect_default = True,
                     files = ctx.files.data + additional_test_outputs,
+                    # _coverage_support is a private attribute added by Bazel to all test targets
+                    # (see https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java).
+                    transitive_files = ctx.attr._coverage_support.files,
                 ),
             ),
             testing.ExecutionInfo(toolchain.execution_requirements),
+            testing.TestEnvironment(test_environment),
         ],
     )
 

--- a/swift/internal/swift_c_module_aspect.bzl
+++ b/swift/internal/swift_c_module_aspect.bzl
@@ -159,7 +159,7 @@ def _swift_c_module_aspect_impl(target, aspect_ctx):
             transitive_compile_flags = depset(
                 direct = ["-I{}".format(include) for include in attr.includes],
             ),
-            transitive_defines = depset(direct = attr.defines),
+            transitive_defines = depset(direct = target.cc.defines),
             transitive_headers = depset(transitive = (
                 transitive_headers_sets +
                 [target.files for target in attr.hdrs] +

--- a/swift/internal/swift_c_module_aspect.bzl
+++ b/swift/internal/swift_c_module_aspect.bzl
@@ -157,7 +157,16 @@ def _swift_c_module_aspect_impl(target, aspect_ctx):
 
         return [SwiftClangModuleInfo(
             transitive_compile_flags = depset(
-                direct = ["-I{}".format(include) for include in attr.includes],
+                direct = [
+                    "-isystem{}".format(include)
+                    for include in target.cc.system_include_directories
+                ] + [
+                    "-iquote{}".format(include)
+                    for include in target.cc.quote_include_directories
+                ] + [
+                    "-I{}".format(include)
+                    for include in target.cc.include_directories
+                ],
             ),
             transitive_defines = depset(direct = target.cc.defines),
             transitive_headers = depset(transitive = (

--- a/swift/internal/swift_c_module_aspect.bzl
+++ b/swift/internal/swift_c_module_aspect.bzl
@@ -147,12 +147,21 @@ def _swift_c_module_aspect_impl(target, aspect_ctx):
             workspace_relative = workspace_relative,
         )
 
+        # Ensure that public headers from libraries that this `cc_library` depend on are also
+        # available to the actions.
+        transitive_headers_sets = []
+        for dep in attr.deps:
+            cc_info = getattr(dep, "cc", None)
+            if cc_info:
+                transitive_headers_sets.append(cc_info.transitive_headers)
+
         return [SwiftClangModuleInfo(
             transitive_compile_flags = depset(
                 direct = ["-I{}".format(include) for include in attr.includes],
             ),
             transitive_defines = depset(direct = attr.defines),
             transitive_headers = depset(transitive = (
+                transitive_headers_sets +
                 [target.files for target in attr.hdrs] +
                 [target.files for target in attr.textual_hdrs]
             )),


### PR DESCRIPTION
Ensure that headers from transitive dependencies are passed as action inputs when exposing a `cc_library` to Swift.