### PR TITLE
Address `buildifier --lint=warn` issues.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -21,7 +21,6 @@ load(
     "SwiftCcLibsInfo",
     "SwiftClangModuleInfo",
     "SwiftInfo",
-    "SwiftToolchainInfo",
 )
 load(":utils.bzl", "collect_transitive")
 load("@bazel_skylib//lib:collections.bzl", "collections")

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -16,7 +16,6 @@
 
 load(":actions.bzl", "run_toolchain_swift_action")
 load(":derived_files.bzl", "derived_files")
-load(":providers.bzl", "SwiftToolchainInfo")
 
 def ensure_swiftmodule_is_embedded(
         actions,

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -16,7 +16,7 @@
 
 load(":actions.bzl", "run_toolchain_action")
 load(":deps.bzl", "collect_link_libraries")
-load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftInfo")
 load(":utils.bzl", "collect_transitive")
 
 def register_link_action(


### PR DESCRIPTION
Address `buildifier --lint=warn` issues.

swift/internal/compiling.bzl:24: load: Loaded symbol "SwiftToolchainInfo" is unused. Please remove it.
To disable the warning, add '@unused' in a comment. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load)
swift/internal/debugging.bzl:19: load: Loaded symbol "SwiftToolchainInfo" is unused. Please remove it.
To disable the warning, add '@unused' in a comment. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load)
swift/internal/linking.bzl:19: load: Loaded symbol "SwiftToolchainInfo" is unused. Please remove it.
To disable the warning, add '@unused' in a comment. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#load)
swift/internal/swift_c_module.bzl:180: attr-single-file: single_file is deprecated in favor of allow_single_file. (https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#attr-single-file)

Changes all made via `buildifier --lint=fix`