### PR TITLE
Support swift_import in ObjC rules

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -857,8 +857,8 @@ def _compile_as_library(
             link_inputs = compile_results.linker_inputs,
             linkopts = compile_results.linker_flags,
             module_map = output_module_map,
-            static_archive = out_archive,
-            swiftmodule = compile_results.output_module,
+            static_archives = [out_archive],
+            swiftmodules = [compile_results.output_module],
             objc_header = objc_header,
         ))
 


### PR DESCRIPTION
Support swift_import in ObjC rules

Previously it was not possible to use a `swift_import` in upstream rules
such as `ios_unit_test` since it was not propagating a compatible
provider. Now `swift_import` propagates Objective-C providers so it can
correctly be linked.

This fixes https://github.com/bazelbuild/rules_swift/issues/37