### PR TITLE
Pass tools to run as tools

### DIFF
--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -203,11 +203,13 @@ def _register_pbswift_generate_action(
     protoc_args.add_joined(transitive_descriptor_sets, join_with = ":")
     protoc_args.add_all([_workspace_relative_path(f) for f in direct_srcs])
 
-    additional_command_inputs = [
+    tools = [
         mkdir_and_run,
         protoc_executable,
         protoc_gen_swift_executable,
     ]
+
+    additional_command_inputs = []
     if module_mapping_file:
         additional_command_inputs.append(module_mapping_file)
 
@@ -220,6 +222,7 @@ def _register_pbswift_generate_action(
             direct = additional_command_inputs,
             transitive = [transitive_descriptor_sets],
         ),
+        tools = tools,
         mnemonic = "ProtocGenSwift",
         outputs = pbswift_files,
         progress_message = "Generating Swift sources for {}".format(target.label),


### PR DESCRIPTION
Previously these were defined as inputs, which is deprecated in bazel.
Instead they should be tools.