### PR TITLE
Link opt builds with -dead_strip on macOS

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -1151,7 +1151,7 @@ def _merge_swift_info_providers(targets):
         transitive_swiftmodules = depset(transitive = transitive_swiftmodules),
     )
 
-def _swift_runtime_linkopts(is_static, toolchain, is_test = False):
+def _swift_runtime_linkopts(is_static, toolchain, is_test = False, is_opt = False):
     """Returns the flags that should be passed to `clang` when linking a binary.
 
     This function provides the appropriate linker arguments to callers who need to
@@ -1165,6 +1165,8 @@ def _swift_runtime_linkopts(is_static, toolchain, is_test = False):
           options are desired.
       is_test: A `Boolean` value indicating whether the target being linked is a
           test target.
+      is_opt: A `Boolean` value indicating whether the target being linked is
+          built with optimizations.
 
     Returns:
       A `list` of command-line flags that should be passed to `clang` to link
@@ -1174,6 +1176,7 @@ def _swift_runtime_linkopts(is_static, toolchain, is_test = False):
         toolchain.linker_opts_producer,
         is_static = is_static,
         is_test = is_test,
+        is_opt = is_opt,
     )
 
 def _swiftc_command_line_and_inputs(

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -198,11 +198,13 @@ on Darwin is required.
 Skylib `partial`. A partial function that returns the flags that should be passed to Clang to link a
 binary or test target with the Swift runtime libraries.
 
-The partial should be called with two arguments:
+The partial should be called with these arguments:
 
 *   `is_static`: A `Boolean` value indicating whether to link against the static or dynamic runtime
     libraries.
 *   `is_test`: A `Boolean` value indicating whether the target being linked is a test target.
+*   `is_opt`: A `Boolean` value indicating whether the target be linked is being built with
+    optimizations.
 """,
         "linker_search_paths": """
 `List` of `string`s. Additional library search paths that should be passed to the linker when

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -58,6 +58,7 @@ def _swift_linking_rule_impl(
 
     additional_inputs = ctx.files.swiftc_inputs
     srcs = ctx.files.srcs
+    compilation_mode = ctx.var["COMPILATION_MODE"]
 
     out_bin = derived_files.executable(ctx.actions, target_name = ctx.label.name)
     objects_to_link = []
@@ -77,7 +78,7 @@ def _swift_linking_rule_impl(
         compile_results = swift_common.compile_as_objects(
             actions = ctx.actions,
             arguments = [],
-            compilation_mode = ctx.var["COMPILATION_MODE"],
+            compilation_mode = compilation_mode,
             copts = copts,
             defines = ctx.attr.defines,
             feature_configuration = feature_configuration,
@@ -110,6 +111,7 @@ def _swift_linking_rule_impl(
         toolchain.linker_opts_producer,
         is_static = True,
         is_test = is_test,
+        is_opt = compilation_mode == "opt",
     ))
 
     # Enable LLVM coverage in CROSSTOOL if this is a coverage build. Note that we explicitly enable

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -31,7 +31,8 @@ def _default_linker_opts(
         os,
         toolchain_root,
         is_static,
-        is_test):
+        is_test,
+        is_opt):
     """Returns options that should be passed by default to `clang` when linking.
 
     This function is wrapped in a `partial` that will be propagated as part of the
@@ -45,13 +46,14 @@ def _default_linker_opts(
         is_static: `True` to link against the static version of the Swift runtime, or `False` to
             link against dynamic/shared libraries.
         is_test: `True` if the target being linked is a test target.
+        is_opt: `True` if the target is being built with `opt` compilation mode.
 
     Returns:
         The command line options to pass to `clang` to link against the desired variant of the Swift
         runtime libraries.
     """
 
-    _ignore = is_test
+    _ignore = (is_opt, is_test)
 
     # TODO(#8): Support statically linking the Swift runtime.
     platform_lib_dir = "{toolchain_root}/lib/swift/{os}".format(

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -39,7 +39,8 @@ def _default_linker_opts(
         platform,
         target,
         is_static,
-        is_test):
+        is_test,
+        is_opt):
     """Returns options that should be passed by default to `clang` when linking.
 
     This function is wrapped in a `partial` that will be propagated as part of the toolchain
@@ -54,6 +55,7 @@ def _default_linker_opts(
         is_static: `True` to link against the static version of the Swift runtime, or `False` to
             link against dynamic/shared libraries.
         is_test: `True` if the target being linked is a test target.
+        is_opt: `True` if the target is being built with `opt` compilation mode.
 
     Returns:
         The command line options to pass to `clang` to link against the desired variant of the Swift
@@ -92,6 +94,9 @@ def _default_linker_opts(
         "-ObjC",
         "-Wl,-objc_abi_version,2",
     ])
+
+    if is_opt:
+        linkopts.append("-Wl,-dead_strip")
 
     # XCTest.framework only lives in the Xcode bundle (its platform framework
     # directory), so test binaries need to have that directory explicitly added to

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -96,7 +96,10 @@ def _default_linker_opts(
     ])
 
     if is_opt:
-        linkopts.append("-Wl,-dead_strip")
+        linkopts.extend([
+            "-Wl,-dead_strip",
+            "-Wl,-no_dead_strip_inits_and_terms",
+        ])
 
     # XCTest.framework only lives in the Xcode bundle (its platform framework
     # directory), so test binaries need to have that directory explicitly added to


### PR DESCRIPTION
This change makes opt builds on macOS link with the `-dead_strip` flag.