### PR TITLE
Bump versions of rules_swift dependencies:

### DIFF
--- a/.travis/bazelrc.linux
+++ b/.travis/bazelrc.linux
@@ -1,6 +1,2 @@
 # This file will be used as the bazelrc file on Linux. Add settings to it if
 # you need to tweak Bazel's behavior or resource usage on that platform.
-
-# TODO(protocolbuffers/protobuf#5418): Remove when there is a protobuf release
-# that contains the migration away from {PACKAGE,REPOSITORY}_NAME.
-build --incompatible_package_name_is_a_function=false

--- a/.travis/bazelrc.osx
+++ b/.travis/bazelrc.osx
@@ -5,7 +5,3 @@
 # ensures that we build artifacts that run on macOS.
 build --cpu=darwin_x86_64
 build --apple_platform_type=macos
-
-# TODO(protocolbuffers/protobuf#5418): Remove when there is a protobuf release
-# that contains the migration away from {PACKAGE,REPOSITORY}_NAME.
-build --incompatible_package_name_is_a_function=false

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -114,14 +114,14 @@ def swift_rules_dependencies():
         git_repository,
         name = "bazel_skylib",
         remote = "https://github.com/bazelbuild/bazel-skylib.git",
-        tag = "0.4.0",
+        tag = "0.5.0",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_swift_protobuf",
-        urls = ["https://github.com/apple/swift-protobuf/archive/1.0.3.zip"],
-        strip_prefix = "swift-protobuf-1.0.3/",
+        urls = ["https://github.com/apple/swift-protobuf/archive/1.2.0.zip"],
+        strip_prefix = "swift-protobuf-1.2.0/",
         type = "zip",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_swift_protobuf/BUILD.overlay",
     )
@@ -129,9 +129,9 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_google_protobuf",
-        # v3.6.1, latest as of 2018-10-31
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protobuf-all-3.6.1.zip"],
-        strip_prefix = "protobuf-3.6.1",
+        # v3.6.1.2, latest as of 2018-12-04
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.zip"],
+        strip_prefix = "protobuf-3.6.1.2",
         type = "zip",
     )
 


### PR DESCRIPTION
Bump versions of rules_swift dependencies:

* bazel-skylib -> 0.5.0
* swift-protobuf -> 1.2.0
* protobuf -> 3.6.1.2