### PR TITLE
Update swift_test to use coverage_support filegroup in apple_support.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,3 +6,10 @@ load(
 )
 
 swift_rules_dependencies()
+
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -283,9 +283,7 @@ def _swift_test_impl(ctx):
                     collect_data = True,
                     collect_default = True,
                     files = ctx.files.data + additional_test_outputs,
-                    # _coverage_support is a private attribute added by Bazel to all test targets
-                    # (see https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/analysis/skylark/SkylarkRuleClassFunctions.java).
-                    transitive_files = ctx.attr._coverage_support.files,
+                    transitive_files = ctx.attr._apple_coverage_support.files,
                 ),
             ),
             testing.ExecutionInfo(toolchain.execution_requirements),
@@ -347,6 +345,10 @@ Additional linker options that should be passed to `clang`. These strings are su
 `$(location ...)` expansion.
 """,
                 mandatory = False,
+            ),
+            "_apple_coverage_support": attr.label(
+                cfg = "host",
+                default = Label("@build_bazel_apple_support//tools:coverage_support"),
             ),
             # Do not add references; temporary attribute for C++ toolchain Skylark migration.
             "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -118,6 +118,13 @@ def swift_rules_dependencies():
     )
 
     _maybe(
+        git_repository,
+        name = "build_bazel_apple_support",
+        remote = "https://github.com/bazelbuild/apple_support.git",
+        tag = "0.1.1",
+    )
+
+    _maybe(
         http_archive,
         name = "com_github_apple_swift_swift_protobuf",
         urls = ["https://github.com/apple/swift-protobuf/archive/1.2.0.zip"],


### PR DESCRIPTION
Update swift_test to use coverage_support filegroup in apple_support.