### PR TITLE
Set ZERO_AR_DATE in bazel_xcode_wrapper

### DIFF
--- a/swift/internal/archiving.bzl
+++ b/swift/internal/archiving.bzl
@@ -124,6 +124,7 @@ def _register_ar_action(
 
     run_toolchain_shell_action(
         actions = actions,
+        env = {"ZERO_AR_DATE": "1"},
         arguments = [args],
         command = command,
         inputs = [mri_script] + libraries + objects,
@@ -175,6 +176,7 @@ def _register_libtool_action(
     run_toolchain_action(
         actions = actions,
         arguments = [args, filelist],
+        env = {"ZERO_AR_DATE": "1"},
         executable = "/usr/bin/libtool",
         inputs = libraries + objects,
         mnemonic = mnemonic,

--- a/tools/wrappers/bazel_xcode_wrapper.sh
+++ b/tools/wrappers/bazel_xcode_wrapper.sh
@@ -97,11 +97,6 @@ for ARG in "$@" ; do
   ARGS+=("$ARG")
 done
 
-# libtool writes the date in the headers of the .ar file
-# unless this is set.
-ZERO_AR_DATE=1
-export ZERO_AR_DATE
-
 # We can't use `exec` here because we need to make sure the `trap` runs
 # afterward.
 "$TOOLNAME" "${ARGS[@]}"

--- a/tools/wrappers/bazel_xcode_wrapper.sh
+++ b/tools/wrappers/bazel_xcode_wrapper.sh
@@ -97,6 +97,11 @@ for ARG in "$@" ; do
   ARGS+=("$ARG")
 done
 
+# libtool writes the date in the headers of the .ar file
+# unless this is set.
+ZERO_AR_DATE=1
+export ZERO_AR_DATE
+
 # We can't use `exec` here because we need to make sure the `trap` runs
 # afterward.
 "$TOOLNAME" "${ARGS[@]}"


### PR DESCRIPTION
This is for hermeticity since `libtool` writes the date in the headers unless this is set.

While using these rules with the remote cache, I found instances where Swift produced libraries were different in the date only.