### PR TITLE
Add "--" to the targets to fix the label parsing.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,6 +14,7 @@ platforms:
     - "--cpu=darwin_x86_64"
     - "--apple_platform_type=macos"
     test_targets:
+    - "--"
     - "//examples/..."
   ubuntu1804:
     build_flags:
@@ -27,5 +28,6 @@ platforms:
     test_flags:
     - "--action_env=PATH"
     test_targets:
+    - "--"
     - "//examples/..."
     - "-//examples/apple/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,7 +14,6 @@ platforms:
     - "--cpu=darwin_x86_64"
     - "--apple_platform_type=macos"
     test_targets:
-    - "--"
     - "//examples/..."
   ubuntu1804:
     build_flags:
@@ -23,6 +22,7 @@ platforms:
     # https://github.com/bazelbuild/rules_swift/issues/4).
     - "--action_env=PATH"
     build_targets:
+    - "--"
     - "//examples/..."
     - "-//examples/apple/..."
     test_flags:


### PR DESCRIPTION
Unfortunately the bazelci.py script doesn't insert the argument separator yet, so we have to add it manually in the test_targets for now.