### PR TITLE
Move skylib to 0.6.0; remove resources/structured_resources attributes

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -1063,34 +1063,6 @@ library. Supports auto-linking.
 """,
                 mandatory = False,
             ),
-            # TODO(b/77853138): Remove once the Apple rules support bundling from
-            # `data`.
-            "resources": attr.label_list(
-                allow_empty = True,
-                allow_files = True,
-                doc = """
-Resources that should be processed by Xcode tools (such as interface builder
-documents, Core Data models, asset catalogs, and so forth) and included in the
-bundle that depends on this library.
-
-This attribute is ignored when building Linux targets.
-""",
-                mandatory = False,
-            ),
-            # TODO(b/77853138): Remove once the Apple rules support bundling from
-            # `data`.
-            "structured_resources": attr.label_list(
-                allow_empty = True,
-                allow_files = True,
-                doc = """
-Files that should be included in the bundle that depends on this library without
-any additional processing. The paths of these files relative to this library
-target are preserved inside the bundle.
-
-This attribute is ignored when building Linux targets.
-""",
-                mandatory = False,
-            ),
             "alwayslink": attr.bool(
                 default = False,
                 doc = """

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -114,7 +114,7 @@ def swift_rules_dependencies():
         git_repository,
         name = "bazel_skylib",
         remote = "https://github.com/bazelbuild/bazel-skylib.git",
-        tag = "0.5.0",
+        tag = "0.6.0",
     )
 
     _maybe(


### PR DESCRIPTION
Move skylib to the 0.6.0 release (Nov 2018)

This isn't directly need by this repo, but it clears the way for
anyone that needs this repo and something in that skylib release.