### PR TITLE
Update Travis to Xcode 10.1 (Apple) and Swift 4.2.1 (Linux).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,18 @@ matrix:
       dist: trusty
       sudo: required
       env:
-        - BAZEL=RELEASE SWIFT_VERSION=4.1.2 CC=clang TARGETS="//examples/... -//examples/apple/..."
+        - BAZEL=RELEASE SWIFT_VERSION=4.2.1 CC=clang TARGETS="//examples/... -//examples/apple/..."
     - os: linux
       dist: trusty
       sudo: required
       env:
-        - BAZEL=HEAD SWIFT_VERSION=4.1.2 CC=clang TARGETS="//examples/... -//examples/apple/..."
+        - BAZEL=HEAD SWIFT_VERSION=4.2.1 CC=clang TARGETS="//examples/... -//examples/apple/..."
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env:
         - BAZEL=RELEASE TARGETS=//examples/...
     - os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       env:
         - BAZEL=HEAD TARGETS=//examples/...
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -42,6 +42,12 @@ if [[ -n "${BAZEL:-}" ]]; then
       --verbose_failures
       --action_env=PATH
   )
+
+  # Can be removed when https://github.com/bazelbuild/bazel/pull/7151 is released
+  if [[ $OSTYPE == darwin* ]]; then
+    ALL_BUILD_ARGS+=("--host_cpu=darwin_x86_64")
+  fi
+
   if [[ -n "${BUILD_ARGS:-}" ]]; then
     ALL_BUILD_ARGS+=(${BUILD_ARGS})
   fi


### PR DESCRIPTION
Update Travis to Xcode 10.1 (Apple) and Swift 4.2.1 (Linux).

Closes #130.
Fixes #119.