### PR TITLE
Bazel trips up on visibility with @repository references.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,7 +10,7 @@ filegroup(
     testonly = 1,
     srcs = [
         "WORKSPACE",
-        "@build_bazel_rules_swift//swift:for_bazel_tests",
-        "@build_bazel_rules_swift//tools:for_bazel_tests",
+        "//swift:for_bazel_tests",
+        "//tools:for_bazel_tests",
     ],
 )

--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -3,7 +3,7 @@
 # platforms.
 
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "//swift:swift.bzl",
     "swift_binary",
     "swift_library",
 )

--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
+load("//swift:swift.bzl", "swift_binary", "swift_library")
 
 licenses(["notice"])
 

--- a/examples/xplatform/dispatch/BUILD
+++ b/examples/xplatform/dispatch/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+load("//swift:swift.bzl", "swift_binary")
 
 licenses(["notice"])
 

--- a/examples/xplatform/hello_world/BUILD
+++ b/examples/xplatform/hello_world/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+load("//swift:swift.bzl", "swift_binary")
 
 licenses(["notice"])
 

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
+    "//swift:swift.bzl",
     "swift_binary",
     "swift_proto_library",
 )

--- a/examples/xplatform/xctest/BUILD
+++ b/examples/xplatform/xctest/BUILD
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_test")
+load("//swift:swift.bzl", "swift_test")
 
 licenses(["notice"])
 

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -11,7 +11,7 @@ filegroup(
     name = "for_bazel_tests",
     testonly = 1,
     srcs = glob(["**"]) + [
-        "@build_bazel_rules_swift//swift/internal:for_bazel_tests",
+        "//swift/internal:for_bazel_tests",
     ],
     visibility = [
         "//:__pkg__",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -13,6 +13,6 @@ filegroup(
         "@bazel_tools//tools/build_defs/cc:action_names_test_files",
     ],
     visibility = [
-        "@build_bazel_rules_swift//swift:__pkg__",
+        "//swift:__pkg__",
     ],
 )

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -7,8 +7,8 @@ filegroup(
     name = "for_bazel_tests",
     testonly = 1,
     srcs = glob(["**"]) + [
-        "@build_bazel_rules_swift//tools/mkdir_and_run:for_bazel_tests",
-        "@build_bazel_rules_swift//tools/wrappers:for_bazel_tests",
+        "//tools/mkdir_and_run:for_bazel_tests",
+        "//tools/wrappers:for_bazel_tests",
     ],
     visibility = [
         "//:__pkg__",

--- a/tools/mkdir_and_run/BUILD
+++ b/tools/mkdir_and_run/BUILD
@@ -12,6 +12,6 @@ filegroup(
     testonly = 1,
     srcs = glob(["**"]),
     visibility = [
-        "@build_bazel_rules_swift//tools:__pkg__",
+        "//tools:__pkg__",
     ],
 )

--- a/tools/wrappers/BUILD
+++ b/tools/wrappers/BUILD
@@ -18,6 +18,6 @@ filegroup(
     testonly = 1,
     srcs = glob(["**"]),
     visibility = [
-        "@build_bazel_rules_swift//tools:__pkg__",
+        "//tools:__pkg__",
     ],
 )

--- a/tools/xctest_runner/BUILD
+++ b/tools/xctest_runner/BUILD
@@ -12,6 +12,6 @@ filegroup(
     testonly = 1,
     srcs = glob(["**"]),
     visibility = [
-        "@build_bazel_rules_swift//tools:__pkg__",
+        "//tools:__pkg__",
     ],
 )


### PR DESCRIPTION
Bazel trips up on visibility with @repository references.

Avoiding https://github.com/bazelbuild/bazel/issues/7180