### PR TITLE
Make swift_module_alias expose the ObjC provider

### DIFF
--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -60,6 +60,8 @@ following dependencies instead:\n\n""".format(
         unsupported_features = ctx.disabled_features,
     )
 
+    objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
+
     compile_results = swift_common.compile_as_library(
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
@@ -73,6 +75,7 @@ following dependencies instead:\n\n""".format(
         deps = ctx.attr.deps,
         feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
+        objc_fragment = objc_fragment,
     )
 
     return compile_results.providers + [
@@ -132,6 +135,6 @@ to create "umbrella modules".
 > `deps` in the new module. You depend on undocumented features at your own
 > risk, as they may change in a future version of Swift.
 """,
-    fragments = ["swift"],
+    fragments = ["swift", "objc"],
     implementation = _swift_module_alias_impl,
 )


### PR DESCRIPTION
It allows `swift_proto_library` to be used by `ios_static_framework`, among others.