### PR TITLE
Set ZERO_AR_DATE=1 for ar and invoke bazel's libtool wrapper on macOS

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -818,12 +818,15 @@ def _compile_as_library(
 
     if toolchain.system_name == "darwin":
         ar_executable = None
+        libtool_executable = toolchain.libtool_executable
     else:
         ar_executable = toolchain.cc_toolchain_info.ar_executable
+        libtool_executable = None
 
     register_static_archive_action(
         actions = actions,
         ar_executable = ar_executable,
+        libtool_executable = libtool_executable,
         libraries = cc_lib_files,
         mnemonic = "SwiftArchive",
         objects = compile_results.output_objects,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -194,6 +194,9 @@ on Darwin is required.
 `List` of `Target`s. Library targets that should be added as implicit dependencies of any
 `swift_library`, `swift_binary`, or `swift_test` target.
 """,
+        "libtool_executable": """
+`String`. The path to the `libtool` executable, which is used to create archives on macOS.
+""",
         "linker_opts_producer": """
 Skylib `partial`. A partial function that returns the flags that should be passed to Clang to link a
 binary or test target with the Swift runtime libraries.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -197,6 +197,7 @@ def _swift_toolchain_impl(ctx):
             cpu = ctx.attr.arch,
             execution_requirements = {},
             implicit_deps = [],
+            libtool_executable = None,
             linker_opts_producer = linker_opts_producer,
             object_format = "elf",
             # TODO(#34): Add SWIFT_FEATURE_USE_RESPONSE_FILES based on Swift compiler version once

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -458,6 +458,7 @@ def _xcode_swift_toolchain_impl(ctx):
             cpu = cpu,
             execution_requirements = execution_requirements,
             implicit_deps = [],
+            libtool_executable = ctx.attr._libtool,
             linker_opts_producer = linker_opts_producer,
             object_format = "macho",
             requested_features = requested_features,
@@ -495,6 +496,13 @@ with stamping enabled.
 The C++ toolchain from which linking flags and other tools needed by the Swift toolchain (such as
 `clang`) will be retrieved.
 """,
+        ),
+        "_libtool": attr.label(
+            cfg = "host",
+            default = Label(
+                "@bazel_tools//tools/objc:libtool",
+            ),
+            executable = True,
         ),
         "_xcode_config": attr.label(
             default = configuration_field(


### PR DESCRIPTION
This PR does 2 things:
- Add `ZERO_AR_DATE=1` to the `ar` command env
- Use bazel's libtool wrapper instead of directly invoking it

Continuing what was started at #120.