### PR TITLE
Migrate the provider containing information about protocol buffers from the old-style 'dep.proto' pattern to the new-style 'dep[ProtoInfo]' one.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @allevato

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -60,6 +60,8 @@ following dependencies instead:\n\n""".format(
         unsupported_features = ctx.disabled_features,
     )
 
+    objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
+
     compile_results = swift_common.compile_as_library(
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
@@ -73,6 +75,7 @@ following dependencies instead:\n\n""".format(
         deps = ctx.attr.deps,
         feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
+        objc_fragment = objc_fragment,
     )
 
     return compile_results.providers + [
@@ -132,6 +135,6 @@ to create "umbrella modules".
 > `deps` in the new module. You depend on undocumented features at your own
 > risk, as they may change in a future version of Swift.
 """,
-    fragments = ["swift"],
+    fragments = ["swift", "objc"],
     implementation = _swift_module_alias_impl,
 )

--- a/swift/internal/swift_proto_library.bzl
+++ b/swift/internal/swift_proto_library.bzl
@@ -56,7 +56,7 @@ swift_proto_library = rule(
 Exactly one `proto_library` target (or any target that propagates a `proto` provider) from which
 the Swift library should be generated.
 """,
-            providers = ["proto"],
+            providers = [ProtoInfo],
         ),
     },
     doc = """

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -227,7 +227,7 @@ def _gather_transitive_module_mappings(targets):
 def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
     toolchain = aspect_ctx.attr._toolchain[SwiftToolchainInfo]
 
-    direct_srcs = _filter_out_well_known_types(target.proto.direct_sources)
+    direct_srcs = _filter_out_well_known_types(target[ProtoInfo].direct_sources)
 
     # Direct sources are passed as arguments to protoc to generate *only* the
     # files in this target, but we need to pass the transitive sources as inputs
@@ -235,7 +235,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
     # protoc to parse.
     # Instead of providing all those files and opening/reading them, we use
     # protoc's support for reading descriptor sets to resolve things.
-    transitive_descriptor_sets = target.proto.transitive_descriptor_sets
+    transitive_descriptor_sets = target[ProtoInfo].transitive_descriptor_sets
     deps = [dep for dep in aspect_ctx.rule.attr.deps if SwiftProtoInfo in dep]
 
     minimal_module_mappings = []


### PR DESCRIPTION
Migrate the provider containing information about protocol buffers from the old-style 'dep.proto' pattern to the new-style 'dep[ProtoInfo]' one.