### PR TITLE
Migrate to new code coverage provider

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -268,28 +268,26 @@ def _swift_test_impl(ctx):
         {"TEST_BINARIES_FOR_LLVM_COV": binary.short_path},
     )
 
-    # TODO(b/79527231): Replace `instrumented_files` with a declared provider when it is available.
-    return struct(
-        instrumented_files = struct(
+    return providers + [
+        DefaultInfo(
+            executable = executable,
+            files = depset(direct = [executable] + additional_test_outputs),
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+                files = ctx.files.data + additional_test_outputs,
+                transitive_files = ctx.attr._apple_coverage_support.files,
+            ),
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
             dependency_attributes = ["deps"],
             extensions = ["swift"],
             source_attributes = ["srcs"],
         ),
-        providers = providers + [
-            DefaultInfo(
-                executable = executable,
-                files = depset(direct = [executable] + additional_test_outputs),
-                runfiles = ctx.runfiles(
-                    collect_data = True,
-                    collect_default = True,
-                    files = ctx.files.data + additional_test_outputs,
-                    transitive_files = ctx.attr._apple_coverage_support.files,
-                ),
-            ),
-            testing.ExecutionInfo(toolchain.execution_requirements),
-            testing.TestEnvironment(test_environment),
-        ],
-    )
+        testing.ExecutionInfo(toolchain.execution_requirements),
+        testing.TestEnvironment(test_environment),
+    ]
 
 swift_binary = rule(
     attrs = dicts.add(

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -75,25 +75,23 @@ def _swift_library_impl(ctx):
     if compile_results.output_header:
         direct_output_files.append(compile_results.output_header)
 
-    # TODO(b/79527231): Replace `instrumented_files` with a declared provider when it is available.
-    return struct(
-        instrumented_files = struct(
+    return compile_results.providers + [
+        DefaultInfo(
+            files = depset(direct = direct_output_files),
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+                files = ctx.files.data,
+            ),
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
             dependency_attributes = ["deps"],
             extensions = ["swift"],
             source_attributes = ["srcs"],
         ),
-        providers = compile_results.providers + [
-            DefaultInfo(
-                files = depset(direct = direct_output_files),
-                runfiles = ctx.runfiles(
-                    collect_data = True,
-                    collect_default = True,
-                    files = ctx.files.data,
-                ),
-            ),
-            OutputGroupInfo(**compile_results.output_groups),
-        ],
-    )
+        OutputGroupInfo(**compile_results.output_groups),
+    ]
 
 swift_library = rule(
     attrs = swift_common.library_rule_attrs(additional_deps_aspects = [swift_c_module_aspect]),


### PR DESCRIPTION
This fixes an incompatible change detailed here: https://github.com/bazelbuild/bazel/issues/7347

This relies on bazel 0.23.0