### PR TITLE
Remove unnecessary apple_platform_type flags

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,18 +3,8 @@ platforms:
   macos:
     environment:
       CC: clang
-    build_flags:
-      # For historical reasons, the default platform for Apple builds is iOS. This
-      # ensures that we build artifacts that run on macOS.
-      - "--cpu=darwin_x86_64"
-      - "--apple_platform_type=macos"
     build_targets:
       - "//examples/..."
-    test_flags:
-      # For historical reasons, the default platform for Apple builds is iOS. This
-      # ensures that we build artifacts that run on macOS.
-      - "--cpu=darwin_x86_64"
-      - "--apple_platform_type=macos"
     test_targets:
       - "//examples/..."
   ubuntu1804:

--- a/.travis/bazelrc.linux
+++ b/.travis/bazelrc.linux
@@ -1,2 +1,0 @@
-# This file will be used as the bazelrc file on Linux. Add settings to it if
-# you need to tweak Bazel's behavior or resource usage on that platform.

--- a/.travis/bazelrc.osx
+++ b/.travis/bazelrc.osx
@@ -1,7 +1,0 @@
-# This file will be used as the bazelrc file on macOS. Add settings to it if
-# you need to tweak Bazel's behavior or resource usage on that platform.
-
-# For historical reasons, the default platform for Apple builds is iOS. This
-# ensures that we build artifacts that run on macOS.
-build --cpu=darwin_x86_64
-build --apple_platform_type=macos

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -36,7 +36,6 @@ if [[ -n "${BAZEL:-}" ]]; then
   # Since they are environment variables, they can't be Bash arrays, so we use
   # double-quoted strings to set them instead and just let them expand below.
   set -x
-  BAZELRC_ARGS=("--bazelrc=.travis/bazelrc.${TRAVIS_OS_NAME}")
   ALL_BUILD_ARGS=(
       --show_progress_rate_limit=30.0
       --verbose_failures
@@ -57,8 +56,8 @@ if [[ -n "${BAZEL:-}" ]]; then
     ALL_TEST_ARGS+=("--test_tag_filters=${TAGS}")
   fi
 
-  bazel "${BAZELRC_ARGS[@]}" build "${ALL_BUILD_ARGS[@]}" -- ${TARGETS}
-  bazel "${BAZELRC_ARGS[@]}" test "${ALL_BUILD_ARGS[@]}" "${ALL_TEST_ARGS[@]}" -- ${TARGETS}
+  bazel build "${ALL_BUILD_ARGS[@]}" -- ${TARGETS}
+  bazel test "${ALL_BUILD_ARGS[@]}" "${ALL_TEST_ARGS[@]}" -- ${TARGETS}
   set +x
 fi
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -33,14 +33,7 @@ On Linux, this rule produces an executable binary for the desired target archite
 
 On Apple platforms, this rule produces a _single-architecture_ binary; it does not produce fat
 binaries. As such, this rule is mainly useful for creating Swift tools intended to run on the
-local build machine. However, for historical reasons, the default Apple platform in Bazel is
-**iOS** instead of macOS. Therefore, if you wish to build a simple single-architecture Swift
-binary that can run on macOS, you must specify the correct CPU and platform on the command line as
-follows:
-
-```shell
-$ bazel build //package:target --cpu=darwin_x86_64 --apple_platform_type=macos
-```
+local build machine.
 
 If you want to create a multi-architecture binary or a bundled application, please use one of the
 platform-specific application rules in [rules_apple](https://github.com/bazelbuild/rules_apple)

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -333,7 +333,7 @@ binary that can run on macOS, you must specify the correct CPU and platform on t
 follows:
 
 ```shell
-$ bazel build //package:target --cpu=darwin_x86_64 --apple_platform_type=macos
+$ bazel build //package:target
 ```
 
 If you want to create a multi-architecture binary or a bundled application, please use one of the


### PR DESCRIPTION
With bazel 0.23.0 this is no longer needed because macOS is now the default