### PR TITLE
Remove host_cpu flag

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -43,11 +43,6 @@ if [[ -n "${BAZEL:-}" ]]; then
       --action_env=PATH
   )
 
-  # Can be removed when https://github.com/bazelbuild/bazel/pull/7151 is released
-  if [[ $OSTYPE == darwin* ]]; then
-    ALL_BUILD_ARGS+=("--host_cpu=darwin_x86_64")
-  fi
-
   if [[ -n "${BUILD_ARGS:-}" ]]; then
     ALL_BUILD_ARGS+=(${BUILD_ARGS})
   fi


### PR DESCRIPTION
`darwin` is now a valid macOS platform with bazel 0.23.0 which was the
only reason we needed this override