### PR TITLE
Stop testing against Bazel release on Travis.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,18 +3,8 @@ platforms:
   macos:
     environment:
       CC: clang
-    build_flags:
-      # For historical reasons, the default platform for Apple builds is iOS. This
-      # ensures that we build artifacts that run on macOS.
-      - "--cpu=darwin_x86_64"
-      - "--apple_platform_type=macos"
     build_targets:
       - "//examples/..."
-    test_flags:
-      # For historical reasons, the default platform for Apple builds is iOS. This
-      # ensures that we build artifacts that run on macOS.
-      - "--cpu=darwin_x86_64"
-      - "--apple_platform_type=macos"
     test_targets:
       - "//examples/..."
   ubuntu1804:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,18 +1,29 @@
 ---
-platforms:
-  macos:
-    environment:
-      CC: clang
+tasks:
+  macos_latest:
+    platform: macos
+    bazel: latest
     build_targets:
       - "//examples/..."
     test_targets:
       - "//examples/..."
-  ubuntu1804:
+
+  macos_last_green:
+    platform: macos
+    bazel: last_green
+    build_targets:
+      - "//examples/..."
+    test_targets:
+      - "//examples/..."
+
+  ubuntu1804_latest:
+    platform: ubuntu1804
+    bazel: latest
     environment:
       CC: clang
     build_flags:
-      # On Linux, we look for Swift toolchain binaries on the path. We may be able
-      # to change this when we start auto-downloading toolchains (see
+      # On Linux, we look for Swift toolchain binaries on the path. We may be
+      # able to change this when we start auto-downloading toolchains (see
       # https://github.com/bazelbuild/rules_swift/issues/4).
       - "--action_env=PATH"
     build_targets:
@@ -25,3 +36,26 @@ platforms:
       - "--"
       - "//examples/..."
       - "-//examples/apple/..."
+
+  ubuntu1804_last_green:
+    platform: ubuntu1804
+    bazel: last_green
+    environment:
+      CC: clang
+    build_flags:
+      # On Linux, we look for Swift toolchain binaries on the path. We may be
+      # able to change this when we start auto-downloading toolchains (see
+      # https://github.com/bazelbuild/rules_swift/issues/4).
+      - "--action_env=PATH"
+    build_targets:
+      - "--"
+      - "//examples/..."
+      - "-//examples/apple/..."
+    test_flags:
+      - "--action_env=PATH"
+    test_targets:
+      - "--"
+      - "//examples/..."
+      - "-//examples/apple/..."
+
+buildifier: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,7 @@ matrix:
       dist: trusty
       sudo: required
       env:
-        - BAZEL=RELEASE SWIFT_VERSION=4.2.1 CC=clang TARGETS="//examples/... -//examples/apple/..."
-    - os: linux
-      dist: trusty
-      sudo: required
-      env:
         - BAZEL=HEAD SWIFT_VERSION=4.2.1 CC=clang TARGETS="//examples/... -//examples/apple/..."
-    - os: osx
-      osx_image: xcode10.1
-      env:
-        - BAZEL=RELEASE TARGETS=//examples/...
     - os: osx
       osx_image: xcode10.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,6 @@ matrix:
       sudo: false
       env: BUILDIFIER=RELEASE
 
-    - os: linux
-      dist: trusty
-      sudo: required
-      env:
-        - BAZEL=HEAD SWIFT_VERSION=4.2.1 CC=clang TARGETS="//examples/... -//examples/apple/..."
-    - os: osx
-      osx_image: xcode10.1
-      env:
-        - BAZEL=HEAD TARGETS=//examples/...
-
 before_install:
   - .travis/install.sh
 

--- a/.travis/bazelrc.linux
+++ b/.travis/bazelrc.linux
@@ -1,2 +1,0 @@
-# This file will be used as the bazelrc file on Linux. Add settings to it if
-# you need to tweak Bazel's behavior or resource usage on that platform.

--- a/.travis/bazelrc.osx
+++ b/.travis/bazelrc.osx
@@ -1,7 +1,0 @@
-# This file will be used as the bazelrc file on macOS. Add settings to it if
-# you need to tweak Bazel's behavior or resource usage on that platform.
-
-# For historical reasons, the default platform for Apple builds is iOS. This
-# ensures that we build artifacts that run on macOS.
-build --cpu=darwin_x86_64
-build --apple_platform_type=macos

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -36,7 +36,6 @@ if [[ -n "${BAZEL:-}" ]]; then
   # Since they are environment variables, they can't be Bash arrays, so we use
   # double-quoted strings to set them instead and just let them expand below.
   set -x
-  BAZELRC_ARGS=("--bazelrc=.travis/bazelrc.${TRAVIS_OS_NAME}")
   ALL_BUILD_ARGS=(
       --show_progress_rate_limit=30.0
       --verbose_failures
@@ -52,8 +51,8 @@ if [[ -n "${BAZEL:-}" ]]; then
     ALL_TEST_ARGS+=("--test_tag_filters=${TAGS}")
   fi
 
-  bazel "${BAZELRC_ARGS[@]}" build "${ALL_BUILD_ARGS[@]}" -- ${TARGETS}
-  bazel "${BAZELRC_ARGS[@]}" test "${ALL_BUILD_ARGS[@]}" "${ALL_TEST_ARGS[@]}" -- ${TARGETS}
+  bazel build "${ALL_BUILD_ARGS[@]}" -- ${TARGETS}
+  bazel test "${ALL_BUILD_ARGS[@]}" "${ALL_TEST_ARGS[@]}" -- ${TARGETS}
   set +x
 fi
 

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -43,11 +43,6 @@ if [[ -n "${BAZEL:-}" ]]; then
       --action_env=PATH
   )
 
-  # Can be removed when https://github.com/bazelbuild/bazel/pull/7151 is released
-  if [[ $OSTYPE == darwin* ]]; then
-    ALL_BUILD_ARGS+=("--host_cpu=darwin_x86_64")
-  fi
-
   if [[ -n "${BUILD_ARGS:-}" ]]; then
     ALL_BUILD_ARGS+=(${BUILD_ARGS})
   fi

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -331,7 +331,7 @@ binary that can run on macOS, you must specify the correct CPU and platform on t
 follows:
 
 ```shell
-$ bazel build //package:target --cpu=darwin_x86_64 --apple_platform_type=macos
+$ bazel build //package:target
 ```
 
 If you want to create a multi-architecture binary or a bundled application, please use one of the


### PR DESCRIPTION
Stop testing against Bazel release on Travis.

BuildKite does this much faster, so we'll lighten the load on Travis by only testing against HEAD.