### PR TITLE
Fix Buildifier version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -62,4 +62,4 @@ tasks:
       - "//examples/..."
       - "-//examples/apple/..."
 
-buildifier: true
+buildifier: latest


### PR DESCRIPTION
Fix Buildifier version

"buildifier: true" has been deprecated by https://github.com/bazelbuild/continuous-integration/pull/542

Closes #155.