### PR TITLE
Force -fmodule-map-file= flags to be absolute paths to fix debugging in Swift 5.0.

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -445,6 +445,7 @@ def _cc_feature_configuration(feature_configuration):
 def _compile_as_objects(
         actions,
         arguments,
+        feature_configuration,
         module_name,
         srcs,
         target_name,
@@ -457,7 +458,6 @@ def _compile_as_objects(
         copts = [],
         defines = [],
         deps = [],
-        feature_configuration = None,
         genfiles_dir = None,
         objc_fragment = None,
         swift_fragment = None):
@@ -467,6 +467,8 @@ def _compile_as_objects(
       actions: The context's `actions` object.
       arguments: A list of `Args` objects that provide additional arguments to the
           compiler, not including the `copts` list.
+      feature_configuration: A feature configuration obtained from
+          `swift_common.configure_features`.
       module_name: The name of the Swift module being compiled. This must be
           present and valid; use `swift_common.derive_module_name` to generate a
           default from the target's label if needed.
@@ -494,10 +496,6 @@ def _compile_as_objects(
       deps: Dependencies of the target being compiled. These targets must
           propagate one of the following providers: `CcInfo`,
           `SwiftClangModuleInfo`, `SwiftInfo`, or `apple_common.Objc`.
-      feature_configuration: A feature configuration obtained from
-          `swift_common.configure_features`. If omitted, a default feature
-          configuration will be used, but this argument will be required in the
-          future.
       genfiles_dir: The Bazel `*-genfiles` directory root. If provided, its path
           is added to ClangImporter's header search paths for compatibility with
           Bazel's C++ and Objective-C rules which support inclusions of generated
@@ -530,10 +528,6 @@ def _compile_as_objects(
         compiler.
     """
     _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
-
-    # TODO(b/112900284): Make this a required argument.
-    if not feature_configuration:
-        feature_configuration = _configure_features(toolchain)
 
     # Force threaded mode for WMO builds, using the same number of cores that is
     # on a Mac Pro for historical reasons.
@@ -663,6 +657,7 @@ def _compile_as_objects(
 def _compile_as_library(
         actions,
         bin_dir,
+        feature_configuration,
         label,
         module_name,
         srcs,
@@ -675,7 +670,6 @@ def _compile_as_library(
         copts = [],
         defines = [],
         deps = [],
-        feature_configuration = None,
         genfiles_dir = None,
         library_name = None,
         linkopts = [],
@@ -694,6 +688,8 @@ def _compile_as_library(
     Args:
       actions: The rule context's `actions` object.
       bin_dir: The Bazel `*-bin` directory root.
+      feature_configuration: A feature configuration obtained from
+          `swift_common.configure_features`.
       label: The target label for which the code is being compiled, which is used
           to determine unique file paths for the outputs.
       module_name: The name of the Swift module being compiled. This must be
@@ -718,10 +714,6 @@ def _compile_as_library(
       deps: Dependencies of the target being compiled. These targets must
           propagate one of the following providers: `CcInfo`,
           `SwiftClangModuleInfo`, `SwiftInfo`, or `apple_common.Objc`.
-      feature_configuration: A feature configuration obtained from
-          `swift_common.configure_features`. If omitted, a default feature
-          configuration will be used, but this argument will be required in the
-          future.
       genfiles_dir: The Bazel `*-genfiles` directory root. If provided, its path
           is added to ClangImporter's header search paths for compatibility with
           Bazel's C++ and Objective-C rules which support inclusions of generated
@@ -762,10 +754,6 @@ def _compile_as_library(
         is enabled on the toolchain, an `apple_common.Objc` provider as well.
     """
     _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
-
-    # TODO(b/112900284): Make this a required argument.
-    if not feature_configuration:
-        feature_configuration = _configure_features(toolchain)
 
     if not module_name:
         fail("'module_name' must be provided. Use " +
@@ -1180,6 +1168,7 @@ def _swift_runtime_linkopts(is_static, toolchain, is_test = False):
 
 def _swiftc_command_line_and_inputs(
         args,
+        feature_configuration,
         module_name,
         srcs,
         toolchain,
@@ -1190,7 +1179,6 @@ def _swiftc_command_line_and_inputs(
         copts = [],
         defines = [],
         deps = [],
-        feature_configuration = None,
         genfiles_dir = None,
         objc_fragment = None,
         swift_fragment = None):
@@ -1207,6 +1195,8 @@ def _swiftc_command_line_and_inputs(
 
     Args:
       args: An `Args` object into which the command line arguments will be added.
+      feature_configuration: A feature configuration obtained from
+          `swift_common.configure_features`.
       module_name: The name of the Swift module being compiled. This must be
           present and valid; use `swift_common.derive_module_name` to generate a
           default from the target's label if needed.
@@ -1230,10 +1220,6 @@ def _swiftc_command_line_and_inputs(
       deps: Dependencies of the target being compiled. These targets must
           propagate one of the following providers: `CcInfo`,
           `SwiftClangModuleInfo`, `SwiftInfo`, or `apple_common.Objc`.
-      feature_configuration: A feature configuration obtained from
-          `swift_common.configure_features`. If omitted, a default feature
-          configuration will be used, but this argument will be required in the
-          future.
       genfiles_dir: The Bazel `*-genfiles` directory root. If provided, its path
           is added to ClangImporter's header search paths for compatibility with
           Bazel's C++ and Objective-C rules which support inclusions of generated
@@ -1249,10 +1235,6 @@ def _swiftc_command_line_and_inputs(
       any source files, referenced module maps and headers, and so forth.)
     """
     _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
-
-    # TODO(b/112900284): Make this a required argument.
-    if not feature_configuration:
-        feature_configuration = _configure_features(toolchain)
 
     all_deps = deps + toolchain.implicit_deps
 

--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -215,6 +215,7 @@ def _compilation_attrs(additional_deps_aspects = []):
         _toolchain_attrs(),
         {
             "srcs": attr.label_list(
+                flags = ["DIRECT_COMPILE_TIME_INPUT"],
                 allow_files = ["swift"],
                 doc = """
 A list of `.swift` source files that will be compiled into the library.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -139,7 +139,9 @@ def declare_compile_outputs(
             args = ["-o", out_obj],
             compile_inputs = [],
             other_outputs = [],
-            output_groups = {},
+            output_groups = {
+                "compilation_outputs": depset(items = [out_obj]),
+            },
             output_objects = [out_obj],
         )
 
@@ -184,7 +186,9 @@ def declare_compile_outputs(
     )
 
     args = ["-output-file-map", output_map_file]
-    output_groups = {}
+    output_groups = {
+        "compilation_outputs": depset(items = output_objs),
+    }
 
     # Configure index-while-building if requested. IDEs and other indexing tools can enable this
     # feature on the command line during a build and then access the index store artifacts that are

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -314,13 +314,12 @@ def new_objc_provider(
 
     return apple_common.new_objc_provider(**objc_provider_args)
 
-def objc_compile_requirements(args, deps, objc_fragment):
+def objc_compile_requirements(args, deps):
     """Collects compilation requirements for Objective-C dependencies.
 
     Args:
         args: An `Args` object to which compile options will be added.
         deps: The `deps` of the target being built.
-        objc_fragment: The `objc` configuration fragment.
 
     Returns:
         A `depset` of files that should be included among the inputs of the compile action.
@@ -402,9 +401,6 @@ def objc_compile_requirements(args, deps, objc_fragment):
     # <https://llvm.org/bugs/show_bug.cgi?id=19501>
     args.add_all(module_maps, before_each = "-Xcc", format_each = "-fmodule-map-file=%s")
 
-    # Add any copts required by the `objc` configuration fragment.
-    args.add_all(_clang_copts(objc_fragment), before_each = "-Xcc")
-
     return depset(transitive = inputs)
 
 def register_autolink_extract_action(
@@ -485,22 +481,6 @@ def write_objc_header_module_map(
         ),
         output = output,
     )
-
-def _clang_copts(objc_fragment):
-    """Returns copts that should be passed to `clang` from the `objc` fragment.
-
-    Args:
-        objc_fragment: The `objc` configuration fragment.
-
-    Returns:
-        A list of `clang` copts.
-    """
-
-    # In general, every compilation mode flag from native `objc_*` rules should be passed, but `-g`
-    # seems to break Clang module compilation. Since this flag does not make much sense for module
-    # compilation and only touches headers, it's ok to omit.
-    clang_copts = objc_fragment.copts + objc_fragment.copts_for_current_compilation_mode
-    return [copt for copt in clang_copts if copt != "-g"]
 
 def _dirname_map_fn(f):
     """Returns the dir name of a file.

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -54,6 +54,11 @@ SWIFT_FEATURE_DEBUG_PREFIX_MAP = "swift.debug_prefix_map"
 # them batches of source files.
 SWIFT_FEATURE_ENABLE_BATCH_MODE = "swift.enable_batch_mode"
 
+# If enabled, Swift compilation actions will pass the `-enable-testing` flag that modifies
+# visibility controls to let a module be imported with the `@testable` attribute. This feature
+# will be enabled by default for dbg/fastbuild builds and disabled by default for opt builds.
+SWIFT_FEATURE_ENABLE_TESTING = "swift.enable_testing"
+
 # If enabled, the compilation action for a target will produce an index store.
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 
@@ -100,8 +105,11 @@ def features_for_build_modes(ctx):
     Returns:
         A list of Swift toolchain features to enable.
     """
+    compilation_mode = ctx.var["COMPILATION_MODE"]
     features = []
-    features.append("swift.{}".format(ctx.var["COMPILATION_MODE"]))
+    features.append("swift.{}".format(compilation_mode))
     if ctx.configuration.coverage_enabled:
-        features.append("swift.coverage")
+        features.append(SWIFT_FEATURE_COVERAGE)
+    if compilation_mode in ("dbg", "fastbuild"):
+        features.append(SWIFT_FEATURE_ENABLE_TESTING)
     return features

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -59,6 +59,11 @@ SWIFT_FEATURE_ENABLE_BATCH_MODE = "swift.enable_batch_mode"
 # will be enabled by default for dbg/fastbuild builds and disabled by default for opt builds.
 SWIFT_FEATURE_ENABLE_TESTING = "swift.enable_testing"
 
+# If enabled, full debug info should be generated instead of line-tables-only. This is required
+# when dSYMs are requested via the `--apple_generate_dsym` flag but the compilation mode is
+# `fastbuild`, because `dsymutil` emits spurious warnings otherwise.
+SWIFT_FEATURE_FULL_DEBUG_INFO = "swift.full_debug_info"
+
 # If enabled, the compilation action for a target will produce an index store.
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 
@@ -92,7 +97,7 @@ SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
 # typically set this automatically if using a sufficiently recent version of Swift (4.2 or higher).
 SWIFT_FEATURE_USE_RESPONSE_FILES = "swift.use_response_files"
 
-def features_for_build_modes(ctx):
+def features_for_build_modes(ctx, objc_fragment = None):
     """Returns a list of Swift toolchain features corresponding to current build modes.
 
     This function explicitly breaks the "don't pass `ctx` as an argument" rule-of-thumb because it
@@ -101,6 +106,7 @@ def features_for_build_modes(ctx):
 
     Args:
         ctx: The current rule context.
+        objc_fragment: The Objective-C configuration fragment, if available.
 
     Returns:
         A list of Swift toolchain features to enable.
@@ -112,4 +118,6 @@ def features_for_build_modes(ctx):
         features.append(SWIFT_FEATURE_COVERAGE)
     if compilation_mode in ("dbg", "fastbuild"):
         features.append(SWIFT_FEATURE_ENABLE_TESTING)
+        if objc_fragment and objc_fragment.generate_dsym:
+            features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
     return features

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -180,6 +180,12 @@ depends on.
         "clang_executable": """
 `String`. The path to the `clang` executable, which is used to link binaries.
 """,
+        "command_line_copts": """
+`List` of `strings`. Flags that were passed to Bazel using the `--swiftcopt` command line flag.
+These flags have the highest precedence; they are added to compilation command lines after the
+toolchain default flags (`SwiftToolchainInfo.swiftc_copts`) and after flags specified in the
+`copts` attributes of Swift targets.
+""",
         "cpu": "`String`. The CPU architecture that the toolchain is targeting.",
         "execution_requirements": """
 `Dict`. Execution requirements that should be passed to any actions spawned to compile or link
@@ -229,7 +235,8 @@ stamping enabled.
 """,
         "swiftc_copts": """
 `List` of `strings`. Additional flags that should be passed to `swiftc` when compiling libraries or
-binaries with this toolchain.
+binaries with this toolchain. These flags will come first in compilation command lines, allowing
+them to be overridden by `copts` attributes and `--swiftcopt` flags.
 """,
         "system_name": """
 `String`. The name of the operating system that the toolchain is targeting.

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -129,7 +129,10 @@ def _swift_linking_rule_impl(
             transitive = [compile_results.compile_inputs],
         )
 
-        dicts.add(additional_output_groups, compile_results.output_groups)
+        additional_output_groups = dicts.add(
+            additional_output_groups,
+            compile_results.output_groups,
+        )
         compilation_providers.append(
             SwiftBinaryInfo(compile_options = compile_results.compile_options),
         )

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -79,12 +79,6 @@ def _swift_linking_rule_impl(
         A tuple with two values: the `File` representing the binary that was linked, and a list of
         providers to be propagated by the target being built.
     """
-
-    # Bazel fails the build if you try to query a fragment that hasn't been declared, even
-    # dynamically with `hasattr`/`getattr`. Thus, we have to use other information to determine
-    # whether we can access the `objc` configuration.
-    objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
-
     copts = expand_locations(ctx, ctx.attr.copts, ctx.attr.swiftc_inputs)
     linkopts = list(linkopts) + expand_locations(ctx, ctx.attr.linkopts, ctx.attr.swiftc_inputs)
 
@@ -114,13 +108,11 @@ def _swift_linking_rule_impl(
             feature_configuration = feature_configuration,
             module_name = module_name,
             srcs = srcs,
-            swift_fragment = ctx.fragments.swift,
             target_name = ctx.label.name,
             toolchain = toolchain,
             additional_input_depsets = [depset(direct = additional_inputs)],
             deps = ctx.attr.deps,
             genfiles_dir = ctx.genfiles_dir,
-            objc_fragment = objc_fragment,
         )
         link_args.add_all(compile_results.linker_flags)
         objects_to_link.extend(compile_results.output_objects)
@@ -340,11 +332,6 @@ platform-specific application rules in [rules_apple](https://github.com/bazelbui
 instead of `swift_binary`.
 """,
     executable = True,
-    fragments = [
-        "cpp",
-        "objc",
-        "swift",
-    ],
     implementation = _swift_binary_impl,
 )
 
@@ -404,11 +391,6 @@ You can also disable this feature for all the tests in a package by applying it 
 `package()` declaration instead of the individual targets.
 """,
     executable = True,
-    fragments = [
-        "cpp",
-        "objc",
-        "swift",
-    ],
     test = True,
     implementation = _swift_test_impl,
 )

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -100,6 +100,5 @@ The list of `.swiftmodule` files provided to Swift targets that depend on this t
 Allows for the use of precompiled Swift modules as dependencies in other `swift_library` and
 `swift_binary` targets.
 """,
-    fragments = ["objc"],
     implementation = _swift_import_impl,
 )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -32,11 +32,7 @@ def _swift_library_impl(ctx):
     if not module_name:
         module_name = swift_common.derive_module_name(ctx.label)
 
-    # Bazel fails the build if you try to query a fragment that hasn't been declared, even
-    # dynamically with `hasattr`/`getattr`. Thus, we have to use other information to determine
-    # whether we can access the `objc` configuration.
     toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
-    objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
 
     feature_configuration = swift_common.configure_features(
         requested_features = ctx.features,
@@ -50,7 +46,6 @@ def _swift_library_impl(ctx):
         label = ctx.label,
         module_name = module_name,
         srcs = ctx.files.srcs,
-        swift_fragment = ctx.fragments.swift,
         toolchain = toolchain,
         additional_inputs = ctx.files.swiftc_inputs,
         alwayslink = ctx.attr.alwayslink,
@@ -60,7 +55,6 @@ def _swift_library_impl(ctx):
         feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
         linkopts = linkopts,
-        objc_fragment = objc_fragment,
     )
 
     direct_output_files = [
@@ -97,10 +91,6 @@ swift_library = rule(
     doc = """
 Compiles and links Swift code into a static library and Swift module.
 """,
-    fragments = [
-        "objc",
-        "swift",
-    ],
     outputs = swift_library_output_map,
     implementation = _swift_library_impl,
 )

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -60,20 +60,16 @@ following dependencies instead:\n\n""".format(
         unsupported_features = ctx.disabled_features,
     )
 
-    objc_fragment = (ctx.fragments.objc if toolchain.supports_objc_interop else None)
-
     compile_results = swift_common.compile_as_library(
         actions = ctx.actions,
         bin_dir = ctx.bin_dir,
         label = ctx.label,
         module_name = module_name,
         srcs = [reexport_src],
-        swift_fragment = ctx.fragments.swift,
         toolchain = ctx.attr._toolchain[SwiftToolchainInfo],
         deps = ctx.attr.deps,
         feature_configuration = feature_configuration,
         genfiles_dir = ctx.genfiles_dir,
-        objc_fragment = objc_fragment,
     )
 
     return compile_results.providers + [
@@ -133,6 +129,5 @@ to create "umbrella modules".
 > `deps` in the new module. You depend on undocumented features at your own
 > risk, as they may change in a future version of Swift.
 """,
-    fragments = ["swift", "objc"],
     implementation = _swift_module_alias_impl,
 )

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":api.bzl", "swift_common")
-load(":features.bzl", "SWIFT_FEATURE_NO_GENERATED_HEADER")
+load(":features.bzl", "SWIFT_FEATURE_ENABLE_TESTING", "SWIFT_FEATURE_NO_GENERATED_HEADER")
 load(
     ":proto_gen_utils.bzl",
     "declare_generated_files",
@@ -274,7 +274,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         feature_configuration = swift_common.configure_features(
             requested_features = aspect_ctx.features + [SWIFT_FEATURE_NO_GENERATED_HEADER],
             swift_toolchain = toolchain,
-            unsupported_features = aspect_ctx.disabled_features,
+            unsupported_features = aspect_ctx.disabled_features + [SWIFT_FEATURE_ENABLE_TESTING],
         )
 
         compile_results = swift_common.compile_as_library(
@@ -285,7 +285,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             srcs = pbswift_files,
             swift_fragment = aspect_ctx.fragments.swift,
             toolchain = toolchain,
-            allow_testing = False,
             deps = compile_deps,
             feature_configuration = feature_configuration,
             genfiles_dir = aspect_ctx.genfiles_dir,

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -283,7 +283,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             label = target.label,
             module_name = swift_common.derive_module_name(target.label),
             srcs = pbswift_files,
-            swift_fragment = aspect_ctx.fragments.swift,
             toolchain = toolchain,
             deps = compile_deps,
             feature_configuration = feature_configuration,
@@ -292,11 +291,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             # use the `lib{name}.a` pattern. This will produce `lib{name}.swift.a`
             # instead.
             library_name = "{}.swift".format(target.label.name),
-            # The generated protos themselves are not usable in Objective-C, but we
-            # still need the Objective-C provider that it propagates since it
-            # carries the static libraries that apple_binary will want to link on
-            # those platforms.
-            objc_fragment = aspect_ctx.fragments.objc,
         )
         providers = compile_results.providers
     else:
@@ -364,9 +358,5 @@ provider.
 Most users should not need to use this aspect directly; it is an implementation
 detail of the `swift_proto_library` rule.
 """,
-    fragments = [
-        "objc",
-        "swift",
-    ],
     implementation = _swift_protoc_gen_aspect_impl,
 )

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -207,6 +207,7 @@ def _swift_toolchain_impl(ctx):
             action_registrars = action_registrars,
             cc_toolchain_info = cc_toolchain,
             clang_executable = ctx.attr.clang_executable,
+            command_line_copts = ctx.fragments.swift.copts(),
             cpu = ctx.attr.arch,
             execution_requirements = {},
             implicit_deps = [],
@@ -269,5 +270,6 @@ The C++ toolchain from which other tools needed by the Swift toolchain (such as
         ),
     }),
     doc = "Represents a Swift compiler toolchain.",
+    fragments = ["swift"],
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -486,7 +486,7 @@ def _xcode_swift_toolchain_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
 
     # Compute the default requested features and conditional ones based on Xcode version.
-    requested_features = features_for_build_modes(ctx)
+    requested_features = features_for_build_modes(ctx, objc_fragment = ctx.fragments.objc)
     requested_features.extend(ctx.features)
     requested_features.append(SWIFT_FEATURE_BUNDLED_XCTESTS)
 

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -19,6 +19,7 @@ toolchain package. If you are looking for rules to build Swift code using this
 toolchain, see `swift.bzl`.
 """
 
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:types.bzl", "types")
@@ -34,6 +35,23 @@ load(
 )
 load(":providers.bzl", "SwiftToolchainInfo")
 load(":wrappers.bzl", "SWIFT_TOOL_WRAPPER_ATTRIBUTES")
+
+def _command_line_objc_copts(objc_fragment):
+    """Returns copts that should be passed to `clang` from the `objc` fragment.
+
+    Args:
+        objc_fragment: The `objc` configuration fragment.
+
+    Returns:
+        A list of `clang` copts, each of which is preceded by `-Xcc` so that they can be passed
+        through `swiftc` to its underlying ClangImporter instance.
+    """
+
+    # In general, every compilation mode flag from native `objc_*` rules should be passed, but `-g`
+    # seems to break Clang module compilation. Since this flag does not make much sense for module
+    # compilation and only touches headers, it's ok to omit.
+    clang_copts = objc_fragment.copts + objc_fragment.copts_for_current_compilation_mode
+    return collections.before_each("-Xcc", [copt for copt in clang_copts if copt != "-g"])
 
 def _default_linker_opts(
         apple_fragment,
@@ -479,12 +497,15 @@ def _xcode_swift_toolchain_impl(ctx):
 
     # TODO(#35): Add SWIFT_FEATURE_DEBUG_PREFIX_MAP based on Xcode version.
 
+    command_line_copts = _command_line_objc_copts(ctx.fragments.objc) + ctx.fragments.swift.copts()
+
     return [
         SwiftToolchainInfo(
             action_environment = env,
             action_registrars = action_registrars,
             cc_toolchain_info = cc_toolchain,
             clang_executable = None,
+            command_line_copts = command_line_copts,
             cpu = cpu,
             execution_requirements = execution_requirements,
             implicit_deps = [],
@@ -536,7 +557,8 @@ The C++ toolchain from which linking flags and other tools needed by the Swift t
     doc = "Represents a Swift compiler toolchain provided by Xcode.",
     fragments = [
         "apple",
-        "cpp",
+        "objc",
+        "swift",
     ],
     implementation = _xcode_swift_toolchain_impl,
 )

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -111,10 +111,12 @@ def swift_rules_dependencies():
     changes to those dependencies.
     """
     _maybe(
-        git_repository,
+        http_archive,
         name = "bazel_skylib",
-        remote = "https://github.com/bazelbuild/bazel-skylib.git",
-        tag = "0.7.0",
+        urls = [
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/0.8.0/bazel-skylib.0.8.0.tar.gz",
+        ],
+        sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
     )
 
     _maybe(

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -120,10 +120,12 @@ def swift_rules_dependencies():
     )
 
     _maybe(
-        git_repository,
+        http_archive,
         name = "build_bazel_apple_support",
-        remote = "https://github.com/bazelbuild/apple_support.git",
-        tag = "0.5.0",
+        urls = [
+            "https://github.com/bazelbuild/apple_support/releases/download/0.6.0/apple_support.0.6.0.tar.gz",
+        ],
+        sha256 = "7356dbd44dea71570a929d1d4731e870622151a5f27164d966dda97305f33471",
     )
 
     _maybe(

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -46,13 +46,67 @@
 
 set -eu
 
+# SYNOPSIS
+#   Rewrites special arguments in the given argument string, echoing the result.
+#
+# USAGE
+#   rewrite_argument <argument>
+function rewrite_argument {
+  case "$1" in
+  -Xwrapped-swift=-ephemeral-module-cache)
+    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
+    echo "-module-cache-path $MODULE_CACHE_DIR"
+    ;;
+  -fmodule-map-file=[^/]*)
+    # TODO(allevato): Remove this workaround once this patch is in a release:
+    # https://github.com/apple/swift-lldb/pull/1369
+    MODULE_MAP_FILE="${$1#-fmodule-map-file=}"
+    echo "-fmodule-map-file=$PWD/$MODULE_MAP_FILE"
+    ;;
+  *)
+    echo "$1"
+    ;;
+  esac
+}
+
+# SYNOPSIS
+#   Rewrites special arguments in the given params file, if any.
+#   If there were no substitutions to be made, the original path is echoed back
+#   out; otherwise, this function echoes the path to a temporary file
+#   containing the rewritten file.
+#
+# USAGE
+#   rewrite_params_file <path>
+function rewrite_params_file {
+  PARAMSFILE="$1"
+  if grep -qe '-fmodule-map-file=' "$PARAMSFILE" ; then
+    NEWFILE="$(mktemp "${TMPDIR%/}/swift_wrapper_params.XXXXXXXXXX")"
+    # TODO(allevato): Remove this workaround once this patch is in a release:
+    # https://github.com/apple/swift-lldb/pull/1369
+    sed \
+        -e "s#-fmodule-map-file=\([^/]\)#-fmodule-map-file=$PWD/\1#g" \
+        "$PARAMSFILE" > "$NEWFILE"
+    echo "$NEWFILE"
+  else
+    # There were no placeholders to substitute, so just return the original
+    # file.
+    echo "$PARAMSFILE"
+  fi
+}
+
 # Called when the wrapper exits (normally or abnormally) to clean up any
 # temporary state.
 function cleanup {
   if [[ -n "$MODULE_CACHE_DIR" ]] ; then
     rm -rf "$MODULE_CACHE_DIR"
   fi
+  if [[ ${#TEMPFILES[@]} -ne 0 ]] ; then
+    rm "${TEMPFILES[@]}"
+  fi
 }
+# If any temporary files are created (like rewritten response files), clean
+# them up when the script exits.
+TEMPFILES=()
 
 trap cleanup EXIT
 
@@ -66,12 +120,16 @@ MODULE_CACHE_DIR=
 ARGS=()
 for ARG in "$@" ; do
   case "$ARG" in
-  -Xwrapped-swift=-ephemeral-module-cache)
-    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
-    ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")
+  @*)
+    PARAMSFILE="${ARG:1}"
+    NEWFILE=$(rewrite_params_file "$PARAMSFILE")
+    if [[ "$PARAMSFILE" != "$NEWFILE" ]] ; then
+      TEMPFILES+=("$NEWFILE")
+    fi
+    ARGS+=("@$NEWFILE")
     ;;
   *)
-    ARGS+=("$ARG")
+    ARGS+=($(rewrite_argument "$ARG"))
     ;;
   esac
 done

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -46,67 +46,13 @@
 
 set -eu
 
-# SYNOPSIS
-#   Rewrites special arguments in the given argument string, echoing the result.
-#
-# USAGE
-#   rewrite_argument <argument>
-function rewrite_argument {
-  case "$1" in
-  -Xwrapped-swift=-ephemeral-module-cache)
-    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
-    echo "-module-cache-path $MODULE_CACHE_DIR"
-    ;;
-  -fmodule-map-file=[^/]*)
-    # TODO(allevato): Remove this workaround once this patch is in a release:
-    # https://github.com/apple/swift-lldb/pull/1369
-    MODULE_MAP_FILE="${1#-fmodule-map-file=}"
-    echo "-fmodule-map-file=$PWD/$MODULE_MAP_FILE"
-    ;;
-  *)
-    echo "$1"
-    ;;
-  esac
-}
-
-# SYNOPSIS
-#   Rewrites special arguments in the given params file, if any.
-#   If there were no substitutions to be made, the original path is echoed back
-#   out; otherwise, this function echoes the path to a temporary file
-#   containing the rewritten file.
-#
-# USAGE
-#   rewrite_params_file <path>
-function rewrite_params_file {
-  PARAMSFILE="$1"
-  if grep -qe '-fmodule-map-file=' "$PARAMSFILE" ; then
-    NEWFILE="$(mktemp "${TMPDIR%/}/swift_wrapper_params.XXXXXXXXXX")"
-    # TODO(allevato): Remove this workaround once this patch is in a release:
-    # https://github.com/apple/swift-lldb/pull/1369
-    sed \
-        -e "s#-fmodule-map-file=\([^/]\)#-fmodule-map-file=$PWD/\1#g" \
-        "$PARAMSFILE" > "$NEWFILE"
-    echo "$NEWFILE"
-  else
-    # There were no placeholders to substitute, so just return the original
-    # file.
-    echo "$PARAMSFILE"
-  fi
-}
-
 # Called when the wrapper exits (normally or abnormally) to clean up any
 # temporary state.
 function cleanup {
   if [[ -n "$MODULE_CACHE_DIR" ]] ; then
     rm -rf "$MODULE_CACHE_DIR"
   fi
-  if [[ ${#TEMPFILES[@]} -ne 0 ]] ; then
-    rm "${TEMPFILES[@]}"
-  fi
 }
-# If any temporary files are created (like rewritten response files), clean
-# them up when the script exits.
-TEMPFILES=()
 
 trap cleanup EXIT
 
@@ -120,16 +66,12 @@ MODULE_CACHE_DIR=
 ARGS=()
 for ARG in "$@" ; do
   case "$ARG" in
-  @*)
-    PARAMSFILE="${ARG:1}"
-    NEWFILE=$(rewrite_params_file "$PARAMSFILE")
-    if [[ "$PARAMSFILE" != "$NEWFILE" ]] ; then
-      TEMPFILES+=("$NEWFILE")
-    fi
-    ARGS+=("@$NEWFILE")
+  -Xwrapped-swift=-ephemeral-module-cache)
+    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
+    ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")
     ;;
   *)
-    ARGS+=($(rewrite_argument "$ARG"))
+    ARGS+=("$ARG")
     ;;
   esac
 done

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -46,13 +46,67 @@
 
 set -eu
 
+# SYNOPSIS
+#   Rewrites special arguments in the given argument string, echoing the result.
+#
+# USAGE
+#   rewrite_argument <argument>
+function rewrite_argument {
+  case "$1" in
+  -Xwrapped-swift=-ephemeral-module-cache)
+    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
+    echo "-module-cache-path $MODULE_CACHE_DIR"
+    ;;
+  -fmodule-map-file=[^/]*)
+    # TODO(allevato): Remove this workaround once this patch is in a release:
+    # https://github.com/apple/swift-lldb/pull/1369
+    MODULE_MAP_FILE="${1#-fmodule-map-file=}"
+    echo "-fmodule-map-file=$PWD/$MODULE_MAP_FILE"
+    ;;
+  *)
+    echo "$1"
+    ;;
+  esac
+}
+
+# SYNOPSIS
+#   Rewrites special arguments in the given params file, if any.
+#   If there were no substitutions to be made, the original path is echoed back
+#   out; otherwise, this function echoes the path to a temporary file
+#   containing the rewritten file.
+#
+# USAGE
+#   rewrite_params_file <path>
+function rewrite_params_file {
+  PARAMSFILE="$1"
+  if grep -qe '-fmodule-map-file=' "$PARAMSFILE" ; then
+    NEWFILE="$(mktemp "${TMPDIR%/}/swift_wrapper_params.XXXXXXXXXX")"
+    # TODO(allevato): Remove this workaround once this patch is in a release:
+    # https://github.com/apple/swift-lldb/pull/1369
+    sed \
+        -e "s#-fmodule-map-file=\([^/]\)#-fmodule-map-file=$PWD/\1#g" \
+        "$PARAMSFILE" > "$NEWFILE"
+    echo "$NEWFILE"
+  else
+    # There were no placeholders to substitute, so just return the original
+    # file.
+    echo "$PARAMSFILE"
+  fi
+}
+
 # Called when the wrapper exits (normally or abnormally) to clean up any
 # temporary state.
 function cleanup {
   if [[ -n "$MODULE_CACHE_DIR" ]] ; then
     rm -rf "$MODULE_CACHE_DIR"
   fi
+  if [[ ${#TEMPFILES[@]} -ne 0 ]] ; then
+    rm "${TEMPFILES[@]}"
+  fi
 }
+# If any temporary files are created (like rewritten response files), clean
+# them up when the script exits.
+TEMPFILES=()
 
 trap cleanup EXIT
 
@@ -66,12 +120,16 @@ MODULE_CACHE_DIR=
 ARGS=()
 for ARG in "$@" ; do
   case "$ARG" in
-  -Xwrapped-swift=-ephemeral-module-cache)
-    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
-    ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")
+  @*)
+    PARAMSFILE="${ARG:1}"
+    NEWFILE=$(rewrite_params_file "$PARAMSFILE")
+    if [[ "$PARAMSFILE" != "$NEWFILE" ]] ; then
+      TEMPFILES+=("$NEWFILE")
+    fi
+    ARGS+=("@$NEWFILE")
     ;;
   *)
-    ARGS+=("$ARG")
+    ARGS+=($(rewrite_argument "$ARG"))
     ;;
   esac
 done

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -46,67 +46,13 @@
 
 set -eu
 
-# SYNOPSIS
-#   Rewrites special arguments in the given argument string, echoing the result.
-#
-# USAGE
-#   rewrite_argument <argument>
-function rewrite_argument {
-  case "$1" in
-  -Xwrapped-swift=-ephemeral-module-cache)
-    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
-    echo "-module-cache-path $MODULE_CACHE_DIR"
-    ;;
-  -fmodule-map-file=[^/]*)
-    # TODO(allevato): Remove this workaround once this patch is in a release:
-    # https://github.com/apple/swift-lldb/pull/1369
-    MODULE_MAP_FILE="${$1#-fmodule-map-file=}"
-    echo "-fmodule-map-file=$PWD/$MODULE_MAP_FILE"
-    ;;
-  *)
-    echo "$1"
-    ;;
-  esac
-}
-
-# SYNOPSIS
-#   Rewrites special arguments in the given params file, if any.
-#   If there were no substitutions to be made, the original path is echoed back
-#   out; otherwise, this function echoes the path to a temporary file
-#   containing the rewritten file.
-#
-# USAGE
-#   rewrite_params_file <path>
-function rewrite_params_file {
-  PARAMSFILE="$1"
-  if grep -qe '-fmodule-map-file=' "$PARAMSFILE" ; then
-    NEWFILE="$(mktemp "${TMPDIR%/}/swift_wrapper_params.XXXXXXXXXX")"
-    # TODO(allevato): Remove this workaround once this patch is in a release:
-    # https://github.com/apple/swift-lldb/pull/1369
-    sed \
-        -e "s#-fmodule-map-file=\([^/]\)#-fmodule-map-file=$PWD/\1#g" \
-        "$PARAMSFILE" > "$NEWFILE"
-    echo "$NEWFILE"
-  else
-    # There were no placeholders to substitute, so just return the original
-    # file.
-    echo "$PARAMSFILE"
-  fi
-}
-
 # Called when the wrapper exits (normally or abnormally) to clean up any
 # temporary state.
 function cleanup {
   if [[ -n "$MODULE_CACHE_DIR" ]] ; then
     rm -rf "$MODULE_CACHE_DIR"
   fi
-  if [[ ${#TEMPFILES[@]} -ne 0 ]] ; then
-    rm "${TEMPFILES[@]}"
-  fi
 }
-# If any temporary files are created (like rewritten response files), clean
-# them up when the script exits.
-TEMPFILES=()
 
 trap cleanup EXIT
 
@@ -120,16 +66,12 @@ MODULE_CACHE_DIR=
 ARGS=()
 for ARG in "$@" ; do
   case "$ARG" in
-  @*)
-    PARAMSFILE="${ARG:1}"
-    NEWFILE=$(rewrite_params_file "$PARAMSFILE")
-    if [[ "$PARAMSFILE" != "$NEWFILE" ]] ; then
-      TEMPFILES+=("$NEWFILE")
-    fi
-    ARGS+=("@$NEWFILE")
+  -Xwrapped-swift=-ephemeral-module-cache)
+    MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
+    ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")
     ;;
   *)
-    ARGS+=($(rewrite_argument "$ARG"))
+    ARGS+=("$ARG")
     ;;
   esac
 done


### PR DESCRIPTION
Force -fmodule-map-file= flags to be absolute paths to fix debugging in Swift 5.0.

Forcing the paths to be absolute seems like the opposite of what we want, and long-term it is. But lldb in Swift 5.0 does not remap relative -fmodule-map-file= paths correctly, so in order to salvage the debugging experience we have to do this temporarily.