### PR TITLE
Don't eval tools for truth, just fail if it wasn't the right type.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,58 @@
-Want to contribute? Great! First, read this page (including the small print at the end).
+# How to Contribute
 
-### Before you contribute
-**Before we can use your code, you must sign the
-[Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1)
-(CLA)**, which you can do online.
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
 
-The CLA is necessary mainly because you own the copyright to your changes,
-even after your contribution becomes part of our codebase, so we need your
-permission to use and distribute your code. We also need to be sure of
-various other things — for instance that you'll tell us if you know that
-your code infringes on other people's patents. You don't have to sign
-the CLA until after you've submitted your code for review and a member has
-approved it, but you must do it before we can put your code into our codebase.
+## File or claim an issue
 
-Before you start working on a larger contribution, you should get in touch
-with us first. Use the issue tracker to explain your idea so we can help and
-possibly guide you.
+Please let us know what you're working on if you want to change or add to the
+project. Before undertaking something, please file an issue or claim an existing
+issue.
 
-### Code reviews and other contributions.
-**All submissions, including submissions by project members, require review.**
-Please follow the instructions in [the contributors documentation](http://bazel.io/contributing.html).
+All significant changes/additions should also be discussed before they can be
+accepted. This gives all participants a chance to validate the design and to
+avoid duplication of effort. Ensuring that there is an issue for discussion
+before working on a PR helps everyone provide input/discussion/advice and
+avoid a PR having to get restarted based on useful feedback.
 
-### The small print
-Contributions made by corporations are covered by a different agreement than
-the one above, the
-[Software Grant and Corporate Contributor License Agreement](https://cla.developers.google.com/about/google-corporate).
+We use [labels](https://github.com/bazelbuild/rules_swift/labels) for the
+issues and pull requests to help track priorities, things being considered,
+deferred, etc. A project owner will try to update labels every week or so, as
+workloads permit.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution;
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Setting up your development environment
+
+To enforce a consistent code style through our code base, we use `buildifier`
+from the [bazelbuild/buildtools](https://github.com/bazelbuild/buildtools) to
+format `BUILD` and `*.bzl` files. We also use `buildifier --lint=warn` to check
+for common issues.
+
+You can download `buildifier` from
+[bazelbuild/buildtools Releases Page](https://github.com/bazelbuild/buildtools/releases).
+
+Bazel's CI is configured to ensure that files in pull requests are formatted
+correctly and that there are no lint issues.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).

--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -456,15 +456,10 @@ def _compile_as_objects(
         toolchain,
         additional_input_depsets = [],
         additional_outputs = [],
-        allow_testing = True,
-        compilation_mode = None,
-        configuration = None,
         copts = [],
         defines = [],
         deps = [],
-        genfiles_dir = None,
-        objc_fragment = None,
-        swift_fragment = None):
+        genfiles_dir = None):
     """Compiles Swift source files into object files (and optionally a module).
 
     Args:
@@ -485,12 +480,6 @@ def _compile_as_objects(
           action because they are referenced by compiler flags.
       additional_outputs: A list of `File`s representing files that should be
           treated as additional outputs of the compilation action.
-      allow_testing: This argument is no longer used and will be removed in a
-          future version.
-      compilation_mode: This argument is no longer used and will be removed in a
-          future version.
-      configuration: This argument is no longer used and will be removed in a
-          future version.
       copts: A list (**not** an `Args` object) of compiler flags that apply to the
           target being built. These flags, along with those from Bazel's Swift
           configuration fragment (i.e., `--swiftcopt` command line flags) are
@@ -504,10 +493,6 @@ def _compile_as_objects(
           is added to ClangImporter's header search paths for compatibility with
           Bazel's C++ and Objective-C rules which support inclusions of generated
           headers from that location.
-      objc_fragment: This argument is no longer used and will be removed in a
-          future version.
-      swift_fragment: This argument is no longer used and will be removed in a
-          future version.
 
     Returns:
       A `struct` containing the following fields:
@@ -531,7 +516,6 @@ def _compile_as_objects(
       * `output_objects`: The object (`.o`) files that were produced by the
         compiler.
     """
-    _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
 
     # Force threaded mode for WMO builds, using the same number of cores that is
     # on a Mac Pro for historical reasons.
@@ -667,18 +651,13 @@ def _compile_as_library(
         srcs,
         toolchain,
         additional_inputs = [],
-        allow_testing = True,
         alwayslink = False,
-        compilation_mode = None,
-        configuration = None,
         copts = [],
         defines = [],
         deps = [],
         genfiles_dir = None,
         library_name = None,
-        linkopts = [],
-        objc_fragment = None,
-        swift_fragment = None):
+        linkopts = []):
     """Compiles Swift source files into static and/or shared libraries.
 
     This is a high-level API that wraps the compilation and library creation steps
@@ -704,15 +683,9 @@ def _compile_as_library(
       additional_inputs: A list of `File`s representing additional inputs that
           need to be passed to the Swift compile action because they are
           referenced in compiler flags.
-      allow_testing: This argument is no longer used and will be removed in a
-          future version.
       alwayslink: Indicates whether the object files in the library should always
           be always be linked into any binaries that depend on it, even if some
           contain no symbols referenced by the binary.
-      compilation_mode: This argument is no longer used and will be removed in a
-          future version.
-      configuration: This argument is no longer used and will be removed in a
-          future version.
       copts: Additional flags that should be passed to `swiftc`.
       defines: Symbols that should be defined by passing `-D` to the compiler.
       deps: Dependencies of the target being compiled. These targets must
@@ -731,10 +704,6 @@ def _compile_as_library(
           used directly by any action registered by this function, but they are
           added to the `SwiftInfo` provider that it returns so that the linker
           flags can be propagated to dependent targets.
-      objc_fragment: This argument is no longer used and will be removed in a
-          future version.
-      swift_fragment: This argument is no longer used and will be removed in a
-          future version.
 
     Returns:
       A `struct` containing the following fields:
@@ -757,8 +726,6 @@ def _compile_as_library(
         rule. This includes the `SwiftInfo` provider, and if Objective-C interop
         is enabled on the toolchain, an `apple_common.Objc` provider as well.
     """
-    _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
-
     if not module_name:
         fail("'module_name' must be provided. Use " +
              "'swift_common.derive_module_name' if necessary to derive one from " +
@@ -1177,15 +1144,10 @@ def _swiftc_command_line_and_inputs(
         srcs,
         toolchain,
         additional_input_depsets = [],
-        allow_testing = True,
-        compilation_mode = None,
-        configuration = None,
         copts = [],
         defines = [],
         deps = [],
-        genfiles_dir = None,
-        objc_fragment = None,
-        swift_fragment = None):
+        genfiles_dir = None):
     """Computes command line arguments and inputs needed to invoke `swiftc`.
 
     The command line arguments computed by this function are any that do *not*
@@ -1209,12 +1171,6 @@ def _swiftc_command_line_and_inputs(
       additional_input_depsets: A list of `depset`s of `File`s representing
           additional input files that need to be passed to the Swift compile
           action because they are referenced by compiler flags.
-      allow_testing: This argument is no longer used and will be removed in a
-          future version.
-      compilation_mode: This argument is no longer used and will be removed in a
-          future version.
-      configuration: This argument is no longer used and will be removed in a
-          future version.
       copts: A list (**not** an `Args` object) of compiler flags that apply to the
           target being built. These flags, along with those from Bazel's Swift
           configuration fragment (i.e., `--swiftcopt` command line flags) are
@@ -1228,18 +1184,12 @@ def _swiftc_command_line_and_inputs(
           is added to ClangImporter's header search paths for compatibility with
           Bazel's C++ and Objective-C rules which support inclusions of generated
           headers from that location.
-      objc_fragment: This argument is no longer used and will be removed in a
-          future version.
-      swift_fragment: This argument is no longer used and will be removed in a
-          future version.
 
     Returns:
       A `depset` containing the full set of files that need to be passed as inputs
       of the Bazel action that spawns a tool with the computed command line (i.e.,
       any source files, referenced module maps and headers, and so forth.)
     """
-    _ignore = [allow_testing, compilation_mode, configuration, objc_fragment, swift_fragment]
-
     all_deps = deps + toolchain.implicit_deps
 
     args.add("-module-name")

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -318,7 +318,7 @@ def _run_shell_action(
         tools = [bazel_xcode_wrapper] + user_tools
     elif type(user_tools) == type(depset()):
         tools = depset(direct = [bazel_xcode_wrapper], transitive = [user_tools])
-    elif user_tools:
+    else:
         fail("'tools' argument must be a sequence or depset.")
 
     # Prepend the wrapper executable to the command being executed.

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -99,7 +99,7 @@ def _maybe(repo_rule, name, **kwargs):
       name: The name of the repository to be defined by the rule.
       **kwargs: Additional arguments passed directly to the repository rule.
     """
-    if name not in native.existing_rules():
+    if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
 def swift_rules_dependencies():


### PR DESCRIPTION
Don't eval tools for truth, just fail if it wasn't the right type.

Newer buildifiers were still flagging tools as not always being set,
but the real issue was if the value in the args was say an empty
string, then that last if would have still failed because an empty
string is False. Instead fail if someone passes anything that isn't
a list or depset no mater what the value is.