### PR TITLE
Make `swift_grpc_library` available to Bazel users.

### DIFF
--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -1,0 +1,73 @@
+# This example illustrates how to use `swift_grpc_library` along with
+# `swift_proto_library` to build Swift binaries for a gRPC server and
+# client.
+#
+# To explore this example:
+#
+# 1.  Build both the `:echo_server` and `:echo_client` targets in this package.
+# 2.  Run the `echo_server` binary in the background of a terminal. It should
+#     print a message indicating that the service has started.
+# 3.  Run the `echo_client` binary in the same terminal. It will send a request
+#     to this service and then print the response that it received.
+
+load(
+    "//swift:swift.bzl",
+    "swift_binary",
+    "swift_grpc_library",
+    "swift_proto_library",
+    "swift_test",
+)
+
+licenses(["notice"])
+
+proto_library(
+    name = "echo_proto",
+    srcs = ["echo.proto"],
+)
+
+swift_proto_library(
+    name = "echo_proto_swift",
+    deps = [":echo_proto"],
+)
+
+swift_grpc_library(
+    name = "echo_client_services_swift",
+    srcs = [":echo_proto"],
+    flavor = "client",
+    deps = [":echo_proto_swift"],
+)
+
+swift_grpc_library(
+    name = "echo_client_test_stubs_swift",
+    srcs = [":echo_proto"],
+    flavor = "client_stubs",
+    deps = [":echo_client_services_swift"],
+)
+
+swift_grpc_library(
+    name = "echo_server_services_swift",
+    srcs = [":echo_proto"],
+    flavor = "server",
+    deps = [":echo_proto_swift"],
+)
+
+swift_binary(
+    name = "echo_server",
+    srcs = ["server_main.swift"],
+    deps = [":echo_server_services_swift"],
+)
+
+swift_test(
+    name = "echo_client_unit_test",
+    srcs = ["client_unit_test.swift"],
+    deps = [
+        ":echo_client_services_swift",
+        ":echo_client_test_stubs_swift",
+    ],
+)
+
+swift_binary(
+    name = "echo_client",
+    srcs = ["client_main.swift"],
+    deps = [":echo_client_services_swift"],
+)

--- a/examples/xplatform/grpc/client_main.swift
+++ b/examples/xplatform/grpc/client_main.swift
@@ -1,0 +1,27 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import examples_xplatform_grpc_echo_proto
+import examples_xplatform_grpc_echo_client_services_swift
+
+// Initialize the client using the same address the server is started on.
+let client = EchoServiceServiceClient(address: "0.0.0.0:9000", secure: false)
+
+// Construct a request to the echo service.
+var request = EchoRequest()
+request.contents = "Hello, world!"
+
+// Make the remote method call and print the response we receive.
+let response = try client.echo(request)
+print(response.contents)

--- a/examples/xplatform/grpc/client_unit_test.swift
+++ b/examples/xplatform/grpc/client_unit_test.swift
@@ -1,0 +1,34 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+import examples_xplatform_grpc_echo_client_services_swift
+import examples_xplatform_grpc_echo_proto
+
+@testable import examples_xplatform_grpc_echo_client_test_stubs_swift
+
+class ClientUnitTest {
+
+  func testSynchronousCall() throws {
+    let client: EchoServiceService = {
+      let stub = EchoServiceServiceTestStub()
+      stub.echoResponses.append(EchoResponse.with { response in
+        response.contents = "Hello"
+      })
+      return stub
+   }()
+   let response = try client.echo(EchoRequest())
+   XCTAssertEqual(response.contents, "Hello")
+  }
+}

--- a/examples/xplatform/grpc/echo.proto
+++ b/examples/xplatform/grpc/echo.proto
@@ -1,0 +1,27 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+service EchoService {
+  rpc Echo(EchoRequest) returns (EchoResponse);
+}
+
+message EchoRequest {
+  string contents = 1;
+}
+
+message EchoResponse {
+  string contents = 1;
+}

--- a/examples/xplatform/grpc/server_main.swift
+++ b/examples/xplatform/grpc/server_main.swift
@@ -1,0 +1,44 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Dispatch
+import SwiftGRPC
+import examples_xplatform_grpc_echo_proto
+import examples_xplatform_grpc_echo_server_services_swift
+
+/// Concrete implementation of the `EchoService` service definition.
+class EchoProvider: EchoServiceProvider {
+
+  /// Called when the server receives a request for the `EchoService.Echo` method.
+  ///
+  /// - Parameters:
+  ///   - request: The message containing the request parameters.
+  ///   - session: Information about the current session.
+  /// - Returns: The response that will be sent back to the client.
+  /// - Throws: If an error occurs while processing the request.
+  func echo(request: EchoRequest, session: EchoServiceEchoSession) throws -> EchoResponse {
+    var response = EchoResponse()
+    response.contents = "You sent: \(request.contents)"
+    return response
+  }
+}
+
+// Initialize and start the service.
+let address = "0.0.0.0:9000"
+let server = ServiceServer(address: address, serviceProviders: [EchoProvider()])
+print("Starting server in \(address)")
+server.start()
+
+// Park the main thread so that the server continues to run and listen for requests.
+dispatchMain()

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -1,0 +1,326 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A rule that generates a Swift library from gRPC services defined in protobuf sources."""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load(":api.bzl", "swift_common")
+load(":features.bzl", "SWIFT_FEATURE_ENABLE_TESTING", "SWIFT_FEATURE_NO_GENERATED_HEADER")
+load(
+    ":proto_gen_utils.bzl",
+    "declare_generated_files",
+    "extract_generated_dir_path",
+    "register_module_mapping_write_action",
+)
+load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo", "SwiftToolchainInfo")
+load(":utils.bzl", "workspace_relative_path")
+
+def _register_grpcswift_generate_action(
+        label,
+        actions,
+        direct_srcs,
+        transitive_descriptor_sets,
+        module_mapping_file,
+        mkdir_and_run,
+        protoc_executable,
+        protoc_plugin_executable,
+        flavor,
+        extra_module_imports):
+    """Registers the actions that generate `.grpc.swift` files from `.proto` files.
+
+    Args:
+        label: The label of the target being analyzed.
+        actions: The context's actions object.
+        direct_srcs: The direct `.proto` sources belonging to the target being analyzed, which
+            will be passed to `protoc`.
+        transitive_descriptor_sets: The transitive `DescriptorSet`s from the `proto_library` being
+            analyzed.
+        module_mapping_file: The `File` containing the mapping between `.proto` files and Swift
+            modules for the transitive dependencies of the target being analyzed. May be `None`, in
+            which case no module mapping will be passed (the case for leaf nodes in the dependency
+            graph).
+        mkdir_and_run: The `File` representing the `mkdir_and_run` executable.
+        protoc_executable: The `File` representing the `protoc` executable.
+        protoc_plugin_executable: The `File` representing the `protoc` plugin executable.
+        flavor: The library flavor to generate.
+        extra_module_imports: Additional modules to import.
+
+    Returns:
+        A list of generated `.grpc.swift` files corresponding to the `.proto` sources.
+    """
+    generated_files = declare_generated_files(label.name, actions, "grpc", direct_srcs)
+    generated_dir_path = extract_generated_dir_path(label.name, "grpc", generated_files)
+
+    mkdir_args = actions.args()
+    mkdir_args.add(generated_dir_path)
+
+    protoc_executable_args = actions.args()
+    protoc_executable_args.add(protoc_executable)
+
+    protoc_args = actions.args()
+
+    # protoc takes an arg of @NAME as something to read, and expects one
+    # arg per line in that file.
+    protoc_args.set_param_file_format("multiline")
+    protoc_args.use_param_file("@%s")
+
+    protoc_args.add(
+        protoc_plugin_executable,
+        format = "--plugin=protoc-gen-swiftgrpc=%s",
+    )
+    protoc_args.add(generated_dir_path, format = "--swiftgrpc_out=%s")
+    protoc_args.add("--swiftgrpc_opt=Visibility=Public")
+    if flavor == "client":
+        protoc_args.add("--swiftgrpc_opt=Client=true")
+        protoc_args.add("--swiftgrpc_opt=Server=false")
+    elif flavor == "client_stubs":
+        protoc_args.add("--swiftgrpc_opt=Client=true")
+        protoc_args.add("--swiftgrpc_opt=Server=false")
+        protoc_args.add("--swiftgrpc_opt=TestStubs=true")
+        protoc_args.add("--swiftgrpc_opt=Implementations=false")
+    elif flavor == "server":
+        protoc_args.add("--swiftgrpc_opt=Client=false")
+        protoc_args.add("--swiftgrpc_opt=Server=true")
+    else:
+        fail("Unsupported swift_grpc_library flavor", attr = "flavor")
+    protoc_args.add_all(
+        extra_module_imports,
+        format_each = "--swiftgrpc_opt=ExtraModuleImports=%s",
+    )
+    if module_mapping_file:
+        protoc_args.add(
+            module_mapping_file,
+            format = "--swiftgrpc_opt=ProtoPathModuleMappings=%s",
+        )
+    protoc_args.add("--descriptor_set_in")
+    protoc_args.add_joined(transitive_descriptor_sets, join_with = ":")
+    protoc_args.add_all([workspace_relative_path(f) for f in direct_srcs])
+
+    additional_command_inputs = [
+        mkdir_and_run,
+        protoc_executable,
+        protoc_plugin_executable,
+    ]
+    if module_mapping_file:
+        additional_command_inputs.append(module_mapping_file)
+
+    # TODO(b/23975430): This should be a simple `actions.run_shell`, but until the
+    # cited bug is fixed, we have to use the wrapper script.
+    actions.run(
+        arguments = [mkdir_args, protoc_executable_args, protoc_args],
+        executable = mkdir_and_run,
+        inputs = depset(
+            direct = additional_command_inputs,
+            transitive = [transitive_descriptor_sets],
+        ),
+        mnemonic = "ProtocGenSwiftGRPC",
+        outputs = generated_files,
+        progress_message = "Generating Swift sources for {}".format(label),
+    )
+
+    return generated_files
+
+def _swift_grpc_library_impl(ctx):
+    if len(ctx.attr.deps) != 1:
+        fail("You must list exactly one target in the deps attribute.", attr = "deps")
+    if len(ctx.attr.srcs) != 1:
+        fail("You must list exactly one target in the srcs attribute.", attr = "srcs")
+
+    toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+
+    # Direct sources are passed as arguments to protoc to generate *only* the
+    # files in this target, but we need to pass the transitive sources as inputs
+    # to the generating action so that all the dependent files are available for
+    # protoc to parse.
+    # Instead of providing all those files and opening/reading them, we use
+    # protoc's support for reading descriptor sets to resolve things.
+    direct_srcs = ctx.attr.srcs[0][ProtoInfo].direct_sources
+    transitive_descriptor_sets = ctx.attr.srcs[0][ProtoInfo].transitive_descriptor_sets
+    deps = ctx.attr.deps
+
+    minimal_module_mappings = deps[0][SwiftProtoInfo].module_mappings
+    transitive_module_mapping_file = register_module_mapping_write_action(
+        ctx.label.name,
+        ctx.actions,
+        minimal_module_mappings,
+    )
+
+    extra_module_imports = []
+    if ctx.attr.flavor == "client_stubs":
+        extra_module_imports += [swift_common.derive_module_name(deps[0].label)]
+
+    # Generate the Swift sources from the .proto files.
+    generated_files = _register_grpcswift_generate_action(
+        ctx.label,
+        ctx.actions,
+        direct_srcs,
+        transitive_descriptor_sets,
+        transitive_module_mapping_file,
+        ctx.executable._mkdir_and_run,
+        ctx.executable._protoc,
+        ctx.executable._protoc_gen_swiftgrpc,
+        ctx.attr.flavor,
+        extra_module_imports,
+    )
+
+    # Compile the generated Swift sources and produce a static library and a
+    # .swiftmodule as outputs. In addition to the other proto deps, we also pass
+    # support libraries like the SwiftProtobuf runtime as deps to the compile
+    # action.
+    compile_deps = deps + ctx.attr._proto_support
+
+    unsupported_features = ctx.disabled_features
+    if ctx.attr.flavor != "client_stubs":
+        unsupported_features.append(SWIFT_FEATURE_ENABLE_TESTING)
+
+    feature_configuration = swift_common.configure_features(
+        requested_features = ctx.features + [SWIFT_FEATURE_NO_GENERATED_HEADER],
+        swift_toolchain = toolchain,
+        unsupported_features = unsupported_features,
+    )
+
+    compile_results = swift_common.compile_as_library(
+        actions = ctx.actions,
+        bin_dir = ctx.bin_dir,
+        label = ctx.label,
+        module_name = swift_common.derive_module_name(ctx.label),
+        srcs = generated_files,
+        toolchain = toolchain,
+        deps = compile_deps,
+        feature_configuration = feature_configuration,
+        genfiles_dir = ctx.genfiles_dir,
+    )
+
+    return compile_results.providers + [
+        DefaultInfo(
+            files = depset(direct = [
+                compile_results.output_archive,
+                compile_results.output_doc,
+                compile_results.output_module,
+            ]),
+        ),
+        OutputGroupInfo(**compile_results.output_groups),
+        deps[0][SwiftProtoInfo],
+    ]
+
+swift_grpc_library = rule(
+    attrs = dicts.add(
+        swift_common.toolchain_attrs(),
+        {
+            "srcs": attr.label_list(
+                doc = """
+Exactly one `proto_library` target that defines the services being generated.
+""",
+                providers = [ProtoInfo],
+            ),
+            "deps": attr.label_list(
+                doc = """
+Exactly one `swift_proto_library` or `swift_grpc_library` target that contains the Swift protos
+used by the services being generated. Test stubs should depend on the `swift_grpc_library`
+implementing the service.
+""",
+                providers = [[SwiftInfo, SwiftProtoInfo]],
+            ),
+            "flavor": attr.string(
+                values = [
+                    "client",
+                    "client_stubs",
+                    "server",
+                ],
+                mandatory = True,
+                doc = """
+The kind of definitions that should be generated:
+
+* `"client"` to generate client definitions.
+* `"client_stubs"` to generate client test stubs.
+* `"server"` to generate server definitions.
+""",
+            ),
+            "_mkdir_and_run": attr.label(
+                cfg = "host",
+                default = Label("@build_bazel_rules_swift//tools/mkdir_and_run"),
+                executable = True,
+            ),
+            # TODO(b/63389580): Migrate to proto_lang_toolchain.
+            "_proto_support": attr.label_list(
+                default = [Label("@com_github_grpc_grpc_swift//:SwiftGRPC")],
+            ),
+            "_protoc": attr.label(
+                cfg = "host",
+                default = Label("@com_google_protobuf//:protoc"),
+                executable = True,
+            ),
+            "_protoc_gen_swiftgrpc": attr.label(
+                cfg = "host",
+                default = Label("@com_github_grpc_grpc_swift//:protoc-gen-swiftgrpc"),
+                executable = True,
+            ),
+        },
+    ),
+    doc = """
+Generates a Swift library from the gRPC services defined in protocol buffer sources.
+
+There should be one `swift_grpc_library` for any `proto_library` that defines services. A target
+based on this rule can be used as a dependency anywhere that a `swift_library` can be used.
+
+We recommend that `swift_grpc_library` targets be located in the same package as the
+`proto_library` and `swift_proto_library` targets they depend on. For more best practices around
+the use of Swift protocol buffer build rules, see the documentation for `swift_proto_library`.
+
+#### Defining Build Targets for Services
+
+Note that `swift_grpc_library` only generates the gRPC service interfaces (the `service`
+definitions) from the `.proto` files. Any messages defined in the same `.proto` file must be
+generated using a `swift_proto_library` target. Thus, the typical structure of a Swift gRPC
+library is similar to the following:
+
+```python
+proto_library(
+    name = "my_protos",
+    srcs = ["my_protos.proto"],
+)
+
+# Generate Swift types from the protos.
+swift_proto_library(
+    name = "my_protos_swift",
+    deps = [":my_protos"],
+)
+
+# Generate Swift types from the services.
+swift_grpc_library(
+    name = "my_protos_client_services_swift",
+    # The `srcs` attribute points to the `proto_library` containing the service definitions...
+    srcs = [":my_protos"],
+    # ...the `flavor` attribute specifies what kind of definitions to generate...
+    flavor = "client",
+    # ...and the `deps` attribute points to the `swift_proto_library` that was generated from
+    # the same `proto_library` and which contains the messages used by those services.
+    deps = [":my_protos_swift"],
+)
+
+# Generate test stubs from swift services.
+swift_grpc_library(
+    name = "my_protos_client_stubs_swift",
+    # The `srcs` attribute points to the `proto_library` containing the service definitions...
+    srcs = [":my_protos"],
+    # ...the `flavor` attribute specifies what kind of definitions to generate...
+    flavor = "client_stubs",
+    # ...and the `deps` attribute points to the `swift_grpc_library` that was generated from
+    # the same `proto_library` and which contains the service implementation.
+    deps = [":my_protos_client_services_swift"],
+)
+```
+""",
+    implementation = _swift_grpc_library_impl,
+)

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -332,7 +332,7 @@ swift_protoc_gen_aspect = aspect(
             # TODO(b/63389580): Migrate to proto_lang_toolchain.
             "_proto_support": attr.label_list(
                 default = [
-                    Label("@com_github_apple_swift_swift_protobuf//:SwiftProtobuf"),
+                    Label("@com_github_apple_swift_protobuf//:SwiftProtobuf"),
                 ],
             ),
             "_protoc": attr.label(
@@ -342,7 +342,7 @@ swift_protoc_gen_aspect = aspect(
             ),
             "_protoc_gen_swift": attr.label(
                 cfg = "host",
-                default = Label("@com_github_apple_swift_swift_protobuf//:ProtoCompilerPlugin"),
+                default = Label("@com_github_apple_swift_protobuf//:ProtoCompilerPlugin"),
                 executable = True,
             ),
         },

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -129,21 +129,50 @@ def swift_rules_dependencies():
 
     _maybe(
         http_archive,
-        name = "com_github_apple_swift_swift_protobuf",
-        urls = ["https://github.com/apple/swift-protobuf/archive/1.2.0.zip"],
-        strip_prefix = "swift-protobuf-1.2.0/",
+        name = "com_github_apple_swift_protobuf",
+        urls = ["https://github.com/apple/swift-protobuf/archive/1.4.0.zip"],
+        sha256 = "70ed9d031144752f106276d495e854b314d7fab4c3e1cd97150655d882dd0eb6",
+        strip_prefix = "swift-protobuf-1.4.0/",
         type = "zip",
-        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_swift_protobuf/BUILD.overlay",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_grpc_grpc_swift",
+        urls = ["https://github.com/grpc/grpc-swift/archive/0.8.1.zip"],
+        sha256 = "04b797a2d0fe03687768f5c503917f418d7612b950ec89919f0a8e3cb70b7a43",
+        strip_prefix = "grpc-swift-0.8.1/",
+        type = "zip",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_google_protobuf",
-        # v3.6.1.2, latest as of 2018-12-04
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.zip"],
-        strip_prefix = "protobuf-3.6.1.2",
+        # v3.7.1, latest as of 2019-04-03
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.7.1.zip"],
+        sha256 = "f976a4cd3f1699b6d20c1e944ca1de6754777918320c719742e1674fcf247b7e",
+        strip_prefix = "protobuf-3.7.1",
         type = "zip",
     )
+
+    # TODO(https://github.com/protocolbuffers/protobuf/issues/5918):
+    # Remove this when protobuf releases protobuf_deps.bzl and instruct users to call
+    # `protobuf_deps()` instead.
+    if not native.existing_rule("net_zlib"):
+        http_archive(
+            name = "net_zlib",
+            build_file = "@com_google_protobuf//examples:third_party/zlib.BUILD",
+            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+            strip_prefix = "zlib-1.2.11",
+            urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+        )
+
+        native.bind(
+            name = "zlib",
+            actual = "@net_zlib//:zlib",
+        )
 
     _maybe(
         _swift_autoconfiguration,

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -41,6 +41,10 @@ load(
     _swift_c_module = "swift_c_module",
 )
 load(
+    "@build_bazel_rules_swift//swift/internal:swift_grpc_library.bzl",
+    _swift_grpc_library = "swift_grpc_library",
+)
+load(
     "@build_bazel_rules_swift//swift/internal:swift_import.bzl",
     _swift_import = "swift_import",
 )
@@ -75,6 +79,7 @@ swift_common = _swift_common
 # Re-export rules.
 swift_binary = _swift_binary
 swift_c_module = _swift_c_module
+swift_grpc_library = _swift_grpc_library
 swift_import = _swift_import
 swift_library = _swift_library
 swift_test = _swift_test

--- a/third_party/com_github_apple_swift_protobuf/BUILD.overlay
+++ b/third_party/com_github_apple_swift_protobuf/BUILD.overlay
@@ -19,8 +19,8 @@ swift_library(
         "Sources/SwiftProtobufPluginLibrary/*.swift",
     ]),
     module_name = "SwiftProtobufPluginLibrary",
-    deps = [":SwiftProtobuf"],
     visibility = ["//visibility:public"],
+    deps = [":SwiftProtobuf"],
 )
 
 swift_binary(
@@ -28,6 +28,6 @@ swift_binary(
     srcs = glob([
         "Sources/protoc-gen-swift/*.swift",
     ]),
-    deps = [":SwiftProtobufPluginLibrary"],
     visibility = ["//visibility:public"],
+    deps = [":SwiftProtobufPluginLibrary"],
 )

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -1,0 +1,67 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "SwiftGRPC",
+    srcs = glob([
+        "Sources/SwiftGRPC/**/*.swift",
+    ]),
+    copts = ["-DSWIFT_PACKAGE"],  # activates CgRPC iports
+    module_name = "SwiftGRPC",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":CgRPC",
+        "@com_github_apple_swift_protobuf//:SwiftProtobuf",
+    ],
+)
+
+cc_library(
+    name = "BoringSSL",
+    srcs = glob([
+        "Sources/BoringSSL/crypto/**/*.c",
+        "Sources/BoringSSL/crypto/**/*.cc",
+        "Sources/BoringSSL/crypto/**/*.h",
+        "Sources/BoringSSL/ssl/**/*.c",
+        "Sources/BoringSSL/ssl/**/*.cc",
+        "Sources/BoringSSL/ssl/**/*.h",
+        "Sources/BoringSSL/third_party/**/*.c",
+        "Sources/BoringSSL/third_party/**/*.h",
+    ]),
+    hdrs = glob(["Sources/BoringSSL/include/**/*.h"]),
+    includes = ["Sources/BoringSSL/include"],
+)
+
+cc_library(
+    name = "CgRPC",
+    srcs = glob([
+        "Sources/CgRPC/include/**/*.h",
+        "Sources/CgRPC/shim/*.c",
+        "Sources/CgRPC/src/**/*.c",
+        "Sources/CgRPC/src/**/*.cc",
+        "Sources/CgRPC/src/**/*.h",
+        "Sources/CgRPC/third_party/nanopb/**/*.c",
+        "Sources/CgRPC/third_party/nanopb/**/*.h",
+    ]) + ["Sources/CgRPC/shim/internal.h"],
+    hdrs = ["Sources/CgRPC/shim/cgrpc.h"],
+    includes = ["Sources/CgRPC/include"],
+    tags = ["swift_module=CgRPC"],
+    deps = [
+        ":BoringSSL",
+        "//external:zlib",
+    ],
+)
+
+swift_binary(
+    name = "protoc-gen-swiftgrpc",
+    srcs = glob([
+        "Sources/protoc-gen-swiftgrpc/*.swift",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_apple_swift_protobuf//:SwiftProtobuf",
+        "@com_github_apple_swift_protobuf//:SwiftProtobufPluginLibrary",
+    ],
+)


### PR DESCRIPTION
Make `swift_grpc_library` available to Bazel users.

RELNOTES: The `swift_grpc_library` rule has been added, which can be used to generate Swift code for gRPC clients/servers. Necessary dependencies (gRPC and gRPC-Swift) are automatically added to the workspace.