### PR TITLE
Add a persistent worker to support `swiftc` incremental compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,16 @@ uses `clang`.
   macOS.
 * Automatically download a Linux toolchain from [swift.org](https://swift.org)
   if one is not already installed.
+
+## Acknowledgments
+
+We gratefully acknowledge the following external packages that rules_swift
+depends on:
+
+* [Apple Support for Bazel](https://github.com/bazelbuild/apple_support) (Google)
+* [Bazel Skylib](https://github.com/bazelbuild/bazel-skylib) (Google)
+* [JSON for Modern C++](https://github.com/nlohmann/json) (Niels Lohmann)
+* [Protocol Buffers](https://github.com/protocolbuffers/protobuf) (Google)
+* [Swift gRPC](https://github.com/grpc/grpc-swift) (Google)
+* [Swift Protobuf](https://github.com/apple/swift-protobuf) (Apple)
+* [zlib](https://www.zlib.net) (Jean-loup Gailly and Mark Adler)

--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -585,15 +585,24 @@ def _compile_as_objects(
     compile_outputs = ([out_module, out_doc] + output_objects +
                        compile_reqs.other_outputs) + additional_outputs
 
+    if toolchain.swift_worker:
+        execution_requirements = {"supports-workers": "1"}
+        tools = [toolchain.swift_worker]
+    else:
+        execution_requirements = {}
+        tools = []
+
     run_toolchain_swift_action(
         actions = actions,
         arguments = [wrapper_args, compile_args] + arguments,
+        execution_requirements = execution_requirements,
         inputs = all_inputs,
         mnemonic = "SwiftCompile",
         outputs = compile_outputs,
         progress_message = "Compiling Swift module {}".format(module_name),
         swift_tool = "swiftc",
         toolchain = toolchain,
+        tools = tools,
     )
 
     linker_flags = []

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -184,6 +184,11 @@ def declare_compile_outputs(
 
         output_map[src.path] = struct(**src_output_map)
 
+    # Output the module-wide `.swiftdeps` file, which is used for incremental builds.
+    swiftdeps = derived_files.swift_dependencies_file(actions, target_name = target_name)
+    other_outputs.append(swiftdeps)
+    output_map[""] = {"swift-dependencies": swiftdeps.path}
+
     actions.write(
         content = struct(**output_map).to_json(),
         output = output_map_file,

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -221,6 +221,28 @@ def _swiftmodule(actions, module_name):
     """
     return actions.declare_file("{}.swiftmodule".format(module_name))
 
+def _swift_dependencies_file(actions, target_name, src = None):
+    """Declares a file containing the compiler-generated Swift dependencies for a target.
+
+    This file is used during incremental compilation to determine which object files and partial
+    modules need to be rebuilt when a particular source file changes.
+
+    Args:
+      actions: The context's actions object.
+      target_name: The name of the target being built.
+      src: An optional `File` representing the source file being compiled.
+
+    Returns:
+      The declared `File`.
+    """
+    if src:
+        dirname, basename = _intermediate_frontend_file_path(target_name, src)
+        return actions.declare_file(
+            paths.join(dirname, "{}.swiftdeps".format(basename)),
+        )
+
+    return actions.declare_file("{}.swiftdeps".format(target_name))
+
 def _whole_module_object_file(actions, target_name):
     """Declares a file for the object file created with whole module optimization.
 
@@ -275,6 +297,7 @@ derived_files = struct(
     swiftc_output_file_map = _swiftc_output_file_map,
     swiftdoc = _swiftdoc,
     swiftmodule = _swiftmodule,
+    swift_dependencies_file = _swift_dependencies_file,
     whole_module_object_file = _whole_module_object_file,
     xctest_bundle = _xctest_bundle,
     xctest_runner_script = _xctest_runner_script,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -238,6 +238,9 @@ stamping enabled.
 binaries with this toolchain. These flags will come first in compilation command lines, allowing
 them to be overridden by `copts` attributes and `--swiftcopt` flags.
 """,
+        "swift_worker": """
+`File`. The executable representing the Swift persistent worker to use for incremental builds.
+""",
         "system_name": """
 `String`. The name of the operating system that the toolchain is targeting.
 """,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -218,6 +218,7 @@ def _swift_toolchain_impl(ctx):
             stamp = ctx.attr.stamp,
             supports_objc_interop = False,
             swiftc_copts = [],
+            swift_worker = ctx.executable._swift_worker,
             system_name = ctx.attr.os,
             unsupported_features = ctx.disabled_features + [
                 SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,

--- a/swift/internal/wrappers.bzl
+++ b/swift/internal/wrappers.bzl
@@ -15,6 +15,13 @@
 """Attributes for Swift tool wrapper executables used by the toolchains."""
 
 SWIFT_TOOL_WRAPPER_ATTRIBUTES = {
+    "_swift_worker": attr.label(
+        cfg = "host",
+        default = Label(
+            "@build_bazel_rules_swift//tools/worker",
+        ),
+        executable = True,
+    ),
     "_swift_wrapper": attr.label(
         cfg = "host",
         default = Label(

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -516,6 +516,7 @@ def _xcode_swift_toolchain_impl(ctx):
             stamp = ctx.attr.stamp if _is_macos(platform) else None,
             supports_objc_interop = True,
             swiftc_copts = swiftc_copts,
+            swift_worker = ctx.executable._swift_worker,
             system_name = "darwin",
             unsupported_features = ctx.disabled_features + [
                 SWIFT_FEATURE_AUTOLINK_EXTRACT,

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -149,6 +149,15 @@ def swift_rules_dependencies():
 
     _maybe(
         http_archive,
+        name = "com_github_nlohmann_json",
+        urls = ["https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip"],
+        sha256 = "69cc88207ce91347ea530b227ff0776db82dcb8de6704e1a3d74f4841bc651cf",
+        type = "zip",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_nlohmann_json/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
         name = "com_google_protobuf",
         # v3.7.1, latest as of 2019-04-03
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.7.1.zip"],

--- a/third_party/bazel_protos/BUILD
+++ b/third_party/bazel_protos/BUILD
@@ -1,0 +1,12 @@
+licenses(["notice"])
+
+proto_library(
+    name = "worker_protocol_proto",
+    srcs = ["worker_protocol.proto"],
+)
+
+cc_proto_library(
+    name = "worker_protocol_cc_proto",
+    visibility = ["//tools/worker:__pkg__"],
+    deps = [":worker_protocol_proto"],
+)

--- a/third_party/bazel_protos/README.md
+++ b/third_party/bazel_protos/README.md
@@ -1,0 +1,3 @@
+This directory contains protocol buffers vendored from the main Bazel
+repository, so that rules_swift does not need to depend on the entire
+`@io_bazel` workspace, which is approximately 100MB.

--- a/third_party/bazel_protos/worker_protocol.proto
+++ b/third_party/bazel_protos/worker_protocol.proto
@@ -1,0 +1,52 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package blaze.worker;
+
+option java_package = "com.google.devtools.build.lib.worker";
+
+// An input file.
+message Input {
+  // The path in the file system where to read this input artifact from. This is
+  // either a path relative to the execution root (the worker process is
+  // launched with the working directory set to the execution root), or an
+  // absolute path.
+  string path = 1;
+
+  // A hash-value of the contents. The format of the contents is unspecified and
+  // the digest should be treated as an opaque token.
+  bytes digest = 2;
+}
+
+// This represents a single work unit that Bazel sends to the worker.
+message WorkRequest {
+  repeated string arguments = 1;
+
+  // The inputs that the worker is allowed to read during execution of this
+  // request.
+  repeated Input inputs = 2;
+}
+
+// The worker sends this message to Bazel when it finished its work on the
+// WorkRequest message.
+message WorkResponse {
+  int32 exit_code = 1;
+
+  // This is printed to the user after the WorkResponse has been received and is
+  // supposed to contain compiler warnings / errors etc. - thus we'll use a
+  // string type here, which gives us UTF-8 encoding.
+  string output = 2;
+}

--- a/third_party/com_github_nlohmann_json/BUILD.overlay
+++ b/third_party/com_github_nlohmann_json/BUILD.overlay
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "json",
+    srcs = glob(
+        ["include/nlohmann/**/*.hpp"],
+        exclude = ["include/nlohmann/json.hpp"]),
+    hdrs = ["include/nlohmann/json.hpp"],
+    includes = ["include"],
+)

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -1,0 +1,42 @@
+package(
+    default_visibility = [
+        "//tools/worker:__pkg__",
+    ],
+)
+
+licenses(["notice"])
+
+cc_library(
+    name = "file_system",
+    srcs = ["file_system.cc"],
+    hdrs = ["file_system.h"],
+    deps = [
+        ":path_utils",
+    ],
+)
+
+cc_library(
+    name = "path_utils",
+    srcs = ["path_utils.cc"],
+    hdrs = ["path_utils.h"],
+)
+
+cc_library(
+    name = "process",
+    srcs = ["process.cc"],
+    hdrs = ["process.h"],
+    deps = [
+        ":path_utils",
+    ],
+)
+
+cc_library(
+    name = "string_utils",
+    srcs = ["string_utils.cc"],
+    hdrs = ["string_utils.h"],
+)
+
+cc_library(
+    name = "temp_file",
+    hdrs = ["temp_file.h"],
+)

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -1,0 +1,88 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/common/file_system.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <string>
+
+#ifdef __APPLE__
+#include <copyfile.h>
+#else
+#include <fcntl.h>
+#include <sys/sendfile.h>
+#endif
+
+#include "tools/common/path_utils.h"
+
+bool CopyFile(const std::string &src, const std::string &dest) {
+#ifdef __APPLE__
+  // The `copyfile` function with `COPYFILE_ALL` mode preserves permissions and
+  // modification time.
+  return copyfile(src.c_str(), dest.c_str(), nullptr, COPYFILE_ALL) == 0;
+#elif __unix__
+  // On Linux, we can use `sendfile` to copy it more easily than calling
+  // `read`/`write` in a loop.
+  struct stat stat_buf;
+  bool success = false;
+
+  int src_fd = open(src.c_str(), O_RDONLY);
+  if (src_fd) {
+    fstat(src_fd, &stat_buf);
+
+    int dest_fd = open(dest.c_str(), O_WRONLY | O_CREAT, stat_buf.st_mode);
+    if (dest_fd) {
+      off_t offset = 0;
+      if (sendfile(dest_fd, src_fd, &offset, stat_buf.st_size) != -1) {
+        struct timespec timespecs[2] = {stat_buf.st_atim, stat_buf.st_mtim};
+        futimens(dest_fd, timespecs);
+        success = true;
+      }
+      close(dest_fd);
+    }
+    close(src_fd);
+  }
+  return success;
+#else
+// TODO(allevato): If we want to support Windows in the future, we'll need to
+// use something like `CopyFileA`.
+#error Only macOS and Unix are supported at this time.
+#endif
+}
+
+bool MakeDirs(const std::string &path, int mode) {
+  // If we got an empty string, we've recursed past the first segment in the
+  // path. Assume it exists (if it doesn't, we'll fail when we try to create a
+  // directory inside it).
+  if (path.empty()) {
+    return true;
+  }
+
+  struct stat dir_stats;
+  if (stat(path.c_str(), &dir_stats) == 0) {
+    // Return true if the directory already exists.
+    return S_ISDIR(dir_stats.st_mode);
+  }
+
+  // Recurse to create the parent directory.
+  if (!MakeDirs(Dirname(path).c_str(), mode)) {
+    return false;
+  }
+
+  // Create the directory that was requested.
+  return mkdir(path.c_str(), mode) == 0;
+}

--- a/tools/common/file_system.h
+++ b/tools/common/file_system.h
@@ -1,0 +1,27 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_
+
+#include <string>
+
+// Copies the file at src to dest. Returns true if successful.
+bool CopyFile(const std::string &src, const std::string &dest);
+
+// Creates a directory at the given path, along with any parent directories that
+// don't already exist. Returns true if successful.
+bool MakeDirs(const std::string &path, int mode);
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_

--- a/tools/common/path_utils.cc
+++ b/tools/common/path_utils.cc
@@ -1,0 +1,44 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/common/path_utils.h"
+
+#include <cstring>
+#include <string>
+
+const char *Basename(const char *path) {
+  const char *base = strrchr(path, '/');
+  return base ? (base + 1) : path;
+}
+
+std::string Dirname(const std::string &path) {
+  auto last_slash = path.rfind('/');
+  if (last_slash == std::string::npos) {
+    return std::string();
+  }
+  return path.substr(0, last_slash);
+}
+
+std::string ReplaceExtension(const std::string &path,
+                             const std::string &new_extension) {
+  auto last_dot = path.rfind('.');
+  auto last_slash = path.rfind('/');
+
+  // If there was no dot, or if it was part of a previous path segment, append
+  // the extension to the path.
+  if (last_dot == std::string::npos || last_dot < last_slash) {
+    return path + new_extension;
+  }
+  return path.substr(0, last_dot) + new_extension;
+}

--- a/tools/common/path_utils.h
+++ b/tools/common/path_utils.h
@@ -1,0 +1,35 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_PATH_UTILS_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_PATH_UTILS_H_
+
+#include <string>
+
+// Returns the base name of the given filepath. For example, given
+// "/foo/bar/baz.txt", returns "baz.txt".
+const char *Basename(const char *path);
+
+// Returns the directory name of the given filepath. For example, given
+// "/foo/bar/baz.txt", returns "/foo/bar".
+std::string Dirname(const std::string &path);
+
+// Replaces the file extension of path with new_extension. It is assumed that
+// new_extension starts with a dot if it is desired for a dot to precede the new
+// extension in the returned path. If the path does not have a file extension,
+// then new_extension is appended to it.
+std::string ReplaceExtension(const std::string &path,
+                             const std::string &new_extension);
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_PATH_UTILS_H_

--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -1,0 +1,186 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/poll.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tools/common/path_utils.h"
+
+extern char **environ;
+
+namespace {
+
+// An RAII class that manages the pipes and posix_spawn state needed to redirect
+// subprocess I/O. Currently only supports stderr, but can be extended to handle
+// stdin and stdout if needed.
+class PosixSpawnIORedirector {
+ public:
+  // Create an I/O redirector that can be used with posix_spawn to capture
+  // stderr.
+  static std::unique_ptr<PosixSpawnIORedirector> Create(bool stdoutToStderr) {
+    int stderr_pipe[2];
+    if (pipe(stderr_pipe) != 0) {
+      return nullptr;
+    }
+
+    return std::unique_ptr<PosixSpawnIORedirector>(
+        new PosixSpawnIORedirector(stderr_pipe, stdoutToStderr));
+  }
+
+  // Explicitly make PosixSpawnIORedirector non-copyable and movable.
+  PosixSpawnIORedirector(const PosixSpawnIORedirector &) = delete;
+  PosixSpawnIORedirector &operator=(const PosixSpawnIORedirector &) = delete;
+  PosixSpawnIORedirector(PosixSpawnIORedirector &&) = default;
+  PosixSpawnIORedirector &operator=(PosixSpawnIORedirector &&) = default;
+
+  ~PosixSpawnIORedirector() {
+    SafeClose(&stderr_pipe_[0]);
+    SafeClose(&stderr_pipe_[1]);
+    posix_spawn_file_actions_destroy(&file_actions_);
+  }
+
+  // Returns the pointer to a posix_spawn_file_actions_t value that should be
+  // passed to posix_spawn to enable this redirection.
+  posix_spawn_file_actions_t *PosixSpawnFileActions() { return &file_actions_; }
+
+  // Returns a pointer to the two-element file descriptor array for the stderr
+  // pipe.
+  int *StderrPipe() { return stderr_pipe_; }
+
+  // Consumes all the data output to stderr by the subprocess and writes it to
+  // the given output stream.
+  void ConsumeAllSubprocessOutput(std::ostream *stderr_stream);
+
+ private:
+  explicit PosixSpawnIORedirector(int stderr_pipe[], bool stdoutToStderr) {
+    memcpy(stderr_pipe_, stderr_pipe, sizeof(int) * 2);
+
+    posix_spawn_file_actions_init(&file_actions_);
+    posix_spawn_file_actions_addclose(&file_actions_, stderr_pipe_[0]);
+    if (stdoutToStderr) {
+      posix_spawn_file_actions_adddup2(&file_actions_, stderr_pipe_[1],
+                                       STDOUT_FILENO);
+    }
+    posix_spawn_file_actions_adddup2(&file_actions_, stderr_pipe_[1],
+                                     STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&file_actions_, stderr_pipe_[1]);
+  }
+
+  // Closes a file descriptor only if it hasn't already been closed.
+  void SafeClose(int *fd) {
+    if (*fd >= 0) {
+      close(*fd);
+      *fd = -1;
+    }
+  }
+
+  int stderr_pipe_[2];
+  posix_spawn_file_actions_t file_actions_;
+};
+
+void PosixSpawnIORedirector::ConsumeAllSubprocessOutput(
+    std::ostream *stderr_stream) {
+  SafeClose(&stderr_pipe_[1]);
+
+  char stderr_buffer[1024];
+  pollfd stderr_poll = {stderr_pipe_[0], POLLIN};
+  int status;
+  while ((status = poll(&stderr_poll, 1, -1)) > 0) {
+    if (stderr_poll.revents) {
+      int bytes_read =
+          read(stderr_pipe_[0], stderr_buffer, sizeof(stderr_buffer));
+      if (bytes_read == 0) {
+        break;
+      }
+      stderr_stream->write(stderr_buffer, bytes_read);
+    }
+  }
+}
+
+// Converts an array of string arguments to char *arguments.
+// The first arg is reduced to its basename as per execve conventions.
+// Note that the lifetime of the char* arguments in the returned array
+// are controlled by the lifetime of the strings in args.
+std::vector<const char *> ConvertToCArgs(const std::vector<std::string> &args) {
+  std::vector<const char *> c_args;
+  c_args.push_back(Basename(args[0].c_str()));
+  for (int i = 1; i < args.size(); i++) {
+    c_args.push_back(args[i].c_str());
+  }
+  c_args.push_back(nullptr);
+  return c_args;
+}
+
+}  // namespace
+
+void ExecProcess(const std::vector<std::string> &args) {
+  std::vector<const char *> exec_argv = ConvertToCArgs(args);
+  execv(args[0].c_str(), const_cast<char **>(exec_argv.data()));
+  std::cerr << "Error executing child process.'" << args[0] << "'. "
+            << strerror(errno) << "\n";
+  abort();
+}
+
+int RunSubProcess(const std::vector<std::string> &args,
+                  std::ostream *stderr_stream, bool stdout_to_stderr) {
+  std::vector<const char *> exec_argv = ConvertToCArgs(args);
+
+  // Set up a pipe to redirect stderr from the child process so that we can
+  // capture it and return it in the response message.
+  std::unique_ptr<PosixSpawnIORedirector> redirector =
+      PosixSpawnIORedirector::Create(stdout_to_stderr);
+  if (!redirector) {
+    (*stderr_stream) << "Error creating stderr pipe for child process.\n";
+    return 254;
+  }
+
+  pid_t pid;
+  int status =
+      posix_spawn(&pid, args[0].c_str(), redirector->PosixSpawnFileActions(),
+                  nullptr, const_cast<char **>(exec_argv.data()), environ);
+  redirector->ConsumeAllSubprocessOutput(stderr_stream);
+
+  if (status == 0) {
+    int wait_status;
+    do {
+      wait_status = waitpid(pid, &status, 0);
+    } while ((wait_status == -1) && (errno == EINTR));
+
+    if (wait_status < 0) {
+      std::cerr << "Error waiting on child process '" << args[0] << "'. "
+                << strerror(errno) << "\n";
+      return wait_status;
+    }
+
+    int exit_status = WEXITSTATUS(status);
+    if (exit_status != 0) {
+      return exit_status;
+    }
+    return 0;
+  } else {
+    std::cerr << "Error forking process '" << args[0] << "'. "
+              << strerror(status) << "\n";
+    return status;
+  }
+}

--- a/tools/common/process.h
+++ b/tools/common/process.h
@@ -1,0 +1,32 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WRAPPERS_PROCESS_H
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_WRAPPERS_PROCESS_H
+
+#include <string>
+#include <vector>
+
+// Turn our current process into a new process. Avoids fork overhead.
+// Never returns.
+void ExecProcess(const std::vector<std::string> &args);
+
+// Spawns a subprocess for given arguments args and waits for it to terminate.
+// The first argument is used for the executable path. If stdout_to_stderr is
+// set, then stdout is redirected to the stderr stream as well. Returns the exit
+// code of the spawned process.
+int RunSubProcess(const std::vector<std::string> &args,
+                  std::ostream *stderr_stream, bool stdout_to_stderr = false);
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WRAPPERS_PROCESS_H

--- a/tools/common/string_utils.cc
+++ b/tools/common/string_utils.cc
@@ -1,0 +1,42 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <map>
+#include <string>
+
+// Finds and replaces all instances of oldsub with newsub, in-place on str.
+// Returns true if the string was changed.
+static bool FindAndReplace(const std::string &oldsub, const std::string &newsub,
+                           std::string *str) {
+  int start = 0;
+  bool changed = false;
+  while ((start = str->find(oldsub, start)) != std::string::npos) {
+    changed = true;
+    str->replace(start, oldsub.length(), newsub);
+    start += newsub.length();
+  }
+  return changed;
+}
+
+bool MakeSubstitutions(std::string *arg,
+                       const std::map<std::string, std::string> &mappings) {
+  bool changed = false;
+
+  // Replace placeholders in the string with their actual values.
+  for (std::pair<std::string, std::string> mapping : mappings) {
+    changed |= FindAndReplace(mapping.first, mapping.second, arg);
+  }
+
+  return changed;
+}

--- a/tools/common/string_utils.h
+++ b/tools/common/string_utils.h
@@ -1,0 +1,25 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_STRING_UTILS_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_STRING_UTILS_H_
+
+#include <map>
+#include <string>
+
+// Rewrites the given argument by replacing any Bazel path placeholders.
+bool MakeSubstitutions(std::string *arg,
+                       const std::map<std::string, std::string> &mappings);
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_STRING_UTILS_H_

--- a/tools/common/temp_file.h
+++ b/tools/common/temp_file.h
@@ -1,0 +1,60 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TEMP_FILE_H
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TEMP_FILE_H
+
+#include <cerrno>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+// An RAII temporary file.
+class TempFile {
+ public:
+  // Create a new temporary file using the given path template string (the same
+  // form used by `mkstemp`). The file will automatically be deleted when the
+  // object goes out of scope.
+  static std::unique_ptr<TempFile> Create(const std::string &path_template) {
+    size_t size = path_template.size() + 1;
+    std::unique_ptr<char[]> path(new char[size]);
+    snprintf(path.get(), size, "%s", path_template.c_str());
+
+    if (mkstemp(path.get()) == -1) {
+      std::cerr << "Failed to create temporary file: " << strerror(errno)
+                << "\n";
+      return nullptr;
+    }
+    return std::unique_ptr<TempFile>(new TempFile(path.get()));
+  }
+
+  // Explicitly make TempFile non-copyable and movable.
+  TempFile(const TempFile &) = delete;
+  TempFile &operator=(const TempFile &) = delete;
+  TempFile(TempFile &&) = default;
+  TempFile &operator=(TempFile &&) = default;
+
+  ~TempFile() { remove(path_.c_str()); }
+
+  // Gets the path to the temporary file.
+  std::string GetPath() const { return path_; }
+
+ private:
+  explicit TempFile(const std::string &path) : path_(path) {}
+
+  std::string path_;
+};
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TEMP_FILE_H

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -1,0 +1,32 @@
+licenses(["notice"])
+
+cc_library(
+    name = "work_processor",
+    srcs = [
+        "output_file_map.cc",
+        "output_file_map.h",
+        "work_processor.cc",
+    ],
+    hdrs = ["work_processor.h"],
+    deps = [
+        "//third_party/bazel_protos:worker_protocol_cc_proto",
+        "//tools/common:file_system",
+        "//tools/common:path_utils",
+        "//tools/common:process",
+        "//tools/common:string_utils",
+        "//tools/common:temp_file",
+        "@com_github_nlohmann_json//:json",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_binary(
+    name = "worker",
+    srcs = ["main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":work_processor",
+        "//third_party/bazel_protos:worker_protocol_cc_proto",
+        "@com_google_protobuf//:protobuf",
+    ],
+)

--- a/tools/worker/main.cc
+++ b/tools/worker/main.cc
@@ -1,0 +1,115 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unistd.h>
+
+#include <iostream>
+
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/util/delimited_message_util.h>
+#include "third_party/bazel_protos/worker_protocol.pb.h"
+#include "tools/worker/work_processor.h"
+
+// How Swift Incremental Compilation Works
+// =======================================
+// When a Swift module is compiled, the output file map (a JSON file mapping
+// source files to outputs) tells the compiler where to write the object (.o)
+// files and partial .swiftmodule files. For incremental mode to work, the
+// output file map must also contain "swift-dependencies" entries; these files
+// contain compiler-internal data that describes how the sources in the module
+// are interrelated. Once all of these outputs exist on the file system, future
+// invocations of the compiler will use them to detect which source files
+// actually need to be recompiled if any of them change.
+//
+// This compilation model doesn't interact well with Bazel, which expects builds
+// to be hermetic (not affected by each other). In other words, outputs of build
+// N are traditionally not available as inputs to build N+1; the action
+// declaration model does not allow this.
+//
+// One could disable the sandbox to hack around this, but this should not be a
+// requirement of a well-designed build rule implementation.
+//
+// Bazel provides "persistent workers" to address this. A persistent worker is a
+// long-running "server" that waits for requests, which it can then handle
+// in-process or by spawning other commands (we do the latter). The important
+// feature here is that this worker can manage a separate file store that allows
+// state to persist across multiple builds.
+//
+// However, there are still some caveats that we have to address:
+//
+// - The "SwiftCompile" actions registered by the build rules must declare the
+//   object files and partial .swiftmodules as outputs, because later actions
+//   need those files as inputs (e.g., archiving a static library or linking a
+//   dynamic library or executable).
+//
+// - Because those files are declared action outputs, Bazel will delete them or
+//   otherwise make them unavailable before the action executes, which destroys
+//   our persistent state.
+//
+// - We could avoid declaring those individual outputs if we had the persistent
+//   worker also link them, but this is infeasible: static archiving uses
+//   platform-dependent logic and will eventually be migrated to actions from
+//   the C++ toolchain, and linking a dynamic library or executable also uses
+//   the C++ toolchain. Furthermore, we may want to stop propagating .a files
+//   for linking and instead propagate the .o files directly, avoiding an
+//   archiving step when it isn't explicitly requested.
+//
+// So to make this work, we redirect the compiler to write its outputs to an
+// alternate location that isn't declared by any Bazel action -- this prevents
+// the files from being deleted between builds so the compiler can find them.
+// (We still use a descendant of `bazel-bin` so that it *will* be removed by a
+// `bazel clean`, as the user would expect.) Then, after the compiler is done,
+// we copy those outputs into the locations where Bazel declared them, so that
+// it can find them as well.
+
+int main(int argc, char *argv[]) {
+  // Set up the input and output streams used to communicate with Bazel over
+  // stdin and stdout.
+  google::protobuf::io::FileInputStream file_input_stream(STDIN_FILENO);
+  file_input_stream.SetCloseOnDelete(false);
+  google::protobuf::io::FileOutputStream file_output_stream(STDOUT_FILENO);
+  file_output_stream.SetCloseOnDelete(false);
+
+  // Pass the "universal arguments" to the Swift work processor. They will be
+  // rewritten to replace any placeholders if necessary, and then passed at the
+  // beginning of any process invocation. Note that these arguments include the
+  // tool itself (i.e., "swiftc") and any platform-specific wrapping that may be
+  // present, like "xcrun".
+  WorkProcessor swift_worker(argc, argv);
+
+  while (true) {
+    blaze::worker::WorkRequest request;
+    if (!google::protobuf::util::ParseDelimitedFromZeroCopyStream(
+            &request, &file_input_stream, nullptr)) {
+      std::cerr << "Could not read WorkRequest from stdin. Killing worker "
+                << "process.\n";
+      return 254;
+    }
+
+    blaze::worker::WorkResponse response;
+    swift_worker.ProcessWorkRequest(request, &response);
+
+    if (!google::protobuf::util::SerializeDelimitedToZeroCopyStream(
+            response, &file_output_stream)) {
+      std::cerr << "Could not write WorkResponse to stdout. Killing worker "
+                << "process.\n";
+      return 254;
+    }
+    // Flush stdout after writing to ensure that Bazel doesn't hang waiting for
+    // the response due to buffering.
+    file_output_stream.Flush();
+  }
+
+  return 0;
+}

--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -1,0 +1,119 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/worker/output_file_map.h"
+
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "tools/common/path_utils.h"
+#include <nlohmann/json.hpp>
+
+namespace {
+
+// Returns the given path transformed to point to the incremental storage area.
+// For example, "bazel-out/config/{genfiles,bin}/path" becomes
+// "bazel-out/config/{genfiles,bin}/_swift_incremental/path".
+static std::string MakeIncrementalOutputPath(std::string path) {
+  auto bin_index = path.find("/bin/");
+  if (bin_index != std::string::npos) {
+    path.replace(bin_index, 5, "/bin/_swift_incremental/");
+    return path;
+  }
+  auto genfiles_index = path.find("/genfiles/");
+  if (genfiles_index != std::string::npos) {
+    path.replace(genfiles_index, 10, "/genfiles/_swift_incremental/");
+    return path;
+  }
+  return path;
+}
+
+};  // end namespace
+
+void OutputFileMap::ReadFromPath(const std::string &path) {
+  std::ifstream stream(path);
+  stream >> json_;
+  UpdateForIncremental();
+}
+
+void OutputFileMap::WriteToPath(const std::string &path) {
+  std::ofstream stream(path);
+  stream << json_;
+}
+
+void OutputFileMap::UpdateForIncremental() {
+  nlohmann::json new_output_file_map;
+  std::map<std::string, std::string> incremental_outputs;
+
+  for (auto &element : json_.items()) {
+    auto src = element.key();
+    auto outputs = element.value();
+
+    // The empty string key is used to represent outputs that are for the whole
+    // module, rather than for a particular source file.
+    if (src.empty()) {
+      nlohmann::json empty_map = outputs;
+      auto path = outputs["swift-dependencies"].get<std::string>();
+      auto new_path = MakeIncrementalOutputPath(path);
+      empty_map["swift-dependencies"] = new_path;
+      incremental_outputs[path] = new_path;
+      new_output_file_map[""] = empty_map;
+      continue;
+    }
+
+    nlohmann::json src_map;
+
+    // Process the outputs for the current source file.
+    for (auto &output : outputs.items()) {
+      auto kind = output.key();
+      auto path = output.value().get<std::string>();
+
+      if (kind == "object") {
+        // If the file kind is "object", we want to update the path to point to
+        // the incremental storage area and then add a "swift-dependencies"
+        // in the same location.
+        auto new_path = MakeIncrementalOutputPath(path);
+        src_map[kind] = new_path;
+        incremental_outputs[path] = new_path;
+
+        auto swiftdeps_path = ReplaceExtension(new_path, ".swiftdeps");
+        src_map["swift-dependencies"] = swiftdeps_path;
+      } else if (kind == "swiftdoc" || kind == "swiftinterface" ||
+                 kind == "swiftmodule") {
+        // Module/interface outputs should be moved to the incremental storage
+        // area without additional processing.
+        auto new_path = MakeIncrementalOutputPath(path);
+        src_map[kind] = new_path;
+        incremental_outputs[path] = new_path;
+      } else if (kind == "swift-dependencies") {
+        // If there was already a "swift-dependencies" entry present, ignore it.
+        // (This shouldn't happen because the build rules won't do this, but
+        // check just in case.)
+        std::cerr << "There was a 'swift-dependencies' entry for " << src
+                  << ", but the build rules should not have done this; "
+                  << "ignoring it.\n";
+      } else {
+        // Otherwise, just copy the mapping over verbatim.
+        src_map[kind] = path;
+      }
+    }
+
+    new_output_file_map[src] = src_map;
+  }
+
+  json_ = new_output_file_map;
+  incremental_outputs_ = incremental_outputs;
+}

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -1,0 +1,59 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_OUTPUT_FILE_MAP_H
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_OUTPUT_FILE_MAP_H
+
+#include <map>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+// Supports loading and rewriting a `swiftc` output file map to support
+// incremental compilation.
+//
+// See
+// https://github.com/apple/swift/blob/master/docs/Driver.md#output-file-maps
+// for more information on how the Swift driver uses this file.
+class OutputFileMap {
+ public:
+  explicit OutputFileMap() {}
+
+  // The in-memory JSON-based representation of the output file map.
+  const nlohmann::json &json() const { return json_; }
+
+  // A map containing expected output files that will be generated in the
+  // incremental storage area. The key is the original object path; the
+  // corresponding value is its location in the incremental storage area.
+  const std::map<std::string, std::string> incremental_outputs() const {
+    return incremental_outputs_;
+  }
+
+  // Reads the output file map from the JSON file at the given path, and updates
+  // it to support incremental builds.
+  void ReadFromPath(const std::string &path);
+
+  // Writes the output file map as JSON to the file at the given path.
+  void WriteToPath(const std::string &path);
+
+ private:
+  // Modifies the output file map's JSON structure in-place to replace file
+  // paths with equivalents in the incremental storage area.
+  void UpdateForIncremental();
+
+  nlohmann::json json_;
+  std::map<std::string, std::string> incremental_outputs_;
+};
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_OUTPUT_FILE_MAP_H_

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -1,0 +1,173 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/worker/work_processor.h"
+
+#include <sys/stat.h>
+
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+#include <google/protobuf/text_format.h>
+#include "tools/common/file_system.h"
+#include "tools/common/path_utils.h"
+#include "tools/common/process.h"
+#include "tools/common/string_utils.h"
+#include "tools/common/temp_file.h"
+#include "tools/worker/output_file_map.h"
+#include <nlohmann/json.hpp>
+
+namespace {
+
+// Returns the requested environment variable in the current process's
+// environment. Aborts if this variable is unset.
+std::string GetMandatoryEnvVar(const std::string &var_name) {
+  char *env_value = getenv(var_name.c_str());
+  if (env_value == nullptr) {
+    std::cerr << "Error: " << var_name << " not set.\n";
+    abort();
+  }
+  return env_value;
+}
+
+// Returns true if the given command line argument enables whole-module
+// optimization in the compiler.
+static bool ArgumentEnablesWMO(const std::string &arg) {
+  return arg == "-wmo" || arg == "-whole-module-optimization" ||
+         arg == "-force-single-frontend-invocation";
+}
+
+};  // end namespace
+
+WorkProcessor::WorkProcessor(int argc, char **argv) {
+#if __APPLE__
+  // On Apple platforms, replace the magic Bazel placeholders with the path
+  // in the corresponding environment variable.
+  std::string developer_dir = GetMandatoryEnvVar("DEVELOPER_DIR");
+  std::string sdk_root = GetMandatoryEnvVar("SDKROOT");
+
+  bazel_placeholders_ = {
+      {"__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir},
+      {"__BAZEL_XCODE_SDKROOT__", sdk_root},
+  };
+
+  for (int i = 1; i < argc; i++) {
+    std::string arg(argv[i]);
+    MakeSubstitutions(&arg, bazel_placeholders_);
+    universal_args_.push_back(arg);
+  }
+#else
+  // On non-Apple platforms, we don't need to make any substitutions.
+  universal_args_.insert(universal_args_.end(), argv + 1, argv + argc);
+#endif
+}
+
+void WorkProcessor::ProcessWorkRequest(
+    const blaze::worker::WorkRequest &request,
+    blaze::worker::WorkResponse *response) {
+  std::vector<std::string> processed_args(universal_args_);
+
+  // Write the processed arguments out to a params file.
+  auto params_file = TempFile::Create("swiftc_args.XXXXXXXXXX");
+  std::ofstream params_file_stream(params_file->GetPath());
+
+  OutputFileMap output_file_map;
+  std::string output_file_map_path;
+  bool is_wmo = false;
+
+  std::string prev_arg;
+  for (auto arg : request.arguments()) {
+    auto original_arg = arg;
+    MakeSubstitutions(&arg, bazel_placeholders_);
+
+    // Peel off the `-output-file-map` argument, so we can rewrite it if
+    // necessary later.
+    if (arg == "-output-file-map") {
+      arg.clear();
+    } else if (prev_arg == "-output-file-map") {
+      output_file_map_path = arg;
+      output_file_map.ReadFromPath(output_file_map_path);
+      arg.clear();
+    } else if (ArgumentEnablesWMO(arg)) {
+      is_wmo = true;
+    }
+
+    if (!arg.empty()) {
+      params_file_stream << arg << '\n';
+    }
+
+    prev_arg = original_arg;
+  }
+
+  if (!output_file_map_path.empty()) {
+    if (!is_wmo) {
+      // Rewrite the output file map to use the incremental storage area and
+      // pass the compiler the path to the rewritten file.
+      auto new_path =
+          ReplaceExtension(output_file_map_path, ".incremental.json");
+      output_file_map.WriteToPath(new_path);
+
+      params_file_stream << "-output-file-map\n";
+      params_file_stream << new_path << '\n';
+
+      // Pass the incremental flags only if WMO is disabled. WMO would overrule
+      // incremental mode anyway, but since we control the passing of this flag,
+      // there's no reason to pass it when it's a no-op.
+      params_file_stream << "-incremental\n";
+    } else {
+      // If WMO is forcing us out of incremental mode, just put the original
+      // output file map back so the outputs end up where they should.
+      params_file_stream << "-output-file-map\n";
+      params_file_stream << output_file_map_path << '\n';
+    }
+  }
+
+  processed_args.push_back("@" + params_file->GetPath());
+  params_file_stream.close();
+
+  if (!is_wmo) {
+    for (auto expected_object_pair : output_file_map.incremental_outputs()) {
+      // Bazel creates the intermediate directories for the files declared at
+      // analysis time, but we need to manually create the ones for the
+      // incremental storage area.
+      auto dir_path = Dirname(expected_object_pair.second);
+      if (!MakeDirs(dir_path, S_IRWXU)) {
+        std::cerr << "Could not create directory " << dir_path << " (errno "
+                  << errno << ")\n";
+      }
+    }
+  }
+
+  std::ostringstream stderr_stream;
+  int exit_code = RunSubProcess(processed_args, &stderr_stream,
+                                /*stdout_to_stderr=*/true);
+
+  if (!is_wmo) {
+    // Copy the output files from the incremental storage area back to the
+    // locations where Bazel declared the files.
+    // TODO(allevato): Investigate copy-on-write on macOS, or hard-linking in
+    // general, as a possible optimization.
+    for (auto expected_object_pair : output_file_map.incremental_outputs()) {
+      if (!CopyFile(expected_object_pair.second, expected_object_pair.first)) {
+        std::cerr << "Could not copy " << expected_object_pair.second << " to "
+                  << expected_object_pair.first << " (errno " << errno << ")\n";
+      }
+    }
+  }
+
+  response->set_exit_code(exit_code);
+  response->set_output(stderr_stream.str());
+}

--- a/tools/worker/work_processor.h
+++ b/tools/worker/work_processor.h
@@ -1,0 +1,41 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORK_PROCESSOR_H
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORK_PROCESSOR_H
+
+#include <map>
+#include <string>
+
+#include "third_party/bazel_protos/worker_protocol.pb.h"
+
+// Manages persistent global state for the Swift worker and processes individual
+// work requests.
+class WorkProcessor {
+ public:
+  // Initializes a new work processor with the given universal arguments from
+  // the job invocation.
+  WorkProcessor(int argc, char **argv);
+
+  // Processes the given work request and writes its exit code and stderr output
+  // (if any) into the given response.
+  void ProcessWorkRequest(const blaze::worker::WorkRequest &request,
+                          blaze::worker::WorkResponse *response);
+
+ private:
+  std::vector<std::string> universal_args_;
+  std::map<std::string, std::string> bazel_placeholders_;
+};
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORK_PROCESSOR_H


### PR DESCRIPTION
Add a persistent worker to support `swiftc` incremental compilation.

To perform incremental builds, pass the `--strategy=SwiftCompile=worker` flag to Bazel (or add it to your .bazelrc file).

Fixes #48.