### PR TITLE
Create a "dummy worker" for upstream integration tests.

### DIFF
--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -1,5 +1,20 @@
 licenses(["notice"])
 
+# Workaround for the rules_apple integration tests to completely remove the
+# persistent worker from the toolchain, because some of its dependencies are
+# too complex to properly mock out in the test workspace.
+#
+# Note that the dummy worker does not actually *do* anything (it's a no-op
+# executable), so using this flag is incompatible with the "worker" strategy
+# for SwiftCompile actions. It's merely used to provide a dependency-free
+# executable that can be easily built.
+config_setting(
+    name = "use_dummy",
+    define_values = {
+        "RULES_SWIFT_BUILD_DUMMY_WORKER": "1",
+    },
+)
+
 cc_library(
     name = "work_processor",
     srcs = [
@@ -20,15 +35,23 @@ cc_library(
     ],
 )
 
+WORKER_DEPS = [
+    ":work_processor",
+    "//third_party/bazel_protos:worker_protocol_cc_proto",
+    "@com_google_protobuf//:protobuf",
+]
+
 cc_binary(
     name = "worker",
-    srcs = ["main.cc"],
+    srcs = select({
+        ":use_dummy": ["dummy_main.cc"],
+        "//conditions:default": ["main.cc"],
+    }),
     visibility = ["//visibility:public"],
-    deps = [
-        ":work_processor",
-        "//third_party/bazel_protos:worker_protocol_cc_proto",
-        "@com_google_protobuf//:protobuf",
-    ],
+    deps = select({
+        ":use_dummy": [],
+        "//conditions:default": WORKER_DEPS,
+    }),
 )
 
 # Consumed by Bazel integration tests.

--- a/tools/worker/dummy_main.cc
+++ b/tools/worker/dummy_main.cc
@@ -1,0 +1,21 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+int main(int argc, char *argv[]) {
+  // This executable intentionally does nothing; integration tests that define
+  // the Bazel flag `--define=RULES_SWIFT_BUILD_DUMMY_WORKER=1` should also
+  // ensure that they do not pass `--strategy=SwiftCompile=worker` at the same
+  // time.
+  return 254;
+}


### PR DESCRIPTION
Create a "dummy worker" for upstream integration tests.

The external dependencies used by the persistent worker are fairly heavyweight, and upstream integration tests (like those in rules_apple) should not be forced to mock them all out in their test workspace (which they would have to, because the worker is an implicit dependency of all toolchains). This change provides a flag that they can pass to Bazel to build a dummy executable that is dependency-free instead.