### PR TITLE
Fix unused function warning on Linux

### DIFF
--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -32,6 +32,7 @@
 
 namespace {
 
+#if __APPLE__
 // Returns the requested environment variable in the current process's
 // environment. Aborts if this variable is unset.
 std::string GetMandatoryEnvVar(const std::string &var_name) {
@@ -42,6 +43,7 @@ std::string GetMandatoryEnvVar(const std::string &var_name) {
   }
   return env_value;
 }
+#endif
 
 // Returns true if the given command line argument enables whole-module
 // optimization in the compiler.


### PR DESCRIPTION
This function is only used on macOS so it produced this warning on Linux:

```
external/build_bazel_rules_swift/tools/worker/work_processor.cc:37:13: error: unused function 'GetMandatoryEnvVar' [-Werror,-Wunused-function]
std::string GetMandatoryEnvVar(const std::string &var_name) {
            ^
1 error generated.
```