### PR TITLE
Use `to_list()` for depset iteration.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -354,7 +354,7 @@ def objc_compile_requirements(args, deps):
             inputs.append(objc.static_framework_file)
             inputs.append(objc.dynamic_framework_file)
             static_framework_names.append(depset(
-                [objc_provider_framework_name(fdir) for fdir in objc.framework_dir],
+                [objc_provider_framework_name(fdir) for fdir in objc.framework_dir.to_list()],
             ))
             all_frameworks.append(objc.framework_dir)
             all_frameworks.append(objc.dynamic_framework_dir)


### PR DESCRIPTION
Use `to_list()` for depset iteration.

Found via --incompatible_depset_is_not_iterable looking at the logs
linked off of https://github.com/bazelbuild/rules_swift/issues/181