### PR TITLE
Make the Swift module cache path explicitly different from Clang's.

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -103,6 +103,7 @@ def _swift_linking_rule_impl(
         compile_results = swift_common.compile_as_objects(
             actions = ctx.actions,
             arguments = [],
+            bin_dir = ctx.bin_dir,
             copts = copts,
             defines = ctx.attr.defines,
             feature_configuration = feature_configuration,


### PR DESCRIPTION
Make the Swift module cache path explicitly different from Clang's.

The cached modules aren't actually shared anyway—the Clang invocation used to generate them from Objective-C differs from the Clang invocation used by Swift's ClangImporter, so they hash to different paths (this is not just a Bazel characteristic, it happens with Xcode as well). At best, this makes sharing the location worthless; at worst, it opens the possibility for corruption or collision.