### PR TITLE
Show the build status only for the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Swift Rules for [Bazel](https://bazel.build)
 
-[![Build status](https://badge.buildkite.com/d562b11425e192a8f6ba9c43715bc8364985bccf54e4b9194a.svg)](https://buildkite.com/bazel/rules-swift-swift)
+[![Build status](https://badge.buildkite.com/d562b11425e192a8f6ba9c43715bc8364985bccf54e4b9194a.svg?branch=master)](https://buildkite.com/bazel/rules-swift-swift)
 
 This repository contains rules for [Bazel](https://bazel.build) that can be
 used to build Swift libraries, tests, and executables for macOS and Linux.


### PR DESCRIPTION
Show the build status only for the master branch.

Otherwise a test_* branch that doesn't currently pass turns the badge red
because it was the "most recent" build on buildkite.