### PR TITLE
Fix CgRPC linker warnings

### DIFF
--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -46,6 +46,7 @@ cc_library(
         "Sources/CgRPC/third_party/nanopb/**/*.h",
     ]) + ["Sources/CgRPC/shim/internal.h"],
     hdrs = ["Sources/CgRPC/shim/cgrpc.h"],
+    copts = ["-DPB_NO_PACKED_STRUCTS=1"],
     includes = ["Sources/CgRPC/include"],
     tags = ["swift_module=CgRPC"],
     deps = [


### PR DESCRIPTION
Without this these warnings are produced at link time:

```
ld: warning: pointer not aligned at address 0x1004354AA (_grpc_lb_v1_ClientStats_fields + 106 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x10043544B (_grpc_lb_v1_ClientStats_fields + 11 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x1004354EE (_grpc_lb_v1_LoadBalanceRequest_fields + 30 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x1004354DB (_grpc_lb_v1_LoadBalanceRequest_fields + 11 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x10043552E (_grpc_lb_v1_InitialLoadBalanceResponse_fields + 30 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x10043555B (_grpc_lb_v1_ServerList_fields + 11 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x10043559E (_grpc_lb_v1_LoadBalanceResponse_fields + 30 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
ld: warning: pointer not aligned at address 0x10043558B (_grpc_lb_v1_LoadBalanceResponse_fields + 11 from bazel-out/ios_x86_64-fastbuild/bin/external/com_github_grpc_grpc_swift/libCgRPC.a(load_balancer.pb.o))
```