### PR TITLE
Use cpp command-line linkopts during final link

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -87,6 +87,7 @@ def _swift_linking_rule_impl(
 
     copts = expand_locations(ctx, ctx.attr.copts, ctx.attr.swiftc_inputs)
     linkopts = list(linkopts) + expand_locations(ctx, ctx.attr.linkopts, ctx.attr.swiftc_inputs)
+    linkopts += ctx.fragments.cpp.linkopts
 
     additional_inputs = ctx.files.swiftc_inputs
     srcs = ctx.files.srcs


### PR DESCRIPTION
Currently, if you have some `--linkopt=...` options specified on the Bazel command line, `swift_binary`/swift_test targets will NOT get these in their final link. This means that you cannot reliably use e.g. `-fsanitize=address` with your cpp transitive dependencies, because the final link might not pass that option to clang and it won't include the library support necessary to define some of the symbols that were inserted earlier in the compile by ASan. This PR attempts to fix this by adding `ctx.fragments.cpp.linkopts` to the list of linker options in these targets, so that the requested linkopts are respected in the final link. First time contributor, so let me know if this is the right way to do this, or if there's a better way.