### PR TITLE
Use the C++ toolchain to register static archive actions.

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -800,12 +800,15 @@ def _compile_as_library(
 
     register_static_archive_action(
         actions = actions,
-        ar_executable = ar_executable,
+        cc_feature_configuration = _cc_feature_configuration(
+            feature_configuration = feature_configuration,
+        ),
+        cc_toolchain = toolchain.cc_toolchain_info,
+        cc_toolchain_files = toolchain.cc_toolchain_files,
         mnemonic = "SwiftArchive",
         objects = compile_results.output_objects,
         output = out_archive,
         progress_message = "Linking {}".format(out_archive.short_path),
-        toolchain = toolchain,
     )
 
     # TODO(b/130741225): Move this logic out of the API and have the rules themselves manipulate

--- a/swift/internal/archiving.bzl
+++ b/swift/internal/archiving.bzl
@@ -14,134 +14,65 @@
 
 """Implementation of static library archiving logic for Swift."""
 
-load(":actions.bzl", "run_toolchain_action")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "CPP_LINK_STATIC_LIBRARY_ACTION_NAME")
 
 def register_static_archive_action(
         actions,
-        ar_executable,
+        cc_feature_configuration,
+        cc_toolchain,
+        cc_toolchain_files,
         output,
-        toolchain,
         mnemonic = "Archive",
         objects = [],
         progress_message = None):
-    """Registers actions that create a static archive.
+    """Registers an action that creates a static archive.
 
     Args:
-      actions: The object used to register actions.
-      ar_executable: The path to the `ar` executable to use when creating the
-          archive, if it should be used.
-      output: A `File` to which the output archive will be written.
-      toolchain: The `SwiftToolchainInfo` provider of the toolchain.
-      mnemonic: The mnemonic to display when the action is executed.
-      objects: A list of `File`s denoting object (.o) files that will be merged
-          into the archive.
-      progress_message: The progress message to display when the action is
-          executed.
+        actions: The object used to register actions.
+        cc_feature_configuration: The C++ feature configuration to use when constructing the
+            action.
+        cc_toolchain: The C++ toolchain provider to use when constructing the action.
+        cc_toolchain_files: A `depset` containing the files from the C++ toolchain, which are
+            required to ensure that the tools are available in the action inputs.
+        output: A `File` to which the output archive will be written.
+        mnemonic: The mnemonic to display when the action is executed.
+        objects: A list of `File`s denoting object (.o) files that will be merged into the archive.
+        progress_message: The progress message to display when the action is executed.
     """
-    if ar_executable:
-        _register_ar_action(
-            actions = actions,
-            ar_executable = ar_executable,
-            mnemonic = mnemonic,
-            objects = objects,
-            output = output,
-            progress_message = progress_message,
-            toolchain = toolchain,
-        )
-    else:
-        _register_libtool_action(
-            actions = actions,
-            mnemonic = mnemonic,
-            objects = objects,
-            output = output,
-            progress_message = progress_message,
-            toolchain = toolchain,
-        )
-
-def _register_ar_action(
-        actions,
-        ar_executable,
-        mnemonic,
-        objects,
-        output,
-        progress_message,
-        toolchain):
-    """Registers an action that creates a static archive using `ar`.
-
-    This function is used to create static archives when the Swift toolchain
-    depends on a Linux toolchain.
-
-    Args:
-      actions: The object used to register actions.
-      ar_executable: The path to the `ar` executable to use when creating the
-          archive, if it should be used.
-      mnemonic: The mnemonic to display when the action is executed.
-      objects: A list of `File`s denoting object (.o) files that will be merged
-          into the archive.
-      output: A `File` to which the output archive will be written.
-      progress_message: The progress message to display when the action is
-          executed.
-      toolchain: The `SwiftToolchainInfo` provider of the toolchain.
-    """
-
-    args = actions.args()
-    args.add("cr")
-    args.add(output)
-    args.add_all(objects)
-
-    run_toolchain_action(
-        actions = actions,
-        arguments = [args],
-        executable = ar_executable,
-        inputs = objects,
-        mnemonic = mnemonic,
-        outputs = [output],
-        progress_message = progress_message,
-        toolchain = toolchain,
+    archiver_path = cc_common.get_tool_for_action(
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+        feature_configuration = cc_feature_configuration,
+    )
+    archiver_variables = cc_common.create_link_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = cc_feature_configuration,
+        is_using_linker = False,
+        output_file = output.path,
     )
 
-def _register_libtool_action(
-        actions,
-        mnemonic,
-        objects,
-        output,
-        progress_message,
-        toolchain):
-    """Registers an action that creates a static archive using `libtool`.
-
-    This function is used to create static archives when the Swift toolchain
-    depends on an Xcode toolchain.
-
-    Args:
-      actions: The object used to register actions.
-      mnemonic: The mnemonic to display when the action is executed.
-      objects: A list of `File`s denoting object (.o) files that will be merged
-          into the archive.
-      output: A `File` to which the output archive will be written.
-      progress_message: The progress message to display when the action is
-          executed.
-      toolchain: The `SwiftToolchainInfo` provider of the toolchain.
-    """
+    command_line = cc_common.get_memory_inefficient_command_line(
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+        feature_configuration = cc_feature_configuration,
+        variables = archiver_variables,
+    )
     args = actions.args()
-    args.add("-static")
-    args.add("-o", output)
+    args.add_all(command_line)
+    args.add_all(objects)
 
-    # This must be the last argument in this set, because the filelist args object
-    # immediately follows it in the invocation below.
-    args.add("-filelist")
+    env = cc_common.get_environment_variables(
+        action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
+        feature_configuration = cc_feature_configuration,
+        variables = archiver_variables,
+    )
 
-    filelist = actions.args()
-    filelist.set_param_file_format("multiline")
-    filelist.use_param_file("%s", use_always = True)
-    filelist.add_all(objects)
-
-    run_toolchain_action(
-        actions = actions,
-        arguments = [args, filelist],
-        executable = "/usr/bin/libtool",
-        inputs = objects,
-        mnemonic = mnemonic,
+    actions.run(
+        executable = archiver_path,
+        arguments = [args],
+        env = env,
+        inputs = depset(
+            direct = objects,
+            # TODO(bazelbuild/bazel#7427): Use `CcToolchainInfo` getters when they are available.
+            transitive = [cc_toolchain_files],
+        ),
         outputs = [output],
-        progress_message = progress_message,
-        toolchain = toolchain,
     )

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -157,6 +157,12 @@ code.
 `run_shell`, which registers an action using `actions.run_shell`. These partials allow the toolchain
 to set the environment and execution requirements, as well as use a wrapper script if necessary.
 """,
+        "cc_toolchain_files": """
+A `depset` of the `File`s in the C++ toolchain.
+
+This field is temporary until `cc_common.CcToolchainInfo` provides getters to access these files
+(https://github.com/bazelbuild/bazel/issues/7427).
+""",
         "cc_toolchain_info": """
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this Swift toolchain
 depends on.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -176,6 +176,7 @@ def _run_swift_action(toolchain_tools, swift_wrapper, actions, **kwargs):
 def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain_files = ctx.attr._cc_toolchain.files
 
     linker_opts_producer = partial.make(
         _default_linker_opts,
@@ -205,6 +206,7 @@ def _swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = {},
             action_registrars = action_registrars,
+            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = ctx.attr.clang_executable,
             command_line_copts = ctx.fragments.swift.copts(),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -484,6 +484,7 @@ def _xcode_swift_toolchain_impl(ctx):
     )
 
     cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain_files = ctx.attr._cc_toolchain.files
 
     # Compute the default requested features and conditional ones based on Xcode version.
     requested_features = features_for_build_modes(ctx, objc_fragment = ctx.fragments.objc)
@@ -503,6 +504,7 @@ def _xcode_swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = env,
             action_registrars = action_registrars,
+            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = None,
             command_line_copts = command_line_copts,


### PR DESCRIPTION
Use the C++ toolchain to register static archive actions.

This lets us leverage any platform-specific flags and wrappers that might be present in CROSSTOOL, instead of replicating that functionality here.