### PR TITLE
Rollback of commit 522cd9d4e8f88fb5caac2945b3f6d38bd0cddba3

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -800,15 +800,12 @@ def _compile_as_library(
 
     register_static_archive_action(
         actions = actions,
-        cc_feature_configuration = _cc_feature_configuration(
-            feature_configuration = feature_configuration,
-        ),
-        cc_toolchain = toolchain.cc_toolchain_info,
-        cc_toolchain_files = toolchain.cc_toolchain_files,
+        ar_executable = ar_executable,
         mnemonic = "SwiftArchive",
         objects = compile_results.output_objects,
         output = out_archive,
         progress_message = "Linking {}".format(out_archive.short_path),
+        toolchain = toolchain,
     )
 
     # TODO(b/130741225): Move this logic out of the API and have the rules themselves manipulate

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -157,12 +157,6 @@ code.
 `run_shell`, which registers an action using `actions.run_shell`. These partials allow the toolchain
 to set the environment and execution requirements, as well as use a wrapper script if necessary.
 """,
-        "cc_toolchain_files": """
-A `depset` of the `File`s in the C++ toolchain.
-
-This field is temporary until `cc_common.CcToolchainInfo` provides getters to access these files
-(https://github.com/bazelbuild/bazel/issues/7427).
-""",
         "cc_toolchain_info": """
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this Swift toolchain
 depends on.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -176,7 +176,6 @@ def _run_swift_action(toolchain_tools, swift_wrapper, actions, **kwargs):
 def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
-    cc_toolchain_files = ctx.attr._cc_toolchain.files
 
     linker_opts_producer = partial.make(
         _default_linker_opts,
@@ -206,7 +205,6 @@ def _swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = {},
             action_registrars = action_registrars,
-            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = ctx.attr.clang_executable,
             command_line_copts = ctx.fragments.swift.copts(),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -484,7 +484,6 @@ def _xcode_swift_toolchain_impl(ctx):
     )
 
     cc_toolchain = find_cpp_toolchain(ctx)
-    cc_toolchain_files = ctx.attr._cc_toolchain.files
 
     # Compute the default requested features and conditional ones based on Xcode version.
     requested_features = features_for_build_modes(ctx, objc_fragment = ctx.fragments.objc)
@@ -504,7 +503,6 @@ def _xcode_swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = env,
             action_registrars = action_registrars,
-            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = None,
             command_line_copts = command_line_copts,


### PR DESCRIPTION
Rollback of commit 522cd9d4e8f88fb5caac2945b3f6d38bd0cddba3


*** Reason for rollback ***

Broke some internal targets.

*** Original change description ***

Use the C++ toolchain to register static archive actions.

This lets us leverage any platform-specific flags and wrappers that might be present in CROSSTOOL, instead of replicating that functionality here.