### PR TITLE
Support -debug-prefix-map for Xcode 10.2 (Swift 5.0) and higher.

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -55,6 +55,7 @@ load(
     "SWIFT_FEATURE_AUTOLINK_EXTRACT",
     "SWIFT_FEATURE_COVERAGE",
     "SWIFT_FEATURE_DBG",
+    "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_FASTBUILD",
@@ -519,6 +520,12 @@ def _compile_as_objects(
             wrapper_args.add("-module-cache-path", _global_module_cache_path(bin_dir))
     else:
         wrapper_args.add("-Xwrapped-swift=-ephemeral-module-cache")
+
+    if swift_common.is_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_DEBUG_PREFIX_MAP,
+    ):
+        wrapper_args.add("-Xwrapped-swift=-debug-prefix-pwd-is-dot")
 
     compile_args = actions.args()
     if swift_common.is_enabled(

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -28,6 +28,7 @@ load(
     ":features.bzl",
     "SWIFT_FEATURE_AUTOLINK_EXTRACT",
     "SWIFT_FEATURE_BUNDLED_XCTESTS",
+    "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
@@ -496,7 +497,9 @@ def _xcode_swift_toolchain_impl(ctx):
         requested_features.append(SWIFT_FEATURE_ENABLE_BATCH_MODE)
         requested_features.append(SWIFT_FEATURE_USE_RESPONSE_FILES)
 
-    # TODO(#35): Add SWIFT_FEATURE_DEBUG_PREFIX_MAP based on Xcode version.
+    # Xcode 10.2 implies Swift 5.0.
+    if _is_xcode_at_least_version(xcode_config, "10.2"):
+        requested_features.append(SWIFT_FEATURE_DEBUG_PREFIX_MAP)
 
     command_line_copts = _command_line_objc_copts(ctx.fragments.objc) + ctx.fragments.swift.copts()
 

--- a/tools/wrappers/swift_wrapper.sh
+++ b/tools/wrappers/swift_wrapper.sh
@@ -70,6 +70,9 @@ for ARG in "$@" ; do
   --persistent_worker)
     USE_WORKER=1
     ;;
+  -Xwrapped-swift=-debug-prefix-pwd-is-dot)
+    ARGS+=(-debug-prefix-map "$PWD=.")
+    ;;
   -Xwrapped-swift=-ephemeral-module-cache)
     MODULE_CACHE_DIR="$(mktemp -d "${TMPDIR%/}/wrapped_swift_module_cache.XXXXXXXXXX")"
     ARGS+=(-module-cache-path "$MODULE_CACHE_DIR")


### PR DESCRIPTION
Support -debug-prefix-map for Xcode 10.2 (Swift 5.0) and higher.