### PR TITLE
Disable -Wunused-function for BoringSSL

### DIFF
--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -31,6 +31,7 @@ cc_library(
         "Sources/BoringSSL/third_party/**/*.h",
     ]),
     hdrs = glob(["Sources/BoringSSL/include/**/*.h"]),
+    copts = ["-Wno-unused-function"],
     includes = ["Sources/BoringSSL/include"],
 )
 


### PR DESCRIPTION
This is the only warning produced by this library. It seems like
upstream they have this off, or they compile things that we're not that
use these other functions.