### PR TITLE
Add custom macOS Swift toolchain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ environment variable `CC=clang` when invoking Bazel.
 This step is not necessary for macOS users because the Xcode toolchain always
 uses `clang`.
 
+## Building with Custom Toolchains
+
+**macOS hosts:** You can build with a custom toolchain installed in
+`/Library/Developer/Toolchains` instead of Xcode's default. To do so, pass the
+following flag to Bazel:
+
+```
+--define=SWIFT_CUSTOM_TOOLCHAIN=toolchain.id
+```
+
+where `toolchain.id` is the value of the `CFBundleIdentifier` key in the
+toolchain's Info.plist file.
+
+**Linux hosts:** At this time, Bazel uses whichever `swift` executable is
+encountered first on your `PATH`.
+
 ## Future Work
 
 * Support for building and linking to shared libraries (`.dylib`/`.so`) written

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -481,6 +481,10 @@ def _xcode_swift_toolchain_impl(ctx):
 
     # Configure the action registrars that automatically prepend xcrunwrapper to registered actions.
     env = _xcode_env(xcode_config, platform)
+    custom_toolchain = ctx.var.get("SWIFT_CUSTOM_TOOLCHAIN")
+    if custom_toolchain:
+        env["TOOLCHAINS"] = custom_toolchain
+
     execution_requirements = {"requires-darwin": ""}
     bazel_xcode_wrapper = ctx.executable._bazel_xcode_wrapper
     action_registrars = struct(


### PR DESCRIPTION
This allows you to pass `--define=SWIFT_CUSTOM_TOOLCHAIN=toolchain.id`
to specify a custom swift toolchain like the ones downloaded from
https://swift.org/download/#snapshots to use.