### PR TITLE
Add CLI for dumping Swift toolchain bundle ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ following flag to Bazel:
 where `toolchain.id` is the value of the `CFBundleIdentifier` key in the
 toolchain's Info.plist file.
 
+To list the available toolchains and their bundle identifiers, you can run:
+
+```
+bazel run @build_bazel_rules_swift//tools/dump_toolchains
+```
+
 **Linux hosts:** At this time, Bazel uses whichever `swift` executable is
 encountered first on your `PATH`.
 

--- a/tools/dump_toolchains/BUILD
+++ b/tools/dump_toolchains/BUILD
@@ -1,0 +1,7 @@
+licenses(["notice"])
+
+sh_binary(
+    name = "dump_toolchains",
+    srcs = ["dump_toolchains.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/dump_toolchains/dump_toolchains.sh
+++ b/tools/dump_toolchains/dump_toolchains.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+if [[ "$(uname)" != Darwin ]]; then
+  echo "error: dumping toolchains is only supported on macOS"
+  exit 1
+fi
+
+toolchain_directory=/Library/Developer/Toolchains
+if [[ ! -d "$toolchain_directory" ]]; then
+  echo "error: '$toolchain_directory' doesn't exist"
+  exit 1
+fi
+
+for toolchain in "$toolchain_directory"/*.xctoolchain
+do
+  plist_path="$toolchain/Info.plist"
+
+  if [[ ! -f "$plist_path" ]]; then
+    echo "error: '$toolchain' is missing Info.plist"
+    exit 1
+  fi
+
+  bundle_id=$(/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" "$plist_path")
+  toolchain_name=$(basename "$toolchain")
+  echo "$toolchain_name -> $bundle_id"
+done


### PR DESCRIPTION
This is useful in combination with https://github.com/bazelbuild/rules_swift/pull/214