### PR TITLE
Fix custom Swift toolchain when linking

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -481,9 +481,10 @@ def _xcode_swift_toolchain_impl(ctx):
 
     # Configure the action registrars that automatically prepend xcrunwrapper to registered actions.
     env = _xcode_env(xcode_config, platform)
+    swift_toolchain_env = {}
     custom_toolchain = ctx.var.get("SWIFT_CUSTOM_TOOLCHAIN")
     if custom_toolchain:
-        env["TOOLCHAINS"] = custom_toolchain
+        swift_toolchain_env["TOOLCHAINS"] = custom_toolchain
 
     execution_requirements = {"requires-darwin": ""}
     bazel_xcode_wrapper = ctx.executable._bazel_xcode_wrapper
@@ -497,7 +498,7 @@ def _xcode_swift_toolchain_impl(ctx):
         ),
         run_swift = partial.make(
             _run_swift_action,
-            env,
+            dicts.add(env, swift_toolchain_env),
             execution_requirements,
             bazel_xcode_wrapper,
             ctx.executable._swift_wrapper,


### PR DESCRIPTION
When using ld through clang on macOS with TOOLCHAINS set, since bazel
restricts the PATH, ld cannot be found since it's not part of the Swift
toolchain, and you get this error:

```
clang-7: error: unable to execute command: Executable "ld" doesn't exist!
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

This now only adds this environment variable to Swift invocations.