### PR TITLE
Enable exclusivity enforcement for dbg builds

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -273,6 +273,9 @@ def _compilation_mode_copts(feature_configuration):
         # import search paths to find definitions during debugging.
         flags.extend(["-Onone", "-DDEBUG", "-Xfrontend", "-serialize-debugging-options"])
 
+    if is_dbg:
+        flags.append("-enforce-exclusivity=checked")
+
     if _is_enabled(
         feature_configuration = feature_configuration,
         feature_name = SWIFT_FEATURE_ENABLE_TESTING,


### PR DESCRIPTION
Add `-enforce-exclusivity=checked` for `dbg` builds. This matches Xcode and without reasoning to the contrary, seems like a good default for rules_swift too.

Note that with Swift 5 this was also enabled for release builds too. https://swift.org/blog/swift-5-exclusivity/