### PR TITLE
Add option to disable proto module generation

### DIFF
--- a/swift/internal/proto_gen_utils.bzl
+++ b/swift/internal/proto_gen_utils.bzl
@@ -115,7 +115,7 @@ def _generated_file_path(name, extension_fragment, proto_file = None):
     )
     if proto_file:
         generated_file_path = paths.replace_extension(
-            workspace_relative_path(proto_file),
+            workspace_relative_path(proto_file).replace("/", "_"),
             ".{}.swift".format(extension_fragment),
         )
         return paths.join(dir_path, generated_file_path)

--- a/swift/internal/swift_proto_library.bzl
+++ b/swift/internal/swift_proto_library.bzl
@@ -59,6 +59,15 @@ def _swift_proto_library_impl(ctx):
 
 swift_proto_library = rule(
     attrs = {
+        "modules": attr.string(
+            default = "on",
+            values = ["on", "off"],
+            doc = """
+Controls wether generate individual modules per proto file. Either `on` (the
+current and default behaviour) or `off`. This is mostly useful when using the
+`pbswift_files` output group.
+            """,
+        ),
         "deps": attr.label_list(
             aspects = [swift_protoc_gen_aspect],
             doc = """

--- a/swift/internal/swift_proto_library.bzl
+++ b/swift/internal/swift_proto_library.bzl
@@ -42,8 +42,12 @@ def _swift_proto_library_impl(ctx):
         cc_info,
         swift_info,
         # Repropagate the `SwiftProtoInfo` provider so that downstream rules/aspects can access the
-        # sources if necessary. (This should typically only be used for IDE support.)
+        # sources if necessary. (This should typically only be used for IDE support.) Also, add an
+        # output group to for the generated files.
         swift_proto_info,
+        OutputGroupInfo(
+            pbswift_files = swift_proto_info.pbswift_files,
+        ),
     ]
 
     # Repropagate the apple_common.Objc provider if present so that apple_binary targets link

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -258,7 +258,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
     proto_deps = [dep for dep in aspect_ctx.rule.attr.deps if SwiftProtoInfo in dep]
 
     minimal_module_mappings = []
-    if direct_srcs:
+    if direct_srcs and aspect_ctx.attr.modules == "on":
         minimal_module_mappings.append(
             _build_module_mapping_from_srcs(target, direct_srcs),
         )
@@ -417,6 +417,9 @@ swift_protoc_gen_aspect = aspect(
     attrs = dicts.add(
         swift_common.toolchain_attrs(),
         {
+            "modules": attr.string(
+                values = ["on", "off"],
+            ),
             "_mkdir_and_run": attr.label(
                 cfg = "host",
                 default = Label(

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -129,7 +129,7 @@ def _register_pbswift_generate_action(
         format = "--plugin=protoc-gen-swift=%s",
     )
     protoc_args.add(generated_dir_path, format = "--swift_out=%s")
-    protoc_args.add("--swift_opt=FileNaming=FullPath")
+    protoc_args.add("--swift_opt=FileNaming=PathToUnderscores")
     protoc_args.add("--swift_opt=Visibility=Public")
     if module_mapping_file:
         protoc_args.add(


### PR DESCRIPTION
This PR does the following:
- change `FileNaming=FullPath` to `FileNaming=PathToUnderscores` so that file names don't collide
- add a `pbswift_files` output group to access the generated `.pbswift` files (from a macro, say)
- Allow to disable modules generation via a `modules` attribute

In our case, all the generated proto files are grouped inside the same module, which is embedded in a `.framework` file to be included in Xcode by our iOS team. So we can't use aliases unfortunately.

What we do is use the `pbswift_files` output group to grab all the generated `.pbswift` files and bundle them together in the same `swift_library` target:
```python
filegroup(
    name = "pbswift_files",
    srcs = [<swift_proto_library targets with modules="off">],
    output_group = "pbswift_files",
)

swift_library(
    name = "XXX",
    srcs = [
        ":pbswift_files",
    ],
    module_name = "MyModule",
    deps = ["@com_github_apple_swift_swift_protobuf//:SwiftProtobuf"],
)
```

While this introduces a new API in the form of the `modules` attribute, the default behaviour is kept.

In any case, I think the first two commits can be useful in their own rights, and we'd be fine keeping the last one as a rebased patch.