### PR TITLE
Add missing "cpp" fragment to `swift_module_alias`.

### DIFF
--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -178,5 +178,6 @@ to create "umbrella modules".
 > `deps` in the new module. You depend on undocumented features at your own
 > risk, as they may change in a future version of Swift.
 """,
+    fragments = ["cpp"],
     implementation = _swift_module_alias_impl,
 )


### PR DESCRIPTION
Add missing "cpp" fragment to `swift_module_alias`.