### PR TITLE
Add ctx argument to cc_common.configure_features

### DIFF
--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -32,6 +32,7 @@ def _swift_import_impl(ctx):
     # toolchains.
     cc_toolchain = ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
     cc_feature_configuration = cc_common.configure_features(
+        ctx = ctx,
         cc_toolchain = cc_toolchain,
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
@@ -126,5 +127,6 @@ The C++ toolchain from which linking flags and other tools needed by the Swift t
 Allows for the use of precompiled Swift modules as dependencies in other `swift_library` and
 `swift_binary` targets.
 """,
+    fragments = ["cpp"],
     implementation = _swift_import_impl,
 )


### PR DESCRIPTION
Add ctx argument to cc_common.configure_features

In order to migrate C++ rules to platforms, we need the access to the C++
configuration fragment in Starlark APIs. All existing APIs have already access
to it, but cc_common.configure_features doesn't. This change adds a
ctx argument to configure_features.

This is the migration needed for
https://github.com/bazelbuild/bazel/issues/7793, and is part of the effort for
https://github.com/bazelbuild/bazel/issues/6516.

If the rule doesn't depend on cpp fragment yet, you will have to add `fragments
=['cpp']` argument to the rule() call.

Note that this behavior is only available in Bazel 0.25 (to be released this month).