### PR TITLE
Request cloning using COPYFILE_CLONE

### DIFF
--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -33,7 +33,8 @@ bool CopyFile(const std::string &src, const std::string &dest) {
 #ifdef __APPLE__
   // The `copyfile` function with `COPYFILE_ALL` mode preserves permissions and
   // modification time.
-  return copyfile(src.c_str(), dest.c_str(), nullptr, COPYFILE_ALL) == 0;
+  return copyfile(src.c_str(), dest.c_str(), nullptr,
+                  COPYFILE_ALL | COPYFILE_CLONE) == 0;
 #elif __unix__
   // On Linux, we can use `sendfile` to copy it more easily than calling
   // `read`/`write` in a loop.

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -160,8 +160,6 @@ void WorkProcessor::ProcessWorkRequest(
   if (!is_wmo) {
     // Copy the output files from the incremental storage area back to the
     // locations where Bazel declared the files.
-    // TODO(allevato): Investigate copy-on-write on macOS, or hard-linking in
-    // general, as a possible optimization.
     for (auto expected_object_pair : output_file_map.incremental_outputs()) {
       if (!CopyFile(expected_object_pair.second, expected_object_pair.first)) {
         std::cerr << "Could not copy " << expected_object_pair.second << " to "


### PR DESCRIPTION
This should be a safe simple addition. From man `copyfile(3)`:

> Try to clone the file instead.  This is a best try flag i.e. if cloning fails, fallback to copying the file.