### PR TITLE
Set worker exit_code to failure if copying files fails

### DIFF
--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -164,6 +164,7 @@ void WorkProcessor::ProcessWorkRequest(
       if (!CopyFile(expected_object_pair.second, expected_object_pair.first)) {
         std::cerr << "Could not copy " << expected_object_pair.second << " to "
                   << expected_object_pair.first << " (errno " << errno << ")\n";
+        exit_code = EXIT_FAILURE;
       }
     }
   }


### PR DESCRIPTION
Follow up to #232. If copying output files fails, mark the worker response as having failed.