### PR TITLE
Fix copts and linkopts relying on input files

### DIFF
--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -52,8 +52,10 @@ def _maybe_parse_as_library_copts(srcs):
 
 def _swift_library_impl(ctx):
     additional_inputs = ctx.files.swiftc_inputs
-    copts = expand_locations(ctx, ctx.attr.copts, additional_inputs)
-    linkopts = expand_locations(ctx, ctx.attr.linkopts, additional_inputs)
+
+    # These can't use additional_inputs since expand_locations needs targets, not files.
+    copts = expand_locations(ctx, ctx.attr.copts, ctx.attr.swiftc_inputs)
+    linkopts = expand_locations(ctx, ctx.attr.linkopts, ctx.attr.swiftc_inputs)
     srcs = ctx.files.srcs
 
     module_name = ctx.attr.module_name


### PR DESCRIPTION
In https://github.com/bazelbuild/rules_swift/commit/32275ca0536eca5610a915f7b26cb841ca0031a3 when the additional_input local variable was introduced, this went from passing `ctx.attr.swiftc_inputs` to passing `ctx.files.swiftc_inputs` into `expand_locations`. This breaks, since the underlying `expand_location` only allows `Target` types, resulting in the following error when passing any file-like target to `swiftc_inputs`:

```
expected type 'Target' for 'targets' element but got type 'File' instead
```

This switches the two `expand_locations` calls back to using `ctx.attr.swiftc_inputs`.