### PR TITLE
Remove the SwiftToolchainInfo.cc_toolchain_files field.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -75,8 +75,7 @@ def _register_static_library_link_action(
         execution_requirements = swift_toolchain.execution_requirements,
         inputs = depset(
             direct = objects,
-            # TODO(bazelbuild/bazel#7427): Use `CcToolchainInfo` getters when they are available.
-            transitive = [swift_toolchain.cc_toolchain_files],
+            transitive = [swift_toolchain.cc_toolchain_info.all_files],
         ),
         mnemonic = "SwiftArchive",
         outputs = [output],

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -124,12 +124,6 @@ code.
 `run_shell`, which registers an action using `actions.run_shell`. These partials allow the toolchain
 to set the environment and execution requirements, as well as use a wrapper script if necessary.
 """,
-        "cc_toolchain_files": """
-A `depset` of the `File`s in the C++ toolchain.
-
-This field is temporary until `cc_common.CcToolchainInfo` provides getters to access these files
-(https://github.com/bazelbuild/bazel/issues/7427).
-""",
         "cc_toolchain_info": """
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this Swift toolchain
 depends on.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -176,7 +176,6 @@ def _run_swift_action(toolchain_tools, swift_wrapper, actions, **kwargs):
 def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
-    cc_toolchain_files = cc_toolchain.all_files
 
     linker_opts_producer = partial.make(
         _default_linker_opts,
@@ -185,7 +184,7 @@ def _swift_toolchain_impl(ctx):
         toolchain_root,
     )
 
-    tools = depset(transitive = [ctx.attr._cc_toolchain.files])
+    tools = depset(transitive = [cc_toolchain.all_files])
     action_registrars = struct(
         run = partial.make(_run_action, tools),
         run_shell = partial.make(_run_shell_action, tools),
@@ -204,7 +203,6 @@ def _swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = {},
             action_registrars = action_registrars,
-            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = ctx.attr.clang_executable,
             command_line_copts = ctx.fragments.swift.copts(),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -506,7 +506,6 @@ def _xcode_swift_toolchain_impl(ctx):
     )
 
     cc_toolchain = find_cpp_toolchain(ctx)
-    cc_toolchain_files = cc_toolchain.all_files
 
     # Compute the default requested features and conditional ones based on Xcode version.
     requested_features = features_for_build_modes(ctx, objc_fragment = ctx.fragments.objc)
@@ -528,7 +527,6 @@ def _xcode_swift_toolchain_impl(ctx):
         SwiftToolchainInfo(
             action_environment = env,
             action_registrars = action_registrars,
-            cc_toolchain_files = cc_toolchain_files,
             cc_toolchain_info = cc_toolchain,
             clang_executable = None,
             command_line_copts = command_line_copts,


### PR DESCRIPTION
Remove the SwiftToolchainInfo.cc_toolchain_files field.

CcToolchainInfo now provides a field for these, so we no longer have to pass them around separately.