### PR TITLE
Clean up clang usage for linking executables.

### DIFF
--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -128,9 +128,6 @@ to set the environment and execution requirements, as well as use a wrapper scri
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this Swift toolchain
 depends on.
 """,
-        "clang_executable": """
-`String`. The path to the `clang` executable, which is used to link binaries.
-""",
         "command_line_copts": """
 `List` of `strings`. Flags that were passed to Bazel using the `--swiftcopt` command line flag.
 These flags have the highest precedence; they are added to compilation command lines after the
@@ -158,10 +155,6 @@ The partial should be called with two arguments:
 *   `is_static`: A `Boolean` value indicating whether to link against the static or dynamic runtime
     libraries.
 *   `is_test`: A `Boolean` value indicating whether the target being linked is a test target.
-""",
-        "linker_search_paths": """
-`List` of `string`s. Additional library search paths that should be passed to the linker when
-linking binaries with this toolchain.
 """,
         "object_format": """
 `String`. The object file format of the platform that the toolchain is targeting. The currently

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -136,7 +136,6 @@ def _create_linux_toolchain(repository_ctx):
              "your environment before invoking Bazel.")
 
     path_to_swiftc = repository_ctx.which("swiftc")
-    path_to_clang = repository_ctx.which("clang")
     root = path_to_swiftc.dirname.dirname
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
 
@@ -153,14 +152,12 @@ package(default_visibility = ["//visibility:public"])
 swift_toolchain(
     name = "toolchain",
     arch = "x86_64",
-    clang_executable = "{path_to_clang}",
     features = [{feature_list}],
     os = "linux",
     root = "{root}",
 )
 """.format(
             feature_list = ", ".join(['"{}"'.format(feature) for feature in feature_values]),
-            path_to_clang = path_to_clang,
             root = root,
         ),
     )

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -204,7 +204,6 @@ def _swift_toolchain_impl(ctx):
             action_environment = {},
             action_registrars = action_registrars,
             cc_toolchain_info = cc_toolchain,
-            clang_executable = ctx.attr.clang_executable,
             command_line_copts = ctx.fragments.swift.copts(),
             cpu = ctx.attr.arch,
             execution_requirements = {},
@@ -232,12 +231,6 @@ The name of the architecture that this toolchain targets.
 
 This name should match the name used in the toolchain's directory layout for architecture-specific
 content, such as "x86_64" in "lib/swift/linux/x86_64".
-""",
-            mandatory = True,
-        ),
-        "clang_executable": attr.string(
-            doc = """
-The path to the `clang` executable, which is used for linking.
 """,
             mandatory = True,
         ),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -528,7 +528,6 @@ def _xcode_swift_toolchain_impl(ctx):
             action_environment = env,
             action_registrars = action_registrars,
             cc_toolchain_info = cc_toolchain,
-            clang_executable = None,
             command_line_copts = command_line_copts,
             cpu = cpu,
             execution_requirements = execution_requirements,


### PR DESCRIPTION
Clean up clang usage for linking executables.

With all the new C++ APIs in Bazel, we should no longer be grabbing the clang executable separately from a legacy provider field. Instead, use cc_common to get the tool path and command line as we now do for the archiver.