### PR TITLE
Add -module-name flag outside of params file

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -606,7 +606,7 @@ def _compile(
 
     run_swift_action(
         actions = actions,
-        arguments = [tool_args, args],
+        arguments = [tool_args, "-module-name", module_name, args],
         execution_requirements = execution_requirements,
         inputs = all_inputs,
         mnemonic = "SwiftCompile",


### PR DESCRIPTION
Adding the `-module-name` flag outside of the params file makes it more convenient to introspect on commands/processes using system tools and APIs. 