### PR TITLE
Have swift_module_alias correctly set the module name in the SwiftInfo provider it creates

### DIFF
--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -98,6 +98,7 @@ def _swift_module_alias_impl(ctx):
             libraries_to_link = [library_to_link],
         ),
         swift_common.create_swift_info(
+            module_name = module_name,
             swiftdocs = [compilation_outputs.swiftdoc],
             swiftmodules = [compilation_outputs.swiftmodule],
             swift_infos = get_providers(deps, SwiftInfo),


### PR DESCRIPTION
Have swift_module_alias correctly set the module name in the SwiftInfo provider it creates