### PR TITLE
Use an explicit loop instead of xargs when collecting compile stats.

### DIFF
--- a/tools/compile_stats/build.sh
+++ b/tools/compile_stats/build.sh
@@ -51,8 +51,9 @@ bazel build --experimental_show_artifacts "${collect_stats_flags[@]}" "$@" \
     2>&1 > /dev/null \
     | sed -e '/Build artifacts:/,$!d' \
     | sed -e 's/^>>>//' -e 't' -e 'd' \
-    | xargs -I{} find {} -type f \
-    > "$manifest"
+    | while read statsdir ; do
+        find "$statsdir" -type f
+      done > "$manifest"
 
 # Run the report generating tool.
 bazel run \


### PR DESCRIPTION
Use an explicit loop instead of xargs when collecting compile stats.

xargs fails when a path is very long (over 255 characters).