### PR TITLE
Use latest version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "build_bazel_rules_swift",
+    sha256 = "96a86afcbdab215f8363e65a10cf023b752e90b23abf02272c4fc668fcb70311",
     urls = [
-        "https://github.com/bazelbuild/rules_swift/releases/download/0.8.0/rules_swift.0.8.0.tar.gz",
+        "https://github.com/bazelbuild/rules_swift/releases/download/0.11.1/rules_swift.0.11.1.tar.gz",
     ],
-    sha256 = "31aad005a9c4e56b256125844ad05eb27c88303502d74138186f9083479f93a6",
 )
 
 load(


### PR DESCRIPTION
I think many people just copy and paste the README into their WORKSPACE file. It should use the latest version. It would be ideal to automate updating it on every release, but I don't know how releases are cut. Are they cut manually?