### PR TITLE
Add /usr/lib/swift to library search paths

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -131,6 +131,10 @@ def _default_linker_opts(
         "-Wl,-objc_abi_version,2",
     ])
 
+    use_system_swift_libs = _is_xcode_at_least_version(xcode_config, "11.0")
+    if use_system_swift_libs:
+        linkopts.append("-L/usr/lib/swift")
+
     # XCTest.framework only lives in the Xcode bundle (its platform framework
     # directory), so test binaries need to have that directory explicitly added to
     # their rpaths.


### PR DESCRIPTION
As of Xcode 11 beta 4, the Swift libraries no longer exist in the
toolchain, so Xcode passes this as well.