### PR TITLE
Refactor (and properly support) link stamping for Swift binaries.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -141,6 +141,7 @@ def register_libraries_to_link(
 def register_link_executable_action(
         actions,
         action_environment,
+        additional_linking_contexts,
         cc_feature_configuration,
         clang_executable,
         deps,
@@ -158,6 +159,8 @@ def register_link_executable_action(
         actions: The object used to register actions.
         action_environment: A `dict` of environment variables that should be set for the compile
             action.
+        additional_linking_contexts: Additional linking contexts that provide libraries or flags
+            that should be linked into the executable.
         cc_feature_configuration: The C++ feature configuration to use when constructing the
             action.
         clang_executable: The path to the `clang` executable that will be invoked to link, which is
@@ -187,17 +190,6 @@ def register_link_executable_action(
     common_args.add(clang_executable)
 
     deps_libraries = []
-
-    if swift_toolchain.stamp:
-        stamp_libs_to_link = []
-        for library in swift_toolchain.stamp[CcInfo].linking_context.libraries_to_link:
-            if library.pic_static_library:
-                stamp_libs_to_link.append(library.pic_static_library)
-            elif library.static_library:
-                stamp_libs_to_link.append(library.static_library)
-
-        if stamp_libs_to_link:
-            deps_libraries.extend(stamp_libs_to_link)
 
     additional_input_depsets = []
     all_linkopts = list(expanded_linkopts)
@@ -238,6 +230,15 @@ def register_link_executable_action(
                 ))
             deps_sdk_dylibs.append(objc.sdk_dylib)
             deps_sdk_frameworks.append(objc.sdk_framework)
+
+    for linking_context in additional_linking_contexts:
+        additional_input_depsets.append(linking_context.additional_inputs)
+        all_linkopts.extend(linking_context.user_link_flags)
+        for library in linking_context.libraries_to_link:
+            if library.pic_static_library:
+                deps_libraries.append(library.pic_static_library)
+            elif library.static_library:
+                deps_libraries.append(library.static_library)
 
     libraries = depset(deps_libraries, order = "topological")
     link_input_depsets = [

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -145,9 +145,26 @@ they are also passed to the C++ APIs used when linking (so features defined in C
 here).
 """,
         "root_dir": "`String`. The workspace-relative root directory of the toolchain.",
-        "stamp": """
-`Target`. A `CcInfo`-providing target that should be linked into any binaries that are built with
-stamping enabled.
+        "stamp_producer": """
+Skylib `partial`. A partial function that compiles build data that should be stamped into binaries.
+This value may be `None` if the toolchain does not support link stamping.
+
+The `swift_binary` and `swift_test` rules call this function _whether or not_ link stamping is
+enabled for that target. This provides toolchains the option of still linking fixed placeholder
+data into the binary if desired, instead of linking nothing at all. Whether stamping is enabled can
+be checked by inspecting `ctx.attr.stamp` inside the partial's implementation.
+
+The rule implementation will call this partial and pass it the following four arguments:
+
+*    `ctx`: The rule context of the target being built.
+*    `cc_feature_configuration`: The C++ feature configuration to use when compiling the stamp
+     code.
+*    `cc_toolchain`: The C++ toolchain (`CcToolchainInfo` provider) to use when compiling the
+     stamp code.
+*    `binary`: The `File` object representing the binary being linked.
+
+The partial should return a `CcLinkingContext` containing the data (such as object files) to be
+linked into the binary, or `None` if nothing should be linked into the binary.
 """,
         "supports_objc_interop": """
 `Boolean`. Indicates whether or not the toolchain supports Objective-C interop.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -122,7 +122,7 @@ def _swift_toolchain_impl(ctx):
             object_format = "elf",
             requested_features = requested_features,
             root_dir = toolchain_root,
-            stamp = ctx.attr.stamp,
+            stamp_producer = None,
             supports_objc_interop = False,
             swiftc_copts = [],
             swift_worker = ctx.executable._worker,
@@ -161,13 +161,6 @@ content, such as "linux" in "lib/swift/linux".
         ),
         "root": attr.string(
             mandatory = True,
-        ),
-        "stamp": attr.label(
-            doc = """
-A `CcInfo`-providing target that should be linked into any binaries that are built with stamping
-enabled.
-""",
-            providers = [[CcInfo]],
         ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -328,7 +328,7 @@ def _xcode_swift_toolchain_impl(ctx):
             object_format = "macho",
             requested_features = requested_features,
             root_dir = None,
-            stamp = ctx.attr.stamp if _is_macos(platform) else None,
+            stamp_producer = None,
             supports_objc_interop = True,
             swiftc_copts = swiftc_copts,
             swift_worker = ctx.executable._worker,
@@ -342,13 +342,6 @@ def _xcode_swift_toolchain_impl(ctx):
 
 xcode_swift_toolchain = rule(
     attrs = dicts.add({
-        "stamp": attr.label(
-            doc = """
-A `CcInfo`-providing target that should be linked into any binaries that are built with stamping
-enabled.
-""",
-            providers = [[CcInfo]],
-        ),
         "_cc_toolchain": attr.label(
             default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
             doc = """


### PR DESCRIPTION
Refactor (and properly support) link stamping for Swift binaries.