### PR TITLE
Make sure that embedded runtimes are also included in the inputs of the link action.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -291,6 +291,7 @@ def register_link_executable_action(
             feature_configuration = cc_feature_configuration,
         )
         link_input_args.add_all(cc_runtime_libs)
+        link_input_depsets.append(cc_runtime_libs)
 
     user_args = actions.args()
     user_args.add_all(all_linkopts)


### PR DESCRIPTION
Make sure that embedded runtimes are also included in the inputs of the link action.