### PR TITLE
Add a pbswift_files output group and use PathToUnderscores

### DIFF
--- a/swift/internal/proto_gen_utils.bzl
+++ b/swift/internal/proto_gen_utils.bzl
@@ -115,7 +115,7 @@ def _generated_file_path(name, extension_fragment, proto_file = None):
     )
     if proto_file:
         generated_file_path = paths.replace_extension(
-            workspace_relative_path(proto_file),
+            workspace_relative_path(proto_file).replace("/", "_"),
             ".{}.swift".format(extension_fragment),
         )
         return paths.join(dir_path, generated_file_path)

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -82,6 +82,7 @@ def _register_grpcswift_generate_action(
         format = "--plugin=protoc-gen-swiftgrpc=%s",
     )
     protoc_args.add(generated_dir_path, format = "--swiftgrpc_out=%s")
+    protoc_args.add("--swiftgrpc_opt=FileNaming=PathToUnderscores")
     protoc_args.add("--swiftgrpc_opt=Visibility=Public")
     if flavor == "client":
         protoc_args.add("--swiftgrpc_opt=Client=true")

--- a/swift/internal/swift_proto_library.bzl
+++ b/swift/internal/swift_proto_library.bzl
@@ -43,8 +43,12 @@ def _swift_proto_library_impl(ctx):
         cc_info,
         swift_info,
         # Repropagate the `SwiftProtoInfo` provider so that downstream rules/aspects can access the
-        # sources if necessary. (This should typically only be used for IDE support.)
+        # sources if necessary. (This should typically only be used for IDE support.) Also, add an
+        # output group to for the generated files.
         swift_proto_info,
+        OutputGroupInfo(
+            pbswift_files = swift_proto_info.pbswift_files,
+        ),
     ]
 
     # Propagate a nested apple_common.Objc provider if present so that apple_binary targets link

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -133,7 +133,7 @@ def _register_pbswift_generate_action(
         format = "--plugin=protoc-gen-swift=%s",
     )
     protoc_args.add(generated_dir_path, format = "--swift_out=%s")
-    protoc_args.add("--swift_opt=FileNaming=FullPath")
+    protoc_args.add("--swift_opt=FileNaming=PathToUnderscores")
     protoc_args.add("--swift_opt=Visibility=Public")
     if module_mapping_file:
         protoc_args.add(


### PR DESCRIPTION
Add a new `pbswift_files` output group in order to consume the generated `pbswift` files in macros for instance

Switch from `FileNaming=FullPath` to `FileNaming=PathToUnderscores`
When compiling `pbswift` files, the linker complains if two files have the same name. This fixes it.