### PR TITLE
Expand the example to include WKT usage.

### DIFF
--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -9,6 +9,9 @@ licenses(["notice"])
 proto_library(
     name = "example_proto",
     srcs = ["example.proto"],
+    deps = [
+        "@com_google_protobuf//:api_proto",
+    ],
 )
 
 swift_proto_library(

--- a/examples/xplatform/proto/example.proto
+++ b/examples/xplatform/proto/example.proto
@@ -14,7 +14,14 @@
 
 syntax = "proto3";
 
+import "google/protobuf/api.proto";
+
 message Person {
   string name = 1;
   int32 age = 2;
+}
+
+message Server {
+  string name = 1;
+  google.protobuf.Api api = 2;
 }

--- a/examples/xplatform/proto/main.swift
+++ b/examples/xplatform/proto/main.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import SwiftProtobuf
 import examples_xplatform_proto_example_proto
 
 let person = Person.with {
@@ -22,3 +23,18 @@ let person = Person.with {
 
 let data = try! person.serializedData()
 print(Array(data))
+
+let server = Server.with {
+  $0.name = "My Server"
+  $0.api.name = "My API"
+  let option = Google_Protobuf_Option.with {
+    $0.name = "Person Option"
+    if let value = try? Google_Protobuf_Any(message: person) {
+      $0.value = value
+    }
+  }
+  $0.api.options.append(option)
+}
+
+let data2 = try! server.serializedData()
+print(Array(data2))


### PR DESCRIPTION
Expand the example to include WKT usage.

Not only shows using the WKT a little, but also servers to exercise
more of swift_proto_library since the WKTs get pulled in thru the runtime
and thus are special handled in the rule's implementation.