### PR TITLE
Make rules_swift work with virtual import directories.

### DIFF
--- a/swift/internal/proto_gen_utils.bzl
+++ b/swift/internal/proto_gen_utils.bzl
@@ -105,6 +105,7 @@ def _generated_file_path(name, extension_fragment, proto_source_root, proto_file
         extension_fragment: An extension fragment that precedes `.swift` on the end of the
             generated files. In other words, the file `foo.proto` will generate a file named
             `foo.{extension_fragment}.swift`.
+        proto_source_root: The source root for the `.proto` file.
         proto_file: The `.proto` file whose generated `.swift` path should be computed.
 
     Returns:

--- a/swift/internal/proto_gen_utils.bzl
+++ b/swift/internal/proto_gen_utils.bzl
@@ -15,9 +15,9 @@
 """Utility functions shared by rules/aspects that generate sources from .proto files."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":utils.bzl", "workspace_relative_path")
+load(":utils.bzl", "proto_import_path")
 
-def declare_generated_files(name, actions, extension_fragment, proto_srcs):
+def declare_generated_files(name, actions, extension_fragment, proto_source_root, proto_srcs):
     """Declares generated `.swift` files that correspond to a list of `.proto` files.
 
     Args:
@@ -26,6 +26,7 @@ def declare_generated_files(name, actions, extension_fragment, proto_srcs):
         extension_fragment: An extension fragment that precedes `.swift` on the end of the
             generated files. In other words, the file `foo.proto` will generate a file named
             `foo.{extension_fragment}.swift`.
+        proto_source_root: the source root of the `.proto` files in `proto_srcs`.
         proto_srcs: A list of `.proto` files.
 
     Returns:
@@ -33,11 +34,11 @@ def declare_generated_files(name, actions, extension_fragment, proto_srcs):
         extensions instead of `.proto`.
     """
     return [
-        actions.declare_file(_generated_file_path(name, extension_fragment, f))
+        actions.declare_file(_generated_file_path(name, extension_fragment, proto_source_root, f))
         for f in proto_srcs
     ]
 
-def extract_generated_dir_path(name, extension_fragment, generated_files):
+def extract_generated_dir_path(name, extension_fragment, proto_source_root, generated_files):
     """Extracts the full path to the directory where `.swift` files are generated.
 
     This dance is required because we cannot get the full (repository-relative) path to the
@@ -52,6 +53,8 @@ def extract_generated_dir_path(name, extension_fragment, generated_files):
         extension_fragment: An extension fragment that precedes `.swift` on the end of the
             generated files. In other words, the file `foo.proto` will generate a file named
             `foo.{extension_fragment}.swift`.
+        proto_source_root: the source root for the `.proto` files `generated_files` are generated
+            from.
         generated_files: A list of generated `.swift` files, one of which will be used to extract
             the directory path.
 
@@ -62,7 +65,7 @@ def extract_generated_dir_path(name, extension_fragment, generated_files):
         return None
 
     first_path = generated_files[0].path
-    dir_name = _generated_file_path(name, extension_fragment)
+    dir_name = _generated_file_path(name, extension_fragment, proto_source_root)
     offset = first_path.find(dir_name)
     return first_path[:offset + len(dir_name)]
 
@@ -88,7 +91,7 @@ def register_module_mapping_write_action(name, actions, module_mappings):
 
     return mapping_file
 
-def _generated_file_path(name, extension_fragment, proto_file = None):
+def _generated_file_path(name, extension_fragment, proto_source_root, proto_file = None):
     """Returns the short path of a generated `.swift` file corresponding to a `.proto` file.
 
     The returned workspace-relative path should be used to declare output files so that they are
@@ -115,7 +118,7 @@ def _generated_file_path(name, extension_fragment, proto_file = None):
     )
     if proto_file:
         generated_file_path = paths.replace_extension(
-            workspace_relative_path(proto_file),
+            proto_import_path(proto_file, proto_source_root),
             ".{}.swift".format(extension_fragment),
         )
         return paths.join(dir_path, generated_file_path)

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -80,6 +80,7 @@ def _filter_out_well_known_types(srcs, proto_source_root):
 
     Args:
       srcs: A list of `.proto` files.
+      proto_source_root: the source root where the `.proto` files are.
 
     Returns:
       The given list of files with any well-known type protos (those living under
@@ -94,8 +95,8 @@ def _filter_out_well_known_types(srcs, proto_source_root):
 def _register_pbswift_generate_action(
         label,
         actions,
-        proto_source_root,
         direct_srcs,
+        proto_source_root,
         transitive_descriptor_sets,
         module_mapping_file,
         mkdir_and_run,
@@ -108,6 +109,7 @@ def _register_pbswift_generate_action(
         actions: The context's actions object.
         direct_srcs: The direct `.proto` sources belonging to the target being analyzed, which
             will be passed to `protoc-gen-swift`.
+        proto_source_root: the source root where the `.proto` files are.
         transitive_descriptor_sets: The transitive `DescriptorSet`s from the `proto_library` being
             analyzed.
         module_mapping_file: The `File` containing the mapping between `.proto` files and Swift
@@ -296,8 +298,8 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         pbswift_files = _register_pbswift_generate_action(
             target.label,
             aspect_ctx.actions,
-            target[ProtoInfo].proto_source_root,
             direct_srcs,
+            target[ProtoInfo].proto_source_root,
             transitive_descriptor_sets,
             transitive_module_mapping_file,
             aspect_ctx.executable._mkdir_and_run,

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -67,6 +67,13 @@ This provider is an implementation detail not meant to be used by clients.
     },
 )
 
+def _proto_include_path(f):
+    virtual_imports = "/_virtual_imports/"
+    if virtual_imports in f.path:
+        return f.path.split(virtual_imports, 1)[1].split("/", 1)[1]
+    else:
+        return workspace_relative_path(f)
+
 def _filter_out_well_known_types(srcs):
     """Returns the given list of files, excluding any well-known type protos.
 
@@ -80,7 +87,7 @@ def _filter_out_well_known_types(srcs):
     return [
         f
         for f in srcs
-        if workspace_relative_path(f) not in _RUNTIME_BUNDLED_PROTO_FILES
+        if _proto_include_path(f) not in _RUNTIME_BUNDLED_PROTO_FILES
     ]
 
 def _register_pbswift_generate_action(
@@ -142,7 +149,7 @@ def _register_pbswift_generate_action(
         )
     protoc_args.add("--descriptor_set_in")
     protoc_args.add_joined(transitive_descriptor_sets, join_with = ":")
-    protoc_args.add_all([workspace_relative_path(f) for f in direct_srcs])
+    protoc_args.add_all([_proto_include_path(f) for f in direct_srcs])
 
     additional_command_inputs = []
     if module_mapping_file:

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -251,3 +251,19 @@ def workspace_relative_path(file):
     """
     workspace_path = paths.join(file.root.path, file.owner.workspace_root)
     return paths.relativize(file.path, workspace_path)
+
+def proto_import_path(f, proto_source_root):
+    """ Returns the import path of a `.proto` file given its path.
+
+    Args:
+        file: The `File` object.
+
+    Returns:
+        The path the `.proto` file should be imported at.
+    """
+    if f.path.startswith(proto_source_root):
+        return f.path[len(proto_source_root) + 1:]
+    else:
+        # Happens before Bazel 1.0, where proto_source_root was not
+        # guaranteed to be a parent of the .proto file
+        return workspace_relative_path(f)

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -256,7 +256,8 @@ def proto_import_path(f, proto_source_root):
     """ Returns the import path of a `.proto` file given its path.
 
     Args:
-        file: The `File` object.
+        f: The `File` object representing the `.proto` file.
+        proto_source_root: The source root for the `.proto` file.
 
     Returns:
         The path the `.proto` file should be imported at.

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -240,7 +240,7 @@ def owner_relative_path(file):
     else:
         return paths.relativize(file.short_path, package)
 
-def workspace_relative_path(file):
+def _workspace_relative_path(file):
     """Returns the path of a file relative to its workspace.
 
     Args:
@@ -267,4 +267,4 @@ def proto_import_path(f, proto_source_root):
     else:
         # Happens before Bazel 1.0, where proto_source_root was not
         # guaranteed to be a parent of the .proto file
-        return workspace_relative_path(f)
+        return _workspace_relative_path(f)


### PR DESCRIPTION
This is necessary for the rule set to work with
`--incompatible_generated_protos_in_virtual_imports` (and also with
`proto_library` rules with `strip_import_prefix` / `import_prefix`)