### PR TITLE
Fix compilation with opt_uses_wmo

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -493,7 +493,8 @@ def _compile(
     # on a Mac Pro for historical reasons.
     # TODO(b/32571265): Generalize this based on platform and core count when an
     # API to obtain this is available.
-    if _is_wmo(copts + swift_toolchain.command_line_copts, feature_configuration):
+    is_wmo = _is_wmo(copts + swift_toolchain.command_line_copts, feature_configuration)
+    if is_wmo:
         # We intentionally don't use `+=` or `extend` here to ensure that a
         # copy is made instead of extending the original.
         copts = copts + ["-num-threads", "12"]
@@ -501,6 +502,7 @@ def _compile(
     compile_reqs = declare_compile_outputs(
         actions = actions,
         copts = copts + swift_toolchain.command_line_copts,
+        is_wmo = is_wmo,
         srcs = srcs,
         target_name = target_name,
         index_while_building = swift_common.is_enabled(


### PR DESCRIPTION
Previously there were 2 checks to see if WMO was enabled, but one wasn't
checking the features. This resulted in build failures because not all
outputs were created. Now there is 1 source of truth for this and the
determination is passed along.