### PR TITLE
Stop propagating duplicate SwiftUsageInfo providers from swift_usage_aspect

### DIFF
--- a/swift/internal/swift_usage_aspect.bzl
+++ b/swift/internal/swift_usage_aspect.bzl
@@ -34,6 +34,12 @@ def _get_swift_toolchain(target, aspect_ctx):
     return None
 
 def _swift_usage_aspect_impl(target, aspect_ctx):
+    # Targets can directly propagate their own `SwiftUsageInfo` provider. In
+    # those case, this aspect must not propagate a `SwiftUsageInfo`, because
+    # doing so results in a Bazel error.
+    if SwiftUsageInfo in target:
+        return []
+
     # If the target itself propagates `SwiftInfo`, get the toolchain from it.
     found_toolchain = _get_swift_toolchain(target, aspect_ctx)
 


### PR DESCRIPTION
With the changes in https://github.com/bazelbuild/rules_apple/pull/566, the `swift_usage_aspect` needs to handle a new case.

If a rule and an aspect both provide the same provider type, bazel raises this error:

[src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/MergedConfiguredTarget.java#L167](https://github.com/bazelbuild/bazel/blob/efb3f1595ee897484c477168b8da42b67602e10e/src/main/java/com/google/devtools/build/lib/analysis/configuredtargets/MergedConfiguredTarget.java#L167)

This changes `swift_usage_aspect` to not propagate a `SwiftUsageInfo` if the target already does. Specifically, this makes the updated `apple_static_framework_import` work in apps that have other swift deps.