### PR TITLE
Fix the `TOOLCHAINS` env var for custom Xcode toolchains.

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -375,12 +375,12 @@ def _xcode_swift_toolchain_impl(ctx):
         toolchain_root,
     )
 
-    # Configure the action registrars that automatically prepend xcrunwrapper to
-    # registered actions.
+    # Configure the environment variables that the worker needs to fill in the
+    # Bazel placeholders for SDK root and developer directory, along with the
+    # custom toolchain if requested.
     env = _xcode_env(xcode_config, platform)
-    swift_toolchain_env = {}
     if custom_toolchain:
-        swift_toolchain_env["TOOLCHAINS"] = custom_toolchain
+        env["TOOLCHAINS"] = custom_toolchain
 
     execution_requirements = {"requires-darwin": ""}
 


### PR DESCRIPTION
Fix the `TOOLCHAINS` env var for custom Xcode toolchains.

This was previously set in a separate dictionary to prevent conflicts with static library archiving actions, but now those go through the C++ APIs and those conflicts no longer occur. Unfortunately, that change also broke this, because the new dictionary was no longer being used anywhere, so this variable never makes it through. The fix is to just set it on the original `env` dictionary again.