### PR TITLE
Avoid introducing duplicate entries in the import search path when there are multiple swiftmodules in a single directory

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -72,6 +72,7 @@ def collect_transitive_compile_inputs(args, deps, direct_defines = []):
         all_swiftmodules,
         format_each = "-I%s",
         map_each = _dirname_map_fn,
+        uniquify = True,
     )
     input_depsets.append(all_swiftmodules)
 


### PR DESCRIPTION
Avoid introducing duplicate entries in the import search path when there are multiple swiftmodules in a single directory