### PR TITLE
Add support for implementation-only imports via the `private_deps` attribute when using Swift 5.1 or higher.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -28,11 +28,40 @@ area of this target, if it has one. This may include data files needed by a
 binary or library, or other programs needed by it.
 """,
         ),
-        "deps": attr.label_list(
+        "deps": swift_deps_attr(
             aspects = additional_deps_aspects,
             doc = """\
 A list of targets that are dependencies of the target being built, which will be
-linked into that target. Allowed kinds of dependencies are:
+linked into that target.
+
+If the Swift toolchain supports implementation-only imports (`private_deps` on
+`swift_library`), then targets in `deps` are treated as regular
+(non-implementation-only) imports that are propagated both to their direct and
+indirect (transitive) dependents.
+""",
+        ),
+    }
+
+def swift_deps_attr(doc, **kwargs):
+    """Returns an attribute suitable for representing Swift rule dependencies.
+
+    The returned attribute will be configured to accept targets that propagate
+    `CcInfo`, `SwiftInfo`, or `apple_common.Objc` providers.
+
+    Args:
+        doc: A string containing a summary description of the purpose of the
+            attribute. This string will be followed by additional text that
+            lists the permitted kinds of targets that may go in this attribute.
+        **kwargs: Additional arguments that are passed to `attr.label_list`
+            unmodified.
+
+    Returns:
+        A rule attribute.
+    """
+    return attr.label_list(
+        doc = doc + """\
+
+Allowed kinds of dependencies are:
 
 *   `swift_c_module`, `swift_import` and `swift_library` (or anything
     propagating `SwiftInfo`)
@@ -43,10 +72,10 @@ targets (or anything propagating the `apple_common.Objc` provider) are allowed
 as dependencies. On platforms that do not support Objective-C interop (such as
 Linux), those dependencies will be **ignored.**
 """,
-            providers = [
-                [CcInfo],
-                [SwiftInfo],
-                [apple_common.Objc],
-            ],
-        ),
-    }
+        providers = [
+            [CcInfo],
+            [SwiftInfo],
+            [apple_common.Objc],
+        ],
+        **kwargs
+    )

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -152,6 +152,11 @@ SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION = "swift.enable_library_evolution"
 # enabled, this feature is a noop.
 SWIFT_FEATURE_EMIT_SWIFTINTERFACE = "swift.emit_swiftinterface"
 
+# If enabled, the toolchain supports private deps (implementation-only imports).
+# This allows Bazel to avoid propagating swiftmodules of such dependencies
+# higher in the dependency graph than they need to be.
+SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
+
 def features_for_build_modes(ctx, objc_fragment = None):
     """Returns a list of Swift toolchain features for current build modes.
 

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -28,6 +28,7 @@ load(
     "@build_bazel_rules_swift//swift/internal:features.bzl",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
+    "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
 )
 
@@ -80,6 +81,23 @@ def _check_debug_prefix_map(repository_ctx, swiftc_path, temp_dir):
         "-version",
         "-debug-prefix-map",
         "foo=bar",
+    )
+
+def _check_supports_private_deps(repository_ctx, swiftc_path, temp_dir):
+    """Returns True if `swiftc` supports implementation-only imports."""
+    param_file = _scratch_file(
+        repository_ctx,
+        temp_dir,
+        "main.swift",
+        """\
+@_implementationOnly import Foundation
+print("Hello")
+""",
+    )
+    return _swift_succeeds(
+        repository_ctx,
+        swiftc_path,
+        "@{}".format(param_file),
     )
 
 def _check_use_response_files(repository_ctx, swiftc_path, temp_dir):
@@ -146,6 +164,7 @@ def _compute_feature_values(repository_ctx, swiftc_path):
 _FEATURE_CHECKS = {
     SWIFT_FEATURE_DEBUG_PREFIX_MAP: _check_debug_prefix_map,
     SWIFT_FEATURE_ENABLE_BATCH_MODE: _check_enable_batch_mode,
+    SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS: _check_supports_private_deps,
     SWIFT_FEATURE_USE_RESPONSE_FILES: _check_use_response_files,
 }
 

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -32,6 +32,7 @@ load(
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
+    "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
     "features_for_build_modes",
 )
@@ -390,6 +391,7 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 11.0 implies Swift 5.1.
     if _is_xcode_at_least_version(xcode_config, "11.0"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION)
+        requested_features.append(SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS)
 
     command_line_copts = (
         _command_line_objc_copts(ctx.fragments.objc) +

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,9 @@
+load(":private_deps_tests.bzl", "private_deps_test_suite")
+
+licenses(["notice"])
+
+private_deps_test_suite()
+
+test_suite(
+    name = "all_tests",
+)

--- a/test/fixtures/BUILD
+++ b/test/fixtures/BUILD
@@ -1,0 +1,1 @@
+# Intentionally blank to define a package.

--- a/test/fixtures/common.bzl
+++ b/test/fixtures/common.bzl
@@ -1,0 +1,22 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common build definitions used by test fixtures."""
+
+# Common tags that prevent the test fixtures from actually being built (i.e.,
+# their actions executed) when running `bazel test` to do analysis testing.
+FIXTURE_TAGS = [
+    "manual",
+    "notap",
+]

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -1,0 +1,81 @@
+load("//swift:swift.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+###############################################################################
+# Fixtures for testing swift_libraries that are private deps of a swift_library
+
+swift_library(
+    name = "private_swift",
+    srcs = ["Empty.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
+    name = "public_swift",
+    srcs = ["Empty.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
+    name = "client_swift_deps",
+    srcs = ["Empty.swift"],
+    private_deps = [
+        ":private_swift",
+    ],
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":public_swift",
+    ],
+)
+
+###############################################################################
+# Fixtures for testing cc_libraries that are private deps of a swift_library
+
+cc_library(
+    name = "private_cc",
+    hdrs = ["private.h"],
+    features = [
+        # A bit hacky, but by claiming we don't support PIC, we can get the
+        # output libraries in `libraries_to_link.static_library` instead of
+        # `pic_static_library`, so that the test doesn't have to worry about
+        # the specific toolchain configuration.
+        "-pic",
+        "-supports_pic",
+    ],
+    tags = FIXTURE_TAGS,
+)
+
+cc_library(
+    name = "public_cc",
+    hdrs = ["public.h"],
+    features = [
+        # See the comment in the target above.
+        "-pic",
+        "-supports_pic",
+    ],
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
+    name = "client_cc_deps",
+    srcs = ["Empty.swift"],
+    private_deps = [
+        ":private_cc",
+    ],
+    tags = FIXTURE_TAGS,
+    deps = [
+        ":public_cc",
+    ],
+)
+
+# TODO(allevato): Add tests for `objc_library` targets that are private deps
+# of a `swift_library`. We can't do this today because `ObjcProvider` doesn't
+# distinguish compilation and linking info, which means we can't easily merge
+# the linking parts that are necessary for `apple_binary` without also merging
+# the header/module map information that we don't want to propagate.

--- a/test/fixtures/private_deps/Empty.swift
+++ b/test/fixtures/private_deps/Empty.swift
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/fixtures/private_deps/private.h
+++ b/test/fixtures/private_deps/private.h
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/fixtures/private_deps/public.h
+++ b/test/fixtures/private_deps/public.h
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -1,0 +1,124 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `swift_library.private_deps`."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:provider_test.bzl",
+    "make_provider_test_rule",
+)
+
+# Force private deps support to be enabled at analysis time, regardless of
+# whether the active toolchain actually supports it.
+private_deps_provider_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": ["swift.supports_private_deps"],
+    },
+)
+
+def private_deps_test_suite():
+    """Test suite for propagation behavior of `swift_library.private_deps`."""
+    name = "private_deps"
+
+    # Each of the two leaf libraries should propagate their own modules.
+    private_deps_provider_test(
+        name = "{}_private_swift_swiftmodules".format(name),
+        expected_files = [
+            "test_fixtures_private_deps_private_swift.swiftmodule",
+        ],
+        field = "transitive_swiftmodules",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:private_swift",
+    )
+
+    private_deps_provider_test(
+        name = "{}_public_swift_swiftmodules".format(name),
+        expected_files = [
+            "test_fixtures_private_deps_public_swift.swiftmodule",
+        ],
+        field = "transitive_swiftmodules",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:public_swift",
+    )
+
+    # The client module should propagate its own module and the one from `deps`,
+    # but not the one from `private_deps`.
+    private_deps_provider_test(
+        name = "{}_client_swift_deps_swiftmodules".format(name),
+        expected_files = [
+            "test_fixtures_private_deps_client_swift_deps.swiftmodule",
+            "test_fixtures_private_deps_public_swift.swiftmodule",
+            "-test_fixtures_private_deps_private_swift.swiftmodule",
+        ],
+        field = "transitive_swiftmodules",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
+    )
+
+    # With private deps that are C++ libraries, we shouldn't propagate the
+    # compilation context of the private deps. That means the public deps'
+    # headers will be repropagated by Swift library, but not the private ones.
+    private_deps_provider_test(
+        name = "{}_client_cc_deps_headers".format(name),
+        expected_files = [
+            "/test/fixtures/private_deps/public.h",
+            "-/test/fixtures/private_deps/private.h",
+            # Some C++ toolchains implicitly propagate standard library headers,
+            # so we can't look for an exact match here.
+            "*",
+        ],
+        field = "compilation_context.headers",
+        provider = "CcInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    # Likewise, we shouldn't repropagate the C++ private deps' module maps.
+    private_deps_provider_test(
+        name = "{}_client_cc_deps_modulemaps".format(name),
+        expected_files = [
+            "/test/fixtures/private_deps/public_cc.modulemaps/module.modulemap",
+            "-/test/fixtures/private_deps/private_cc.modulemaps/module.modulemap",
+        ],
+        field = "transitive_modulemaps",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    # Make sure we don't also lose linking information when handling C++ private
+    # deps. All libraries should be propagated, even if their compilation
+    # contexts aren't.
+    private_deps_provider_test(
+        name = "{}_client_cc_deps_libraries".format(name),
+        expected_files = [
+            "/test/fixtures/private_deps/libprivate_cc.a",
+            "/test/fixtures/private_deps/libpublic_cc.a",
+            # There may be other libraries here, like implicit toolchain
+            # dependencies, which we need to ignore.
+            "*",
+        ],
+        field = "linking_context.libraries_to_link.static_library!",
+        provider = "CcInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )


### PR DESCRIPTION
Add support for implementation-only imports via the `private_deps` attribute when using Swift 5.1 or higher.

Targets in `private_deps` make their swiftmodules available to direct dependents but do not propagate them further up the graph.