### PR TITLE
Stop declaring module swiftdeps output

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -225,15 +225,6 @@ def declare_compile_outputs(
 
         output_map[src.path] = struct(**src_output_map)
 
-    # Output the module-wide `.swiftdeps` file, which is used for incremental
-    # builds.
-    swiftdeps = derived_files.swift_dependencies_file(
-        actions = actions,
-        target_name = target_name,
-    )
-    other_outputs.append(swiftdeps)
-    output_map[""] = {"swift-dependencies": swiftdeps.path}
-
     actions.write(
         content = struct(**output_map).to_json(),
         output = output_map_file,

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -249,29 +249,6 @@ def _swiftmodule(actions, module_name):
     """
     return actions.declare_file("{}.swiftmodule".format(module_name))
 
-def _swift_dependencies_file(actions, target_name, src = None):
-    """Declares a file for compiler-generated Swift dependencies for a target.
-
-    This file is used during incremental compilation to determine which object
-    files and partial modules need to be rebuilt when a particular source file
-    changes.
-
-    Args:
-        actions: The context's actions object.
-        target_name: The name of the target being built.
-        src: An optional `File` representing the source file being compiled.
-
-    Returns:
-        The declared `File`.
-    """
-    if src:
-        dirname, basename = _intermediate_frontend_file_path(target_name, src)
-        return actions.declare_file(
-            paths.join(dirname, "{}.swiftdeps".format(basename)),
-        )
-
-    return actions.declare_file("{}.swiftdeps".format(target_name))
-
 def _whole_module_object_file(actions, target_name):
     """Declares a file for object files created with whole module optimization.
 
@@ -328,7 +305,6 @@ derived_files = struct(
     swiftdoc = _swiftdoc,
     swiftinterface = _swiftinterface,
     swiftmodule = _swiftmodule,
-    swift_dependencies_file = _swift_dependencies_file,
     whole_module_object_file = _whole_module_object_file,
     xctest_bundle = _xctest_bundle,
     xctest_runner_script = _xctest_runner_script,

--- a/tools/common/path_utils.cc
+++ b/tools/common/path_utils.cc
@@ -31,14 +31,26 @@ std::string Dirname(const std::string &path) {
 }
 
 std::string ReplaceExtension(const std::string &path,
-                             const std::string &new_extension) {
-  auto last_dot = path.rfind('.');
+                             const std::string &new_extension,
+                             bool all_extensions) {
   auto last_slash = path.rfind('/');
 
-  // If there was no dot, or if it was part of a previous path segment, append
-  // the extension to the path.
-  if (last_dot == std::string::npos || last_dot < last_slash) {
+  std::string::size_type dot;
+  if (all_extensions) {
+    // Find the first dot, signifying the first of all extensions.
+    if (last_slash != std::string::npos) {
+      dot = path.find('.', last_slash);
+    } else {
+      dot = path.find('.');
+    }
+  } else {
+    // Find the last extension only.
+    dot = path.rfind('.');
+  }
+
+  // If there was no dot append the extension to the path.
+  if (dot == std::string::npos) {
     return path + new_extension;
   }
-  return path.substr(0, last_dot) + new_extension;
+  return path.substr(0, dot) + new_extension;
 }

--- a/tools/common/path_utils.h
+++ b/tools/common/path_utils.h
@@ -30,6 +30,7 @@ std::string Dirname(const std::string &path);
 // extension in the returned path. If the path does not have a file extension,
 // then new_extension is appended to it.
 std::string ReplaceExtension(const std::string &path,
-                             const std::string &new_extension);
+                             const std::string &new_extension,
+                             bool all_extensions = false);
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_PATH_UTILS_H_

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -50,7 +50,7 @@ class OutputFileMap {
  private:
   // Modifies the output file map's JSON structure in-place to replace file
   // paths with equivalents in the incremental storage area.
-  void UpdateForIncremental();
+  void UpdateForIncremental(const std::string &path);
 
   nlohmann::json json_;
   std::map<std::string, std::string> incremental_outputs_;


### PR DESCRIPTION
Module `.swiftdeps` files have thus far been declared outputs, but there are reasons they should not be. This change removes the module `.swiftdeps` from declared outputs. This matches the source file `.swiftdeps`, which are already not declared.

The module `.swiftdeps` don't contain paths, but do contain other build environment information: timestamps and a hash of command line arguments. This info varies across machines. Another potential issue is these  module`.swiftdeps` files are both an input and an output to `swiftc` actions, but rules_swift declares them only as outputs. No actions declare them as inputs.

Unless module `.swiftdeps` can be marked as `no-remote`, then making them undeclared seems to be the best approach.