### PR TITLE
Add -Osize support

### DIFF
--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -61,6 +61,7 @@ load(
     "SWIFT_FEATURE_NO_GENERATED_HEADER",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
+    "SWIFT_FEATURE_OPT_USES_OSIZE",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
@@ -300,7 +301,15 @@ def _compilation_mode_copts(feature_configuration):
     # https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode
     flags = []
     if is_opt:
-        flags.extend(["-O", "-DNDEBUG"])
+        flags.append("-DNDEBUG")
+        if _is_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_OPT_USES_OSIZE,
+        ):
+            flags.append("-Osize")
+        else:
+            flags.append("-O")
+
         if _is_enabled(
             feature_configuration = feature_configuration,
             feature_name = SWIFT_FEATURE_OPT_USES_WMO,

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -111,6 +111,10 @@ SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 # the `-whole-module-optimization` flag (in addition to `-O`).
 SWIFT_FEATURE_OPT_USES_WMO = "swift.opt_uses_wmo"
 
+# If enabled, builds using the "opt" compilation mode will invoke `swiftc` with
+# the `-Osize` flag instead of `-O`.
+SWIFT_FEATURE_OPT_USES_OSIZE = "swift.opt_uses_osize"
+
 # If enabled, Swift compilation actions will use the same global Clang module
 # cache used by Objective-C compilation actions. This is disabled by default
 # because under some circumstances Clang module cache corruption can cause the


### PR DESCRIPTION
This adds a feature to use `-Osize` instead of `-O` which apparently
should rarely have a major impact on "normal" apps' performance
https://forums.swift.org/t/performance-impact-of-swift-compiler-optimization-level/30170/2