### PR TITLE
Use -filelist when linking swift_library

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -57,7 +57,11 @@ def _register_static_library_link_action(
     )
     args = actions.args()
     args.add_all(command_line)
-    args.add_all(objects)
+    args.add("-filelist")
+    objects_args = actions.args()
+    objects_args.set_param_file_format("multiline")
+    objects_args.use_param_file("%s", use_always=True)
+    objects_args.add_all(objects)
 
     env = cc_common.get_environment_variables(
         action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
@@ -72,7 +76,7 @@ def _register_static_library_link_action(
     execution_requirements = {req: "1" for req in execution_requirements_list}
 
     actions.run(
-        arguments = [args],
+        arguments = [args, objects_args],
         env = env,
         executable = archiver_path,
         execution_requirements = execution_requirements,


### PR DESCRIPTION
The list of object files can potentially become very long. Linking should be performed using `-filelist` and a parameter file.