### PR TITLE
Refactor slightly how actions are registered in the Swift rules.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -18,27 +18,49 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:types.bzl", "types")
 
-def get_swift_tool(swift_toolchain, tool):
-    """Gets the path to the given Swift toolchain tool.
+def _get_swift_driver_mode_args(driver_mode, swift_toolchain):
+    """Gets the arguments to pass to the worker to invoke the Swift driver.
 
     Args:
+        driver_mode: The mode in which to invoke the Swift driver. In other
+            words, this is the name of the executable of symlink that you want
+            to execute (e.g., `swift`, `swiftc`, `swift-autolink-extract`).
         swift_toolchain: The Swift toolchain being used to register actions.
-        tool: The name of a tool in the Swift toolchain (i.e., in the `bin`
-            directory).
 
     Returns:
-        The path to the tool. If the toolchain provides a root directory, then
-        the path will include the `bin` directory of that toolchain. If the
-        toolchain does not provide a root, then it is assumed that the tool will
-        be available by invoking just its name (e.g., found on the system path
-        or by another delegating tool like `xcrun` from Xcode).
-    """
-    if ("/" not in tool and swift_toolchain.root_dir):
-        return paths.join(swift_toolchain.root_dir, "bin", tool)
-    return tool
+        A list of values that can be added to an `Args` object and passed to the
+        worker to invoke the command.
 
-def run_swift_action(actions, swift_toolchain, **kwargs):
-    """Executes a Swift toolchain tool using the worker.
+        This method implements three kinds of "dispatch":
+
+        1.  If the toolchain provides a custom driver executable, it is invoked
+            with the requested mode passed via the `--driver_mode` argument.
+        2.  If the toolchain provides a root directory, then the returned list
+            will be the path to the executable with the same name as the driver
+            mode in the `bin` directory of that toolchain.
+        3.  If the toolchain does not provide a root, then it is assumed that
+            the tool will be available by invoking just the driver mode by name
+            (e.g., found on the system path or by another delegating tool like
+            `xcrun` from Xcode).
+    """
+    if swift_toolchain.swift_executable:
+        return [
+            swift_toolchain.swift_executable,
+            "--driver-mode={}".format(driver_mode),
+        ]
+
+    if swift_toolchain.root_dir:
+        return [paths.join(swift_toolchain.root_dir, "bin", driver_mode)]
+
+    return [driver_mode]
+
+def run_swift_action(
+        actions,
+        arguments,
+        driver_mode,
+        swift_toolchain,
+        **kwargs):
+    """Executes the Swift driver using the worker.
 
     This function applies the toolchain's environment and execution requirements
     and wraps the invocation in the worker tool that handles platform-specific
@@ -48,18 +70,24 @@ def run_swift_action(actions, swift_toolchain, **kwargs):
 
     Since this function uses the worker as the `executable` of the underlying
     action, it is an error to pass `executable` into this function. Instead, the
-    tool to run should be the first item in the `arguments` list (or in the
-    first `Args` object). This tool should be obtained using `get_swift_tool` in
-    order to correctly handle toolchains with explicit root directories.
+    `driver_mode` argument should be used to specify which Swift tool should be
+    invoked (`swift`, `swiftc`, `swift-autolink-extract`, etc.). This lets the
+    rules correctly handle the case where a custom driver executable is provided
+    by passing the `--driver-mode` flag that overrides its internal `argv[0]`
+    handling.
 
     Args:
         actions: The `Actions` object with which to register actions.
+        arguments: The arguments to pass to the invoked action.
+        driver_mode: The mode in which to invoke the Swift driver. In other
+            words, this is the name of the executable of symlink that you want
+            to execute (e.g., `swift`, `swiftc`, `swift-autolink-extract`).
         swift_toolchain: The Swift toolchain being used to register actions.
         **kwargs: Additional arguments to `actions.run`.
     """
     if "executable" in kwargs:
         fail("run_swift_action does not support 'executable'. " +
-             "The tool to run should be the first item in 'arguments'.")
+             "Use 'driver_mode' instead.")
 
     remaining_args = dict(kwargs)
 
@@ -86,7 +114,14 @@ def run_swift_action(actions, swift_toolchain, **kwargs):
     else:
         tools = toolchain_files
 
+    driver_mode_args = actions.args()
+    driver_mode_args.add_all(_get_swift_driver_mode_args(
+        driver_mode = driver_mode,
+        swift_toolchain = swift_toolchain,
+    ))
+
     actions.run(
+        arguments = [driver_mode_args] + arguments,
         env = env,
         executable = swift_toolchain.swift_worker,
         execution_requirements = execution_requirements,

--- a/swift/internal/api.bzl
+++ b/swift/internal/api.bzl
@@ -29,7 +29,7 @@ load("@bazel_skylib//lib:new_sets.bzl", "sets")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:types.bzl", "types")
-load(":actions.bzl", "get_swift_tool", "run_swift_action")
+load(":actions.bzl", "run_swift_action")
 load(":attrs.bzl", "swift_common_rule_attrs")
 load(
     ":compiling.bzl",
@@ -600,14 +600,6 @@ def _compile(
     swiftdoc = derived_files.swiftdoc(actions, module_name = module_name)
     additional_outputs = []
 
-    # Since all actions go through the worker (whether in persistent mode or
-    # not), the actual tool we want to run (swiftc) should be the first
-    # "argument".
-    tool_args = actions.args()
-    tool_args.add(
-        get_swift_tool(swift_toolchain = swift_toolchain, tool = "swiftc"),
-    )
-
     args = actions.args()
     if _is_enabled(
         feature_configuration = feature_configuration,
@@ -758,7 +750,8 @@ def _compile(
 
     run_swift_action(
         actions = actions,
-        arguments = [tool_args, args],
+        arguments = [args],
+        driver_mode = "swiftc",
         execution_requirements = execution_requirements,
         inputs = all_inputs,
         mnemonic = "SwiftCompile",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":actions.bzl", "get_swift_tool", "run_swift_action")
+load(":actions.bzl", "run_swift_action")
 load(":derived_files.bzl", "derived_files")
 load(":providers.bzl", "SwiftInfo")
 load(":utils.bzl", "collect_cc_libraries", "get_providers")
@@ -525,16 +525,13 @@ def register_autolink_extract_action(
         toolchain: The `SwiftToolchainInfo` provider of the toolchain.
     """
     args = actions.args()
-    args.add(get_swift_tool(
-        swift_toolchain = toolchain,
-        tool = "swift-autolink-extract",
-    ))
     args.add_all(objects)
     args.add("-o", output)
 
     run_swift_action(
         actions = actions,
         arguments = [args],
+        driver_mode = "swift-autolink-extract",
         inputs = objects,
         mnemonic = "SwiftAutolinkExtract",
         outputs = [output],

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -14,7 +14,7 @@
 
 """Functions relating to debugging support during compilation and linking."""
 
-load(":actions.bzl", "get_swift_tool", "run_swift_action")
+load(":actions.bzl", "run_swift_action")
 load(":derived_files.bzl", "derived_files")
 
 def ensure_swiftmodule_is_embedded(
@@ -97,7 +97,6 @@ def _register_modulewrap_action(
         toolchain: The `SwiftToolchainInfo` provider of the toolchain.
     """
     args = actions.args()
-    args.add(get_swift_tool(swift_toolchain = toolchain, tool = "swift"))
     args.add("-modulewrap")
     args.add(swiftmodule)
 
@@ -110,6 +109,7 @@ def _register_modulewrap_action(
     run_swift_action(
         actions = actions,
         arguments = [args],
+        driver_mode = "swift",
         inputs = [swiftmodule],
         mnemonic = "SwiftModuleWrap",
         outputs = [object],

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -112,9 +112,6 @@ using this toolchain.
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this
 Swift toolchain depends on.
 """,
-        "clang_executable": """\
-`String`. The path to the `clang` executable, which is used to link binaries.
-""",
         "command_line_copts": """\
 `List` of `strings`. Flags that were passed to Bazel using the `--swiftcopt`
 command line flag. These flags have the highest precedence; they are added to
@@ -204,6 +201,14 @@ linked into the binary.
 compiling libraries or binaries with this toolchain. These flags will come first
 in compilation command lines, allowing them to be overridden by `copts`
 attributes and `--swiftcopt` flags.
+""",
+        "swift_executable": """\
+A replacement Swift driver executable.
+
+If this is `None`, the default Swift driver in the toolchain will be used.
+Otherwise, this binary will be used and `--driver-mode` will be passed to ensure
+that it is invoked in the correct mode (i.e., `swift`, `swiftc`,
+`swift-autolink-extract`, etc.).
 """,
         "swift_worker": """\
 `File`. The executable representing the worker executable used to invoke the

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -180,7 +180,6 @@ def _create_linux_toolchain(repository_ctx):
              "in your environment before invoking Bazel.")
 
     path_to_swiftc = repository_ctx.which("swiftc")
-    path_to_clang = repository_ctx.which("clang")
     root = path_to_swiftc.dirname.dirname
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
 
@@ -197,7 +196,6 @@ package(default_visibility = ["//visibility:public"])
 swift_toolchain(
     name = "toolchain",
     arch = "x86_64",
-    clang_executable = "{path_to_clang}",
     features = [{feature_list}],
     os = "linux",
     root = "{root}",
@@ -207,7 +205,6 @@ swift_toolchain(
                 '"{}"'.format(feature)
                 for feature in feature_values
             ]),
-            path_to_clang = path_to_clang,
             root = root,
         ),
     )


### PR DESCRIPTION
Refactor slightly how actions are registered in the Swift rules.

Swift toolchains now have a `swift_executable` attribute that lets the configurator replace the Swift driver used by the rules with a custom executable in their workspace. This can be useful for testing the build rules alongside compiler development, and since that file is part of the workspace and a proper input of actions, it also works correctly across remote build environments.

Also remove the no-longer-used `SwiftToolchainInfo.clang_executable` field, now that linking has migrated to the `cc_common.link` API.