### PR TITLE
Uniquify prebuilt framework search paths

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -426,6 +426,7 @@ def objc_compile_requirements(args, deps):
         depset(transitive = all_frameworks),
         format_each = "-F%s",
         map_each = paths.dirname,
+        uniquify = True,
     )
 
     # Disable the `LC_LINKER_OPTION` load commands for static framework


### PR DESCRIPTION
Prevent duplicate framework search paths when there are multiple frameworks in a single directory.

See also https://github.com/bazelbuild/rules_swift/pull/334 which similarly enabled `uniquify` for import search paths.