### PR TITLE
Add execution requirements based on Xcode availability to Swift rules that care about Xcodes.

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -377,7 +377,14 @@ def _xcode_swift_toolchain_impl(ctx):
     if custom_toolchain:
         env["TOOLCHAINS"] = custom_toolchain
 
+    # TODO(steinman): Replace this with xcode_config.execution_info once it is available.
     execution_requirements = {"requires-darwin": ""}
+    if xcode_config:
+        if xcode_config.availability() == "remote":
+            execution_requirements["no-local"] = "1"
+        elif xcode_config.availability() == "local":
+            execution_requirements["no-remote"] = "1"
+        execution_requirements["supports-xcode-requirements-set"] = "1"
 
     cc_toolchain = find_cpp_toolchain(ctx)
 


### PR DESCRIPTION
Add execution requirements based on Xcode availability to Swift rules that care about Xcodes.

This is part of a series of changes to enable Xcode autodetection, but this does not currently change behavior.

RELNOTES: None.
