### PR TITLE
Start refactoring action registration to be more "modular".

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -15,49 +15,135 @@
 """Functions for registering actions that invoke Swift tools."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:types.bzl", "types")
+load(":features.bzl", "are_all_features_enabled")
+load(":toolchain_config.bzl", "swift_toolchain_config")
 
-def _get_swift_driver_mode_args(driver_mode, swift_toolchain):
-    """Gets the arguments to pass to the worker to invoke the Swift driver.
+# The names of actions currently supported by the Swift build rules.
+swift_action_names = struct(
+    # Extracts a linker input file containing libraries to link from a compiled
+    # object file to provide autolink functionality based on `import` directives
+    # on ELF platforms.
+    AUTOLINK_EXTRACT = "SwiftAutolinkExtract",
+
+    # Compiles one or more `.swift` source files into a `.swiftmodule` and
+    # object files.
+    COMPILE = "SwiftCompile",
+
+    # Wraps a `.swiftmodule` in a `.o` file on ELF platforms so that it can be
+    # linked into a binary for debugging.
+    MODULEWRAP = "SwiftModuleWrap",
+)
+
+def _apply_configurator(configurator, prerequisites, args):
+    """Calls an action configurator with the given arguments.
+
+    This function appropriately handles whether the configurator is a Skylib
+    partial or a plain function.
 
     Args:
-        driver_mode: The mode in which to invoke the Swift driver. In other
-            words, this is the name of the executable of symlink that you want
-            to execute (e.g., `swift`, `swiftc`, `swift-autolink-extract`).
-        swift_toolchain: The Swift toolchain being used to register actions.
+        configurator: The action configurator to call.
+        prerequisites: The prerequisites struct that the configurator may use
+            to control its behavior.
+        args: The `Args` object to which the configurator will add command line
+            arguments for the tool being invoked.
 
     Returns:
-        A list of values that can be added to an `Args` object and passed to the
-        worker to invoke the command.
-
-        This method implements three kinds of "dispatch":
-
-        1.  If the toolchain provides a custom driver executable, it is invoked
-            with the requested mode passed via the `--driver_mode` argument.
-        2.  If the toolchain provides a root directory, then the returned list
-            will be the path to the executable with the same name as the driver
-            mode in the `bin` directory of that toolchain.
-        3.  If the toolchain does not provide a root, then it is assumed that
-            the tool will be available by invoking just the driver mode by name
-            (e.g., found on the system path or by another delegating tool like
-            `xcrun` from Xcode).
+        The `swift_toolchain_config.config_result` value, or `None`, that was
+        returned by the configurator.
     """
-    if swift_toolchain.swift_executable:
-        return [
-            swift_toolchain.swift_executable,
-            "--driver-mode={}".format(driver_mode),
-        ]
+    if types.is_function(configurator):
+        return configurator(prerequisites, args)
+    else:
+        return partial.call(configurator, prerequisites, args)
 
-    if swift_toolchain.root_dir:
-        return [paths.join(swift_toolchain.root_dir, "bin", driver_mode)]
+def apply_action_configs(
+        action_name,
+        args,
+        feature_configuration,
+        prerequisites,
+        swift_toolchain):
+    """Applies the action configs for the given action.
 
-    return [driver_mode]
+    TODO(b/147091143): Make this function private after the compilation actions
+    have been migrated to `run_toolchain_action`.
+
+    Args:
+        action_name: The name of the action that should be run.
+        args: The `Args` object to which command line flags will be added.
+        feature_configuration: A feature configuration obtained from
+            `swift_common.configure_features`.
+        prerequisites: An action-specific `struct` whose fields can be accessed
+            by the action configurators to add files and other dependent data to
+            the command line.
+        swift_toolchain: The Swift toolchain being used to build.
+
+    Returns:
+        A `swift_toolchain_config.action_inputs` value that contains the files
+        that are required inputs of the action, as determined by the
+        configurators.
+    """
+    inputs = []
+    transitive_inputs = []
+
+    for action_config in swift_toolchain.action_configs:
+        # Skip the action config if it does not apply to the requested action.
+        if action_name not in action_config.actions:
+            continue
+
+        if action_config.features == None:
+            # If the feature list was `None`, unconditionally apply the
+            # configurators.
+            should_apply_configurators = True
+        else:
+            # Check each of the feature lists to determine if any of them has
+            # all of its features satisfied by the feature configuration.
+            should_apply_configurators = False
+            for feature_names in action_config.features:
+                if are_all_features_enabled(
+                    feature_configuration = feature_configuration,
+                    feature_names = feature_names,
+                ):
+                    should_apply_configurators = True
+                    break
+
+        # If one of the feature lists is completely satisfied, invoke the
+        # configurators.
+        if should_apply_configurators:
+            for configurator in action_config.configurators:
+                action_inputs = _apply_configurator(
+                    configurator,
+                    prerequisites,
+                    args,
+                )
+                if action_inputs:
+                    inputs.extend(action_inputs.inputs)
+                    transitive_inputs.extend(action_inputs.transitive_inputs)
+
+    # Merge the action results into a single result that we return.
+    return swift_toolchain_config.config_result(
+        inputs = inputs,
+        transitive_inputs = transitive_inputs,
+    )
+
+def is_action_enabled(action_name, swift_toolchain):
+    """Returns True if the given action is enabled in the Swift toolchain.
+
+    Args:
+        action_name: The name of the action.
+        swift_toolchain: The Swift toolchain being used to build.
+
+    Returns:
+        True if the action is enabled, or False if it is not.
+    """
+    tool_config = swift_toolchain.tool_configs.get(action_name)
+    return bool(tool_config)
 
 def run_swift_action(
         actions,
+        action_name,
         arguments,
-        driver_mode,
         swift_toolchain,
         **kwargs):
     """Executes the Swift driver using the worker.
@@ -76,12 +162,14 @@ def run_swift_action(
     by passing the `--driver-mode` flag that overrides its internal `argv[0]`
     handling.
 
+    TODO(b/147091143): Remove this once all actions have migrated off of it.
+
     Args:
         actions: The `Actions` object with which to register actions.
+        action_name: The name of the toolchain action to run. This is used to
+            retrieve the configured tool's environment and execution
+            requirements during the migration phase.
         arguments: The arguments to pass to the invoked action.
-        driver_mode: The mode in which to invoke the Swift driver. In other
-            words, this is the name of the executable of symlink that you want
-            to execute (e.g., `swift`, `swiftc`, `swift-autolink-extract`).
         swift_toolchain: The Swift toolchain being used to register actions.
         **kwargs: Additional arguments to `actions.run`.
     """
@@ -93,13 +181,11 @@ def run_swift_action(
 
     # Note that we add the toolchain values second; we do not want the caller to
     # ever be able to override those values.
-    env = dicts.add(
-        remaining_args.pop("env", None) or {},
-        swift_toolchain.action_environment or {},
-    )
+    tool_config = swift_toolchain.tool_configs.get(action_name)
+    env = dicts.add(remaining_args.pop("env", None) or {}, tool_config.env)
     execution_requirements = dicts.add(
         remaining_args.pop("execution_requirements", None) or {},
-        swift_toolchain.execution_requirements or {},
+        tool_config.execution_requirements,
     )
 
     # Add the toolchain's files to the `tools` argument of the action.
@@ -115,10 +201,8 @@ def run_swift_action(
         tools = toolchain_files
 
     driver_mode_args = actions.args()
-    driver_mode_args.add_all(_get_swift_driver_mode_args(
-        driver_mode = driver_mode,
-        swift_toolchain = swift_toolchain,
-    ))
+    driver_mode_args.add(tool_config.executable)
+    driver_mode_args.add_all(tool_config.args)
 
     actions.run(
         arguments = [driver_mode_args] + arguments,
@@ -127,4 +211,96 @@ def run_swift_action(
         execution_requirements = execution_requirements,
         tools = tools,
         **remaining_args
+    )
+
+def run_toolchain_action(
+        actions,
+        action_name,
+        feature_configuration,
+        prerequisites,
+        swift_toolchain,
+        mnemonic = None,
+        **kwargs):
+    """Runs an action using the toolchain's tool and action configurations.
+
+    Args:
+        actions: The rule context's `Actions` object, which will be used to
+            create `Args` objects.
+        action_name: The name of the action that should be run.
+        feature_configuration: A feature configuration obtained from
+            `swift_common.configure_features`.
+        mnemonic: The mnemonic to associate with the action. If not provided,
+            the action name itself will be used.
+        prerequisites: An action-specific `struct` whose fields can be accessed
+            by the action configurators to add files and other dependent data to
+            the command line.
+        swift_toolchain: The Swift toolchain being used to build.
+        **kwargs: Additional arguments passed directly to `actions.run`.
+    """
+    tool_config = swift_toolchain.tool_configs.get(action_name)
+    if not tool_config:
+        fail(
+            "There is no tool configured for the action " +
+            "'{}' in this toolchain. If this action is ".format(action_name) +
+            "supported conditionally, you must call 'is_action_enabled' " +
+            "before attempting to register it.",
+        )
+
+    args = actions.args()
+    if tool_config.use_param_file:
+        args.set_param_file_format("multiline")
+        args.use_param_file("@%s", use_always = True)
+
+    execution_requirements = dict(tool_config.execution_requirements)
+
+    # If the tool configuration says to use the worker process, then use the
+    # worker as the actual executable and pass the tool as the first argument
+    # (and as a tool input). Otherwise, just use the tool as the executable
+    # directly.
+    tools = []
+    if tool_config.worker_mode:
+        # Only enable persistent workers if the toolchain supports response
+        # files, because the worker unconditionally writes its arguments into
+        # one to prevent command line overflow in this mode.
+        if (
+            tool_config.worker_mode == "persistent" and
+            tool_config.use_param_file
+        ):
+            execution_requirements["supports-workers"] = 1
+
+        executable = swift_toolchain.swift_worker
+        args.add(tool_config.executable)
+        if not types.is_string(tool_config.executable):
+            tools.append(tool_config.executable)
+    else:
+        executable = tool_config.executable
+    tools.extend(tool_config.additional_tools)
+
+    # If the tool configuration has any required arguments, add those first.
+    if tool_config.args:
+        args.add_all(tool_config.args)
+
+    # Apply the action configs that are relevant based on the requested action
+    # and feature configuration, to populate the `Args` object and collect the
+    # required inputs.
+    action_inputs = apply_action_configs(
+        action_name = action_name,
+        args = args,
+        feature_configuration = feature_configuration,
+        prerequisites = prerequisites,
+        swift_toolchain = swift_toolchain,
+    )
+
+    actions.run(
+        arguments = [args],
+        env = tool_config.env,
+        executable = executable,
+        execution_requirements = execution_requirements,
+        inputs = depset(
+            action_inputs.inputs,
+            transitive = action_inputs.transitive_inputs,
+        ),
+        mnemonic = mnemonic if mnemonic else action_name,
+        tools = tools,
+        **kwargs
     )

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -16,9 +16,10 @@
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load(":actions.bzl", "run_swift_action")
+load(":actions.bzl", "run_toolchain_action", "swift_action_names")
 load(":derived_files.bzl", "derived_files")
 load(":providers.bzl", "SwiftInfo")
+load(":toolchain_config.bzl", "swift_toolchain_config")
 load(":utils.bzl", "collect_cc_libraries", "get_providers")
 
 def collect_transitive_compile_inputs(args, deps, direct_defines = []):
@@ -501,12 +502,43 @@ def output_groups_from_compilation_outputs(compilation_outputs):
 
     return output_groups
 
+def autolink_extract_action_configs():
+    """Returns the list of action configs needed to perform autolink extraction.
+
+    If a toolchain supports autolink extraction, it should add these to its list
+    of action configs so that those actions will be correctly configured.
+
+    Returns:
+        The list of action configs needed to perform autolink extraction.
+    """
+    return [
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.AUTOLINK_EXTRACT],
+            configurators = [
+                _autolink_extract_input_configurator,
+                _autolink_extract_output_configurator,
+            ],
+        ),
+    ]
+
+def _autolink_extract_input_configurator(prerequisites, args):
+    """Configures the inputs of the autolink-extract action."""
+    object_files = prerequisites.object_files
+
+    args.add_all(object_files)
+    return swift_toolchain_config.config_result(inputs = object_files)
+
+def _autolink_extract_output_configurator(prerequisites, args):
+    """Configures the outputs of the autolink-extract action."""
+    args.add("-o", prerequisites.autolink_file)
+
 def register_autolink_extract_action(
         actions,
+        feature_configuration,
         module_name,
         objects,
         output,
-        toolchain):
+        swift_toolchain):
     """Extracts autolink information from Swift `.o` files.
 
     For some platforms (such as Linux), autolinking of imported frameworks is
@@ -517,28 +549,28 @@ def register_autolink_extract_action(
 
     Args:
         actions: The object used to register actions.
+        feature_configuration: The Swift feature configuration.
         module_name: The name of the module to which the `.o` files belong (used
             when generating the progress message).
         objects: The list of object files whose autolink information will be
             extracted.
         output: A `File` into which the autolink information will be written.
-        toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
     """
-    args = actions.args()
-    args.add_all(objects)
-    args.add("-o", output)
-
-    run_swift_action(
+    prerequisites = struct(
+        autolink_file = output,
+        object_files = objects,
+    )
+    run_toolchain_action(
         actions = actions,
-        arguments = [args],
-        driver_mode = "swift-autolink-extract",
-        inputs = objects,
-        mnemonic = "SwiftAutolinkExtract",
+        action_name = swift_action_names.AUTOLINK_EXTRACT,
+        feature_configuration = feature_configuration,
         outputs = [output],
+        prerequisites = prerequisites,
         progress_message = (
             "Extracting autolink data for Swift module {}".format(module_name)
         ),
-        swift_toolchain = toolchain,
+        swift_toolchain = swift_toolchain,
     )
 
 def swift_library_output_map(name, alwayslink):

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -14,14 +14,16 @@
 
 """Functions relating to debugging support during compilation and linking."""
 
-load(":actions.bzl", "run_swift_action")
+load(":actions.bzl", "run_toolchain_action", "swift_action_names")
 load(":derived_files.bzl", "derived_files")
+load(":toolchain_config.bzl", "swift_toolchain_config")
 
 def ensure_swiftmodule_is_embedded(
         actions,
+        feature_configuration,
         swiftmodule,
         target_name,
-        toolchain):
+        swift_toolchain):
     """Ensures that a `.swiftmodule` file is embedded in a library or binary.
 
     This function handles the distinctions between how different object file
@@ -30,9 +32,10 @@ def ensure_swiftmodule_is_embedded(
 
     Args:
         actions: The object used to register actions.
+        feature_configuration: The Swift feature configuration.
         swiftmodule: The `.swiftmodule` file to be wrapped.
         target_name: The name of the target being built.
-        toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
 
     Returns:
       A `struct` containing three fields:
@@ -49,7 +52,7 @@ def ensure_swiftmodule_is_embedded(
     linker_inputs = []
     objects_to_link = []
 
-    if toolchain.object_format == "elf":
+    if swift_toolchain.object_format == "elf":
         # For ELF-format binaries, we need to invoke a Swift modulewrap action
         # to wrap the .swiftmodule file in a .o file that gets propagated to the
         # linker.
@@ -61,16 +64,17 @@ def ensure_swiftmodule_is_embedded(
 
         _register_modulewrap_action(
             actions = actions,
+            feature_configuration = feature_configuration,
             object = modulewrap_obj,
             swiftmodule = swiftmodule,
-            toolchain = toolchain,
+            swift_toolchain = swift_toolchain,
         )
-    elif toolchain.object_format == "macho":
+    elif swift_toolchain.object_format == "macho":
         linker_flags.append("-Wl,-add_ast_path,{}".format(swiftmodule.path))
         linker_inputs.append(swiftmodule)
     else:
         fail("Internal error: Unexpected object format '{}'.".format(
-            toolchain.object_format,
+            swift_toolchain.object_format,
         ))
 
     return struct(
@@ -79,11 +83,42 @@ def ensure_swiftmodule_is_embedded(
         objects_to_link = objects_to_link,
     )
 
+def modulewrap_action_configs():
+    """Returns the list of action configs needed to perform module wrapping.
+
+    If a toolchain supports module wrapping, it should add these to its list of
+    action configs so that those actions will be correctly configured.
+
+    Returns:
+        The list of action configs needed to perform module wrapping.
+    """
+    return [
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.MODULEWRAP],
+            configurators = [
+                _modulewrap_input_configurator,
+                _modulewrap_output_configurator,
+            ],
+        ),
+    ]
+
+def _modulewrap_input_configurator(prerequisites, args):
+    """Configures the inputs of the modulewrap action."""
+    swiftmodule_file = prerequisites.swiftmodule_file
+
+    args.add(swiftmodule_file)
+    return swift_toolchain_config.config_result(inputs = [swiftmodule_file])
+
+def _modulewrap_output_configurator(prerequisites, args):
+    """Configures the outputs of the modulewrap action."""
+    args.add("-o", prerequisites.object_file)
+
 def _register_modulewrap_action(
         actions,
+        feature_configuration,
         object,
         swiftmodule,
-        toolchain):
+        swift_toolchain):
     """Wraps a Swift module in a `.o` file that can be linked into a binary.
 
     This step (invoking `swift -modulewrap`) is required for the `.swiftmodule`
@@ -92,29 +127,23 @@ def _register_modulewrap_action(
 
     Args:
         actions: The object used to register actions.
+        feature_configuration: The Swift feature configuration.
         object: The object file that will be produced by the modulewrap task.
         swiftmodule: The `.swiftmodule` file to be wrapped.
-        toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
     """
-    args = actions.args()
-    args.add("-modulewrap")
-    args.add(swiftmodule)
-
-    # Awkward workaround because Bazel's C++ toolchain returns "local" instead
-    # of a real triple.
-    if toolchain.cc_toolchain_info.target_gnu_system_name != "local":
-        args.add("-target", toolchain.cc_toolchain_info.target_gnu_system_name)
-    args.add("-o", object)
-
-    run_swift_action(
+    prerequisites = struct(
+        object_file = object,
+        swiftmodule_file = swiftmodule,
+    )
+    run_toolchain_action(
         actions = actions,
-        arguments = [args],
-        driver_mode = "swift",
-        inputs = [swiftmodule],
-        mnemonic = "SwiftModuleWrap",
+        action_name = swift_action_names.MODULEWRAP,
+        feature_configuration = feature_configuration,
         outputs = [object],
+        prerequisites = prerequisites,
         progress_message = (
             "Wrapping {} for debugging".format(swiftmodule.short_path)
         ),
-        swift_toolchain = toolchain,
+        swift_toolchain = swift_toolchain,
     )

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -99,9 +99,8 @@ Propagates information about a Swift toolchain to compilation and linking rules
 that use the toolchain.
 """,
     fields = {
-        "action_environment": """\
-`Dict`. Environment variables that should be set during any actions spawned to
-compile or link Swift code.
+        "action_configs": """\
+This field is an internal implementation detail of the build rules.
 """,
         "all_files": """\
 A `depset` of `File`s containing all the Swift toolchain files (tools,
@@ -121,13 +120,6 @@ attributes of Swift targets.
 """,
         "cpu": """\
 `String`. The CPU architecture that the toolchain is targeting.
-""",
-        "execution_requirements": """\
-`Dict`. Execution requirements that should be passed to any actions spawned to
-compile or link Swift code.
-
-For example, when using an Xcode toolchain, the execution requirements should be
-such that running on Darwin is required.
 """,
         "linker_opts_producer": """\
 Skylib `partial`. A partial function that returns the flags that should be
@@ -196,20 +188,6 @@ linked into the binary.
         "supports_objc_interop": """\
 `Boolean`. Indicates whether or not the toolchain supports Objective-C interop.
 """,
-        "swiftc_copts": """\
-`List` of `strings`. Additional flags that should be passed to `swiftc` when
-compiling libraries or binaries with this toolchain. These flags will come first
-in compilation command lines, allowing them to be overridden by `copts`
-attributes and `--swiftcopt` flags.
-""",
-        "swift_executable": """\
-A replacement Swift driver executable.
-
-If this is `None`, the default Swift driver in the toolchain will be used.
-Otherwise, this binary will be used and `--driver-mode` will be passed to ensure
-that it is invoked in the correct mode (i.e., `swift`, `swiftc`,
-`swift-autolink-extract`, etc.).
-""",
         "swift_worker": """\
 `File`. The executable representing the worker executable used to invoke the
 compiler and other Swift tools (for both incremental and non-incremental
@@ -217,6 +195,21 @@ compiles).
 """,
         "system_name": """\
 `String`. The name of the operating system that the toolchain is targeting.
+""",
+        "test_configuration": """\
+`Struct` containing two fields:
+
+*   `env`: A `dict` of environment variables to be set when running tests
+    that were built with this toolchain.
+*   `execution_requirements`: A `dict` of execution requirements for tests
+    that were built with this toolchain.
+
+This is used, for example, with Xcode-based toolchains to ensure that the
+`xctest` helper and coverage tools are found in the correct developer
+directory when running tests.
+""",
+        "tool_configs": """\
+This field is an internal implementation detail of the build rules.
 """,
         "unsupported_features": """\
 `List` of `string`s. Features that should be implicitly disabled by default for

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -401,7 +401,7 @@ def _swift_test_impl(ctx):
         executable = binary
 
     test_environment = dicts.add(
-        swift_toolchain.action_environment,
+        swift_toolchain.test_configuration.env,
         {"TEST_BINARIES_FOR_LLVM_COV": binary.short_path},
     )
 
@@ -422,7 +422,9 @@ def _swift_test_impl(ctx):
             extensions = ["swift"],
             source_attributes = ["srcs"],
         ),
-        testing.ExecutionInfo(swift_toolchain.execution_requirements),
+        testing.ExecutionInfo(
+            swift_toolchain.test_configuration.execution_requirements,
+        ),
         testing.TestEnvironment(test_environment),
     ]
 

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -1,0 +1,333 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Definitions used to configure toolchains and actions."""
+
+load("@bazel_skylib//lib:partial.bzl", "partial")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:types.bzl", "types")
+
+_ActionConfigInfo = provider(
+    doc = "An action configuration in the Swift toolchain.",
+    fields = [
+        "actions",
+        "configurators",
+        "features",
+    ],
+)
+
+_ConfigResultInfo = provider(
+    doc = "The inputs required by an action configurator.",
+    fields = [
+        "inputs",
+        "transitive_inputs",
+    ],
+)
+
+_ToolConfigInfo = provider(
+    doc = "A tool used by the Swift toolchain and its requirements.",
+    fields = [
+        "additional_tools",
+        "args",
+        "env",
+        "executable",
+        "execution_requirements",
+        "use_param_file",
+        "worker_mode",
+    ],
+)
+
+def _normalize_action_config_features(features):
+    """Validates and normalizes the `features` of an `action_config`.
+
+    This method validates that the argument is either `None`, a non-empty
+    list of strings, or a non-empty list of lists of strings. If the argument is
+    the shorthand form (a list of strings), it is normalized by wrapping it in
+    an outer list so that action building code does not need to be concerned
+    about the distinction.
+
+    Args:
+        features: The `features` argument passed to `action_config`.
+
+    Returns:
+        The `features` argument, normalized if necessary.
+    """
+    if features == None:
+        return features
+
+    failure_message = (
+        "The 'features' argument passed to " +
+        "'swift_toolchain_config.action_config' must be either None, a list " +
+        "of strings, or a list of lists of strings.",
+    )
+
+    # Fail if the argument is not a list, or if it is but it is empty.
+    if not types.is_list(features) or not features:
+        fail(failure_message)
+
+    outer_list_has_strings = False
+    outer_list_has_lists = False
+
+    # Check each element in the list to determine if it is a list of lists
+    # or a list of strings.
+    for element in features:
+        if types.is_list(element):
+            outer_list_has_lists = True
+        elif types.is_string(element) and element:
+            outer_list_has_strings = True
+        else:
+            fail(failure_message)
+
+    # Forbid mixing lists and strings at the top-level.
+    if outer_list_has_strings and outer_list_has_lists:
+        fail(failure_message)
+
+    # If the original list was a list of strings, wrap it before returning it
+    # to the caller.
+    if outer_list_has_strings:
+        return [features]
+
+    # Otherwise, return the original list of lists.
+    return features
+
+def _action_config(actions, configurators, features = None):
+    """Returns a new Swift toolchain action configuration.
+
+    This function validates the inputs, causing the build to fail if they have
+    incorrect types or are otherwise invalid.
+
+    Args:
+        actions: A `list` of strings denoting the names of the actions for
+            which the configurators should be invoked.
+        configurators: A `list` of functions or Skylib partials that will be
+            invoked to add command line arguments and collect inputs for the
+            actions. These functions/partials take two arguments---a
+            `prerequisites` struct and an `Args` object---and return a `depset`
+            of `File`s that should be used as inputs to the action (or `None`
+            if the configurator does not add any inputs).
+        features: The `list` of features that must be enabled for the
+            configurators to be applied to the action. This argument can take
+            one of three forms: `None` (the default), in which case the
+            configurators are unconditionally applied; a non-empty `list` of
+            `list`s of feature names (strings), in which case *all* features
+            mentioned in *one* of the inner lists must be enabled; or a single
+            non-empty `list` of feature names, which is a shorthand form
+            equivalent to that single list wrapped in another list.
+
+    Returns:
+        A validated action configuration.
+    """
+    return _ActionConfigInfo(
+        actions = actions,
+        configurators = configurators,
+        features = _normalize_action_config_features(features),
+    )
+
+def _add_arg_impl(
+        arg_name_or_value,
+        value,
+        prerequisites,
+        args,
+        format = None):
+    """Implementation function for the `add_arg` convenience configurator.
+
+    Args:
+        arg_name_or_value: The `arg_name_or_value` passed to `Args.add`. Bound
+            at partial creation time.
+        value: The `value` passed to `Args.add`. Bound at partial creation
+            time.
+        prerequisites: Unused by this function.
+        args: The `Args` object to which flags will be added.
+        format: The `format` passed to `Args.add`. Bound at partial creation
+            time.
+    """
+    _unused = [prerequisites]
+
+    # `Args.add` doesn't permit the `value` argument to be `None`, only
+    # "unbound", so we have to check for this and not pass it *at all* if it
+    # wasn't specified when the partial was created.
+    if value == None:
+        args.add(arg_name_or_value, format = format)
+    else:
+        args.add(arg_name_or_value, value, format = format)
+
+def _add_arg(arg_name_or_value, value = None, format = None):
+    """Returns a configurator that adds a simple argument to the command line.
+
+    This is provided as a convenience for the simple case where a configurator
+    wishes to add a flag to the command line, perhaps based on the enablement
+    of a feature, without writing a separate function solely for that one flag.
+
+    Args:
+        arg_name_or_value: The `arg_name_or_value` argument that will be passed
+            to `Args.add`.
+        value: The `value` argument that will be passed to `Args.add` (`None`
+            by default).
+        format: The `format` argument that will be passed to `Args.add` (`None`
+            by default).
+
+    Returns:
+        A Skylib `partial` that can be added to the `configurators` list of an
+        `action_config`.
+    """
+    return partial.make(
+        _add_arg_impl,
+        arg_name_or_value,
+        value,
+        format = format,
+    )
+
+def _config_result(inputs = [], transitive_inputs = []):
+    """Returns a value that can be returned from an action configurator.
+
+    Args:
+        inputs: A list of `File`s that should be passed as inputs to the action
+            being configured.
+        transitive_inputs: A list of `depset`s of `File`s that should be passed
+            as inputs to the action being configured.
+
+    Returns:
+        A new config result that can be returned from a configurator.
+    """
+    return _ConfigResultInfo(
+        inputs = inputs,
+        transitive_inputs = transitive_inputs,
+    )
+
+def _driver_tool_config(
+        driver_mode,
+        args = [],
+        swift_executable = None,
+        toolchain_root = None,
+        **kwargs):
+    """Returns a new Swift toolchain tool configuration for the Swift driver.
+
+    This is a convenience function that supports the various ways that the Swift
+    driver can have its location specified or overridden by the build rules,
+    such as by providing a toolchain root directory or a custom executable. It
+    supports three kinds of "dispatch":
+
+    1.  If the toolchain provides a custom driver executable, the returned tool
+        config invokes it with the requested mode passed via the `--driver_mode`
+        argument.
+    2.  If the toolchain provides a root directory, then the returned tool
+        config will use an executable that is a string with the same name as the
+        driver mode in the `bin` directory of that toolchain.
+    3.  If the toolchain does not provide a root, then the returned tool config
+        simply uses the driver mode as the executable, assuming that it will be
+        available by invoking that alone (e.g., it will be found on the system
+        path or by another delegating tool like `xcrun` from Xcode).
+
+    Args:
+        driver_mode: The mode in which to invoke the Swift driver. In other
+            words, this is the name of the executable of symlink that you want
+            to execute (e.g., `swift`, `swiftc`, `swift-autolink-extract`).
+        args: A list of arguments that are always passed to the driver.
+        swift_executable: A custom Swift driver executable, if provided by the
+            toolchain.
+        toolchain_root: The root directory of the Swift toolchain, if the
+            toolchain provides it.
+        **kwargs: Additional arguments that will be passed unmodified to
+            `swift_toolchain_config.tool_config`.
+
+    Returns:
+        A new tool configuration.
+    """
+    if swift_executable:
+        executable = swift_executable
+        args = ["--driver-mode={}".format(driver_mode)] + args
+    elif toolchain_root:
+        executable = paths.join(toolchain_root, "bin", driver_mode)
+    else:
+        executable = driver_mode
+
+    return _tool_config(args = args, executable = executable, **kwargs)
+
+def _validate_worker_mode(worker_mode):
+    """Validates the `worker_mode` argument of `tool_config`.
+
+    This function fails the build if the worker mode is not None, "persistent",
+    or "wrap".
+
+    Args:
+        worker_mode: The worker mode to validate.
+
+    Returns:
+        The original worker mode, if it was valid.
+    """
+    if worker_mode != None and worker_mode not in ("persistent", "wrap"):
+        fail(
+            "The 'worker_mode' argument of " +
+            "'swift_toolchain_config.tool_config' must be either None, " +
+            "'persistent', or 'wrap'.",
+        )
+
+    return worker_mode
+
+def _tool_config(
+        executable,
+        additional_tools = [],
+        args = [],
+        env = {},
+        execution_requirements = {},
+        use_param_file = False,
+        worker_mode = None):
+    """Returns a new Swift toolchain tool configuration.
+
+    Args:
+        executable: The `File` or `string` denoting the tool that should be
+            executed. This will be used as the `executable` argument of spawned
+            actions unless `worker_mode` is set, in which case it will be used
+            as the first argument to the worker.
+        additional_tools: A list of `File`s denoting additional tools that
+            should be passed as inputs to actions that use this tool. This
+            should be used if `executable` is, for example, a symlink that
+            points to another executable or if it is a driver that launches
+            other executables as subprocesses.
+        args: A list of arguments that are always passed to the tool.
+        env: A dictionary of environment variables that should be set when
+            invoking actions using this tool.
+        execution_requirements: A dictionary of execution requirements that
+            should be passed when creating actions with this tool.
+        use_param_file: If True, actions invoked using this tool will have their
+            arguments written to a param file.
+        worker_mode: A string, or `None`, describing how the tool is invoked
+            using the build rules' worker, if at all. If `None`, the tool will
+            be invoked directly. If `"wrap"`, the tool will be wrapped in an
+            invocation of the worker but otherwise run as a single process. If
+            `"persistent"`, then the action will be launched with execution
+            requirements that indicate that Bazel should attempt to use a
+            persistent worker if the spawn strategy allows for it (starting a
+            new instance if necessary, or connecting to an existing one).
+
+    Returns:
+        A new tool configuration.
+    """
+    return _ToolConfigInfo(
+        additional_tools = additional_tools,
+        args = args,
+        env = env,
+        executable = executable,
+        execution_requirements = execution_requirements,
+        use_param_file = use_param_file,
+        worker_mode = _validate_worker_mode(worker_mode),
+    )
+
+swift_toolchain_config = struct(
+    action_config = _action_config,
+    add_arg = _add_arg,
+    config_result = _config_result,
+    driver_tool_config = _driver_tool_config,
+    tool_config = _tool_config,
+)


### PR DESCRIPTION
Start refactoring action registration to be more "modular".

Inspired loosely by CROSSTOOL, this lets us split out various parts of toolchain and action configuration so that they can be shared among multiple actions. This will be critical when the build rules start supporting actions other than SwiftCompile, such as emitting precompiled modules for C/Obj-C dependencies.

There are two concepts: a tool config and an action config. A tool config describes an executable and some of its properties (its environment, execution requirements, etc.). This means these can now differ between different tools in the same toolchain (previously, all tools shared the same environment and exec reqs). An action config describes how args and inputs are decided for an action, based on which features are set in the feature configuration.

I've tried to keep this change from getting too large, so only the toolchain-specific compiler flags and the ModuleWrap and AutolinkExtract actions have been migrated over to the new logic. The Compile action has been mostly left alone, except where necessary to use the new APIs, and will be migrated separately.

RELNOTES: None.
