### PR TITLE
Move autolink-related logic out of compiling.bzl and into its own file.

### DIFF
--- a/swift/internal/autolinking.bzl
+++ b/swift/internal/autolinking.bzl
@@ -1,0 +1,90 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of autolink logic for Swift."""
+
+load(":actions.bzl", "run_toolchain_action", "swift_action_names")
+load(":toolchain_config.bzl", "swift_toolchain_config")
+
+def _autolink_extract_input_configurator(prerequisites, args):
+    """Configures the inputs of the autolink-extract action."""
+    object_files = prerequisites.object_files
+
+    args.add_all(object_files)
+    return swift_toolchain_config.config_result(inputs = object_files)
+
+def _autolink_extract_output_configurator(prerequisites, args):
+    """Configures the outputs of the autolink-extract action."""
+    args.add("-o", prerequisites.autolink_file)
+
+def autolink_extract_action_configs():
+    """Returns the list of action configs needed to perform autolink extraction.
+
+    If a toolchain supports autolink extraction, it should add these to its list
+    of action configs so that those actions will be correctly configured.
+
+    Returns:
+        The list of action configs needed to perform autolink extraction.
+    """
+    return [
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.AUTOLINK_EXTRACT],
+            configurators = [
+                _autolink_extract_input_configurator,
+                _autolink_extract_output_configurator,
+            ],
+        ),
+    ]
+
+def register_autolink_extract_action(
+        actions,
+        autolink_file,
+        feature_configuration,
+        module_name,
+        object_files,
+        swift_toolchain):
+    """Extracts autolink information from Swift `.o` files.
+
+    For some platforms (such as Linux), autolinking of imported frameworks is
+    achieved by extracting the information about which libraries are needed from
+    the `.o` files and producing a text file with the necessary linker flags.
+    That file can then be passed to the linker as a response file (i.e.,
+    `@flags.txt`).
+
+    Args:
+        actions: The object used to register actions.
+        autolink_file: A `File` into which the autolink information will be
+            written.
+        feature_configuration: The Swift feature configuration.
+        module_name: The name of the module to which the `.o` files belong (used
+            when generating the progress message).
+        object_files: The list of object files whose autolink information will
+            be extracted.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+    """
+    prerequisites = struct(
+        autolink_file = autolink_file,
+        object_files = object_files,
+    )
+    run_toolchain_action(
+        actions = actions,
+        action_name = swift_action_names.AUTOLINK_EXTRACT,
+        feature_configuration = feature_configuration,
+        outputs = [autolink_file],
+        prerequisites = prerequisites,
+        progress_message = (
+            "Extracting autolink data for Swift module {}".format(module_name)
+        ),
+        swift_toolchain = swift_toolchain,
+    )

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -24,7 +24,7 @@ load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
-load(":compiling.bzl", "autolink_extract_action_configs")
+load(":autolinking.bzl", "autolink_extract_action_configs")
 load(":debugging.bzl", "modulewrap_action_configs")
 load(
     ":features.bzl",


### PR DESCRIPTION
Move autolink-related logic out of compiling.bzl and into its own file.

Also clean up the parameter names slightly, and make a minor tweak to the behavior so that objects output by modulewrap don't get passed to autolink-extract (they aren't harmful, but they aren't helpful either).

RELNOTES: None.
