### PR TITLE
Add vfsoverlay feature for improved compilation performance

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1978,6 +1978,10 @@ roots:
     name: \"{}\"
     contents:""".format(virtual_import_search_path)
 
+    if not swiftmodules:
+        contents += " []"
+        return contents
+
     for swiftmodule in swiftmodules:
         contents += """
       - type: file

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -836,7 +836,11 @@ def _dependencies_swiftmodules_configurator(prerequisites, args):
 
 def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args):
     """Provides a single `.swiftmodule` search path using a vfsoverlay."""
-    swiftmodules = prerequisites.swift_info.transitive_swiftmodules
+    swiftmodules = depset([
+        module.swift.swiftmodule
+        for module in prerequisites.transitive_modules
+        if module.swift
+    ])
 
     # Bug: `swiftc` doesn't pass its `-vfsoverlay` arg to the frontend.
     # Workaround: Pass `-vfsoverlay` directly via `-Xfrontend`.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1311,6 +1311,8 @@ def _declare_compile_outputs(
         user_compile_flags: The flags that will be passed to the compile action,
             which are scanned to determine whether a single frontend invocation
             will be used or not.
+        swift_info: The merged SwiftInfo representing the action's Swift
+            dependencies.
 
     Returns:
         A tuple containing two elements:

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -225,6 +225,28 @@ def _swiftc_output_file_map(actions, target_name):
     """
     return actions.declare_file("{}.output_file_map.json".format(target_name))
 
+def _swiftc_vfsoverlay(actions, module_name):
+    """Declares a file for the vfsoverlay for a compilation action.
+
+    The vfsoverlay is YAML-formatted file that allows us to provide a single
+    import search path argument, instead of one import search path per package.
+    This defines a virtual file system, independent of the real file system
+    layout.
+
+    Using a single import search path can avoid the worst case: a quadratic
+    search to find N modules (transitive dependencies) in N directories. For
+    targets with large transitive dependency sets, this can bring significant
+    improvements to compile times.
+
+    Args:
+        actions: The context's actions object.
+        module_name: The name of the module being built.
+
+    Returns:
+        The declared `File`.
+    """
+    return actions.declare_file("{}.vfsoverlay.yaml".format(module_name))
+
 def _swiftdoc(actions, module_name):
     """Declares a file for the Swift doc file created by a compilation rule.
 
@@ -315,6 +337,7 @@ derived_files = struct(
     static_archive = _static_archive,
     stats_directory = _stats_directory,
     swiftc_output_file_map = _swiftc_output_file_map,
+    swiftc_vfsoverlay = _swiftc_vfsoverlay,
     swiftdoc = _swiftdoc,
     swiftinterface = _swiftinterface,
     swiftmodule = _swiftmodule,

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -233,11 +233,6 @@ def _swiftc_vfsoverlay(actions, module_name):
     This defines a virtual file system, independent of the real file system
     layout.
 
-    Using a single import search path can avoid the worst case: a quadratic
-    search to find N modules (transitive dependencies) in N directories. For
-    targets with large transitive dependency sets, this can bring significant
-    improvements to compile times.
-
     Args:
         actions: The context's actions object.
         module_name: The name of the module being built.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -176,3 +176,14 @@ SWIFT_FEATURE_EMIT_SWIFTINTERFACE = "swift.emit_swiftinterface"
 # This allows Bazel to avoid propagating swiftmodules of such dependencies
 # higher in the dependency graph than they need to be.
 SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
+
+# If enabled, Swift compilation actions will use a single import search path by
+# generating a vfsoverlay containing a single virtual swiftmodule directory.
+# For Swift actions with large transitive dependency sets, this results in
+# faster searching of swiftmodules, and faster compilation times.
+#
+# Using a single import search path can avoid the worst case: a quadratic
+# search to find N modules (transitive dependencies) in N directories. For
+# targets with large transitive dependency sets, this can bring significant
+# improvements to compile times.
+SWIFT_FEATURE_ENABLE_VFSOVERLAYS = "swift.enable_vfsoverlays"

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -23,17 +23,6 @@ load(
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
 )
 
-# If enabled, Swift compilation actions will use a single import search path by
-# generating a vfsoverlay containing a single virtual swiftmodule directory.
-# For Swift actions with large transitive dependency sets, this results in
-# faster searching of swiftmodules, and faster compilation times.
-#
-# Using a single import search path can avoid the worst case: a quadratic
-# search to find N modules (transitive dependencies) in N directories. For
-# targets with large transitive dependency sets, this can bring significant
-# improvements to compile times.
-SWIFT_FEATURE_ENABLE_VFSOVERLAYS = "swift.enable_vfsoverlays"
-
 def are_all_features_enabled(feature_configuration, feature_names):
     """Returns `True` if all features are enabled in the feature configuration.
 

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -27,6 +27,11 @@ load(
 # generating a vfsoverlay containing a single virtual swiftmodule directory.
 # For Swift actions with large transitive dependency sets, this results in
 # faster searching of swiftmodules, and faster compilation times.
+#
+# Using a single import search path can avoid the worst case: a quadratic
+# search to find N modules (transitive dependencies) in N directories. For
+# targets with large transitive dependency sets, this can bring significant
+# improvements to compile times.
 SWIFT_FEATURE_ENABLE_VFSOVERLAYS = "swift.enable_vfsoverlays"
 
 def are_all_features_enabled(feature_configuration, feature_names):

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -23,6 +23,12 @@ load(
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
 )
 
+# If enabled, Swift compilation actions will use a single import search path by
+# generating a vfsoverlay containing a single virtual swiftmodule directory.
+# For Swift actions with large transitive dependency sets, this results in
+# faster searching of swiftmodules, and faster compilation times.
+SWIFT_FEATURE_ENABLE_VFSOVERLAYS = "swift.enable_vfsoverlays"
+
 def are_all_features_enabled(feature_configuration, feature_names):
     """Returns `True` if all features are enabled in the feature configuration.
 


### PR DESCRIPTION
For Swift modules with large transitive dependency sets, compilation performance can be sped up by replacing all `-I` flags – which is one per Bazel package, with a single `-I` flag and a `-vfsoverlay`.

In my measurements, I saw compilation time drop ~30% for a module that's near the root of our app's dependency tree. That module had >300 transitive `swift_library` dependencies.

Modules with few dependencies don't directly gain anything, but when building a Swift app, changing a module can mean recompiling all of its transitive reverse dependencies. This change improves the performance of these cascading rebuilds.

Another piece of anecdata: Incremental compilation after adding `private let i = 1` to a class, resulting in about a dozen modules being rebuilt:

Without vfsoverlay: ~215s
With vfsoverlay: ~166s

Almost a minute off.

For a reference point, this is using vfsoverlays to provide what header maps provide in Clang.