### PR TITLE
Migrate a number of feature-driven compilation flags to the action config model.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -108,6 +108,15 @@ def apply_action_configs(
                     should_apply_configurators = True
                     break
 
+        # If we should apply the configurators so far but there are exclusionary
+        # features, check those as well and possibly decide to not apply the
+        # configurators based on those.
+        if should_apply_configurators and action_config.not_features:
+            should_apply_configurators = not are_all_features_enabled(
+                feature_configuration = feature_configuration,
+                feature_names = action_config.not_features,
+            )
+
         # If one of the feature lists is completely satisfied, invoke the
         # configurators.
         if should_apply_configurators:

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -25,6 +25,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
 load(":autolinking.bzl", "autolink_extract_action_configs")
+load(":compiling.bzl", "compile_action_configs")
 load(":debugging.bzl", "modulewrap_action_configs")
 load(
     ":features.bzl",
@@ -84,7 +85,11 @@ def _all_action_configs():
     Returns:
         A list of action configurations for the toolchain.
     """
-    return modulewrap_action_configs() + autolink_extract_action_configs()
+    return (
+        compile_action_configs() +
+        modulewrap_action_configs() +
+        autolink_extract_action_configs()
+    )
 
 def _default_linker_opts(
         cc_toolchain,

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -24,6 +24,7 @@ _ActionConfigInfo = provider(
         "actions",
         "configurators",
         "features",
+        "not_features",
     ],
 )
 
@@ -101,7 +102,11 @@ def _normalize_action_config_features(features):
     # Otherwise, return the original list of lists.
     return features
 
-def _action_config(actions, configurators, features = None):
+def _action_config(
+        actions,
+        configurators,
+        features = None,
+        not_features = None):
     """Returns a new Swift toolchain action configuration.
 
     This function validates the inputs, causing the build to fail if they have
@@ -124,6 +129,12 @@ def _action_config(actions, configurators, features = None):
             mentioned in *one* of the inner lists must be enabled; or a single
             non-empty `list` of feature names, which is a shorthand form
             equivalent to that single list wrapped in another list.
+        not_features: The `list` of features that must *not* be enabled for the
+            configurators to be applied to the action. Unlike the `features`
+            argument, this is only a single list, and it is a conjunction; if
+            and only if *all* of the features in the list are enabled, the
+            configurators will not be applied, even if `features` was also
+            satisfied.
 
     Returns:
         A validated action configuration.
@@ -132,6 +143,7 @@ def _action_config(actions, configurators, features = None):
         actions = actions,
         configurators = configurators,
         features = _normalize_action_config_features(features),
+        not_features = not_features,
     )
 
 def _add_arg_impl(

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -26,6 +26,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
+load(":compiling.bzl", "compile_action_configs")
 load(
     ":features.bzl",
     "SWIFT_FEATURE_BITCODE_EMBEDDED",
@@ -304,6 +305,7 @@ def _all_action_configs(
             ),
         )
 
+    action_configs.extend(compile_action_configs())
     return action_configs
 
 def _all_tool_configs(


### PR DESCRIPTION
Migrate a number of feature-driven compilation flags to the action config model.

This change removes `swiftc_command_line_and_inputs` as a public API (there are no users currently within Google, which gives us an opportunity to rethink its design under the new model). Then, we move the majority of its feature checks that control command line flags to equivalent COMPILE action configs.

This got slightly awkward around the current treatment of WMO, since we need to check both the feature configuration and the user compile flags to determine what kind of outputs are needed, so in some cases, the check had to be split—for example, the action config already filters based on feature, so the configurator function needs to check the user compile flags for the presence of WMO based only if features for WMO *weren't* satisfied.

RELNOTES: None.
