### PR TITLE
Remove duplicate quote include search path

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -486,7 +486,9 @@ def _output_dirs_clang_search_paths_configurator(prerequisites, args):
             "-iquote{}".format(prerequisites.bin_dir.path),
         ])
 
-    if prerequisites.genfiles_dir:
+    if prerequisites.genfiles_dir and (
+        prerequisites.genfiles_dir != prerequisites.bin_dir
+    ):
         args.add_all([
             "-Xcc",
             "-iquote{}".format(prerequisites.genfiles_dir.path),


### PR DESCRIPTION
`bazel-genfiles` has been merged to `bazel-bin` since the flipping of
the `--incompatible_merge_genfiles_directory` flag. This removes one
when both are present.