### PR TITLE
Fix swift_library linkopts ordering for ObjC

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1391,7 +1391,7 @@ def new_objc_provider(
     if objc_header:
         objc_provider_args["header"] = depset(direct = [objc_header])
     if linkopts:
-        objc_provider_args["linkopt"] = depset(direct = linkopts)
+        objc_provider_args["linkopt"] = depset(direct = linkopts, order = "topological")
 
     force_loaded_libraries = [
         archive


### PR DESCRIPTION
Previously this list would be interpreted backwards

Fixes https://github.com/bazelbuild/rules_swift/issues/338

This is also how this is done in rules_apple https://github.com/bazelbuild/rules_apple/blob/53282252b393e451634d4f410d555df3f295c00e/apple/internal/swift_support.bzl#L84