### PR TITLE
Allow cacheable_swiftmodule feature independent of compilation mode

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -108,10 +108,15 @@ def _apply_action_configs(
         # features, check those as well and possibly decide to not apply the
         # configurators based on those.
         if should_apply_configurators and action_config.not_features:
-            should_apply_configurators = not are_all_features_enabled(
-                feature_configuration = feature_configuration,
-                feature_names = action_config.not_features,
-            )
+            # The configurators will not be applied if any of the
+            # `not_features` exclusion lists are entirely enabled.
+            for feature_names in action_config.not_features:
+                if are_all_features_enabled(
+                    feature_configuration = feature_configuration,
+                    feature_names = feature_names,
+                ):
+                    should_apply_configurators = False
+                    break
 
         # If one of the feature lists is completely satisfied, invoke the
         # configurators.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -217,8 +217,8 @@ def compile_action_configs():
                 ),
             ],
             not_features = [
-                SWIFT_FEATURE_OPT,
-                SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
+                [SWIFT_FEATURE_OPT],
+                [SWIFT_FEATURE_CACHEABLE_SWIFTMODULES],
             ],
         ),
 

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -129,12 +129,16 @@ def _action_config(
             mentioned in *one* of the inner lists must be enabled; or a single
             non-empty `list` of feature names, which is a shorthand form
             equivalent to that single list wrapped in another list.
-        not_features: The `list` of features that must *not* be enabled for the
-            configurators to be applied to the action. Unlike the `features`
-            argument, this is only a single list, and it is a conjunction; if
-            and only if *all* of the features in the list are enabled, the
-            configurators will not be applied, even if `features` was also
-            satisfied.
+        not_features: The `list` of features that must be disabled for the
+            configurators to be applied to the action. Like `features`, this
+            argument can take one of three forms: `None` (the default), in
+            which case the configurators are applied if `features` was
+            satisfied; a non-empty `list` of `list`s of feature names (strings),
+            in which case *all* features mentioned in *one* of the inner lists
+            must be disabled, otherwise the configurators will not be applied,
+            even if `features` was satisfied; or a single non-empty `list` of
+            feature names, which is a shorthand form equivalent to that single
+            list wrapped in another list.
 
     Returns:
         A validated action configuration.
@@ -143,7 +147,7 @@ def _action_config(
         actions = actions,
         configurators = configurators,
         features = _normalize_action_config_features(features),
-        not_features = not_features,
+        not_features = _normalize_action_config_features(not_features),
     )
 
 def _add_arg_impl(


### PR DESCRIPTION
We noticed that `swiftc` command lines were containing offsetting flags when enabling the `cacheable_swiftmodules` feature.

```
-Xfrontend -no-serialize-debugging-options -Xfrontend -serialize-debugging-option
```

The cause is the `not_features` used in this case: https://github.com/bazelbuild/rules_swift/blob/657eda57a097980848dbb3c880b94faeddaa3cd1/swift/internal/compiling.bzl#L211-L223

Which says to add `-serialize-debugging-option` using this logic:

```py
if not (opt and cacheable_swiftmodules):
   # use -serialize-debugging-option
```

but the logic should be:

```py
if not (opt or cacheable_swiftmodules):
   # use -serialize-debugging-option
```

This fix changes `not_features` to match `features` in structure and meaning. Now, the `or` can be expressed using a list of list of feature names:

```
not_features = [
    [SWIFT_FEATURE_OPT],
    [SWIFT_FEATURE_CACHEABLE_SWIFTMODULES],
]
```

Fixes #398 

The change that introduced the regression was https://github.com/bazelbuild/rules_swift/pull/376