### PR TITLE
bzl-visibility is no longer in the defaults.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -37,9 +37,7 @@ tasks:
 
 buildifier:
   version: latest
-  # Disable 'bzl-visibility' since it doesn't work properly.
-  #  https://github.com/bazelbuild/buildtools/issues/718
   # TODO(b/140761855): Remove native-cc from this list.
   # TODO(b/140761855): Remove native-proto from this list.
   # TODO(b/140761855): Remove native-py from this list.
-  warnings: -bzl-visibility,-native-cc,-native-proto,-native-py
+  warnings: -native-cc,-native-proto,-native-py


### PR DESCRIPTION
bzl-visibility is no longer in the defaults.

Looking at the issue mentioned, it doesn't sound like it can be made to
generally work, so it got removed from the default set in
bazelbuild/buildtools#721

RELNOTES: None
