### PR TITLE
Require the `swift_module` tag on `cc_library` targets that are

### DIFF
--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -1,0 +1,92 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logic for generating Clang module map files."""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def write_module_map(
+        actions,
+        module_map_file,
+        module_name,
+        headers = [],
+        textual_headers = [],
+        workspace_relative = False):
+    """Writes the content of the module map to a file.
+
+    Args:
+        actions: The actions object from the aspect context.
+        module_map_file: A `File` representing the module map being written.
+        module_name: The name of the module being generated.
+        headers: The `list` of `File`s representing the public headers of the
+            target whose module map is being written.
+        textual_headers: The `list` of `File`s representing the textual headers
+            of the target whose module map is being written.
+        workspace_relative: A Boolean value indicating whether the header paths
+            written in the module map file should be relative to the workspace
+            or relative to the module map file.
+    """
+    content = "module {} {{\n".format(module_name)
+    content += "".join([
+        '    header "{}"\n'.format(_header_path(
+            header_file = header_file,
+            module_map_file = module_map_file,
+            workspace_relative = workspace_relative,
+        ))
+        for header_file in headers
+    ])
+    content += "".join([
+        '    textual header "{}"\n'.format(_header_path(
+            header_file = header_file,
+            module_map_file = module_map_file,
+            workspace_relative = workspace_relative,
+        ))
+        for header_file in textual_headers
+    ])
+    content += "    export *\n"
+    content += "}\n"
+
+    actions.write(
+        content = content,
+        output = module_map_file,
+    )
+
+def _header_path(header_file, module_map_file, workspace_relative):
+    """Returns the path to a header file to be written in the module map.
+
+    Args:
+        header_file: A `File` representing the header whose path should be
+            returned.
+        module_map_file: A `File` representing the module map being written,
+            which is used during path relativization if necessary.
+        workspace_relative: A Boolean value indicating whether the path should
+            be workspace-relative or module-map-relative.
+
+    Returns:
+        The path to the header file, relative to either the workspace or the
+        module map as requested.
+    """
+
+    # If the module map is workspace-relative, then the file's path is what we
+    # want.
+    if workspace_relative:
+        return header_file.path
+
+    # Otherwise, since the module map is generated, we need to get the full path
+    # to it rather than just its short path (that is, the path starting with
+    # bazel-out/). Then, we can simply walk up the same number of parent
+    # directories as there are path segments, and append the header file's path
+    # to that.
+    num_segments = len(paths.dirname(module_map_file.path).split("/"))
+    return ("../" * num_segments) + header_file.path

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -48,7 +48,7 @@ cc_library(
         "-pic",
         "-supports_pic",
     ],
-    tags = FIXTURE_TAGS,
+    tags = FIXTURE_TAGS + ["swift_module"],
 )
 
 cc_library(
@@ -59,7 +59,7 @@ cc_library(
         "-pic",
         "-supports_pic",
     ],
-    tags = FIXTURE_TAGS,
+    tags = FIXTURE_TAGS + ["swift_module"],
 )
 
 swift_library(


### PR DESCRIPTION
Require the `swift_module` tag on `cc_library` targets that are
(direct or transitive) dependencies of `swift_*` targets to generate
module maps for them and import them into Swift.

This wasn't a hard requirement before because, even if we created a
module map for a library that didn't contain Swift-compatible C code,
as long as no Swift code actually tried to import it, no harm was
done. This will no longer be true when we start precompiling explicit
modules for C dependencies, at which point we **must** be able to
distinguish which ones are Swift-compatible and which are not (i.e.,
currently most of them).

RELNOTES: `cc_library` targets must have `swift_module` or
`swift_module=ModuleName` in their `tags` in order to be imported into
Swift.
