### PR TITLE
Allow `.swiftinterface` files to be emitted without library evolution enabled by adding `--features=swift.emit_swiftinterface` to the build.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -116,7 +116,6 @@ def compile_action_configs():
             configurators = [_emit_module_interface_path_configurator],
             features = [
                 SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION,
-                SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION,
                 SWIFT_FEATURE_EMIT_SWIFTINTERFACE,
             ],
         ),
@@ -965,7 +964,6 @@ def _declare_compile_outputs(
         feature_configuration = feature_configuration,
         feature_names = [
             SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION,
-            SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION,
             SWIFT_FEATURE_EMIT_SWIFTINTERFACE,
         ],
     ):

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -181,6 +181,7 @@ def _swift_library_impl(ctx):
     direct_output_files = compact([
         compilation_outputs.generated_header,
         compilation_outputs.swiftdoc,
+        compilation_outputs.swiftinterface,
         compilation_outputs.swiftmodule,
         library_to_link.pic_static_library,
     ])


### PR DESCRIPTION
Allow `.swiftinterface` files to be emitted without library evolution enabled by adding `--features=swift.emit_swiftinterface` to the build.

Note that doing so causes the compiler to emit a warning that `.swiftinterface` files are not supported without library evolution. However, the file is still emitted and has what appears to be somewhat valid content.

These interface files should not be used as inputs for upstream builds, and certainly not used for the creation of distributed libraries. The purpose of this change is to allow the creation of other source tooling that loads `.swiftinterface` files, when that tooling may be built from sources of the compiler that don't match the version that was used to build the module itself.

RELNOTES: None.
