### PR TITLE
Add a test to verify that `.swiftmodules` are propagated through non-Swift targets, like `objc_library`.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,11 +1,14 @@
 load(":generated_header_tests.bzl", "generated_header_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
+load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 
 licenses(["notice"])
 
 generated_header_test_suite()
 
 private_deps_test_suite()
+
+swift_through_non_swift_test_suite()
 
 test_suite(
     name = "all_tests",

--- a/test/fixtures/swift_through_non_swift/BUILD
+++ b/test/fixtures/swift_through_non_swift/BUILD
@@ -1,0 +1,31 @@
+load("//swift:swift.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+###############################################################################
+# Fixtures for testing swift_libraries propagate through objc_libraries
+
+swift_library(
+    name = "lower",
+    srcs = ["Empty.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+objc_library(
+    name = "middle",
+    hdrs = ["Empty.h"],
+    tags = FIXTURE_TAGS,
+    deps = [":lower"],
+)
+
+swift_library(
+    name = "upper",
+    srcs = ["Empty.swift"],
+    tags = FIXTURE_TAGS,
+    deps = [":middle"],
+)

--- a/test/fixtures/swift_through_non_swift/Empty.h
+++ b/test/fixtures/swift_through_non_swift/Empty.h
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/fixtures/swift_through_non_swift/Empty.swift
+++ b/test/fixtures/swift_through_non_swift/Empty.swift
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/swift_through_non_swift_tests.bzl
+++ b/test/swift_through_non_swift_tests.bzl
@@ -1,0 +1,43 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `SwiftInfo` propagation through non-Swift targets."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:provider_test.bzl",
+    "provider_test",
+)
+
+def swift_through_non_swift_test_suite():
+    """Test suite for propagation of `SwiftInfo` through non-Swift targets."""
+    name = "swift_through_non_swift"
+
+    # The lower swiftmodule should get propagated through the `objc_library` (by
+    # the aspect) and up to the upper target. Make sure it wasn't dropped.
+    provider_test(
+        name = "{}_swiftmodules_propagate_through_non_swift_targets".format(name),
+        expected_files = [
+            "test_fixtures_swift_through_non_swift_lower.swiftmodule",
+            "test_fixtures_swift_through_non_swift_upper.swiftmodule",
+        ],
+        field = "transitive_swiftmodules",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )


### PR DESCRIPTION
Add a test to verify that `.swiftmodules` are propagated through non-Swift targets, like `objc_library`.

RELNOTES: None.
