### PR TITLE
Migrate Objc compile info to CcCompilationContext

### DIFF
--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -202,6 +202,8 @@ def _swift_library_impl(ctx):
             additional_inputs = additional_inputs,
             cc_infos = get_providers(deps, CcInfo),
             compilation_outputs = compilation_outputs,
+            defines = ctx.attr.defines,
+            includes = [ctx.bin_dir.path],
             libraries_to_link = [library_to_link],
             private_cc_infos = get_providers(private_deps, CcInfo),
             user_link_flags = linkopts,

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -100,6 +100,7 @@ def _swift_module_alias_impl(ctx):
         create_cc_info(
             cc_infos = get_providers(deps, CcInfo),
             compilation_outputs = compilation_outputs,
+            includes = [ctx.bin_dir.path],
             libraries_to_link = [library_to_link],
         ),
         swift_common.create_swift_info(

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -77,6 +77,8 @@ def create_cc_info(
         additional_inputs = [],
         cc_infos = [],
         compilation_outputs = None,
+        defines = [],
+        includes = [],
         libraries_to_link = [],
         private_cc_infos = [],
         user_link_flags = []):
@@ -90,6 +92,10 @@ def create_cc_info(
             provider.
         compilation_outputs: The compilation outputs from a Swift compile
             action, as returned by `swift_common.compile`, or None.
+        defines: The list of compiler defines to insert into the compilation
+            context.
+        includes: The list of include paths to insert into the compilation
+            context.
         libraries_to_link: A list of `LibraryToLink` objects that represent the
             libraries that should be linked into the final binary.
         private_cc_infos: A list of `CcInfo` providers from private
@@ -104,9 +110,11 @@ def create_cc_info(
     """
     all_additional_inputs = list(additional_inputs)
     all_user_link_flags = list(user_link_flags)
+    all_headers = []
     if compilation_outputs:
         all_additional_inputs.extend(compilation_outputs.linker_inputs)
         all_user_link_flags.extend(compilation_outputs.linker_flags)
+        all_headers = compact([compilation_outputs.generated_header])
 
     local_cc_infos = [
         CcInfo(
@@ -114,6 +122,11 @@ def create_cc_info(
                 additional_inputs = all_additional_inputs,
                 libraries_to_link = libraries_to_link,
                 user_link_flags = all_user_link_flags,
+            ),
+            compilation_context = cc_common.create_compilation_context(
+                defines = depset(defines),
+                headers = depset(all_headers),
+                includes = depset(includes),
             ),
         ),
     ]


### PR DESCRIPTION
Migrate Objc compile info to CcCompilationContext

Step 1 of 3-step plan:
1. Migrate the definitions.
2. Migrate the uses.
3. Delete old ObjcProvider definitions.

See https://github.com/bazelbuild/bazel/issues/10674.

RELNOTES: None
