### PR TITLE
Turn off the bzl-visibility check

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,4 +40,6 @@ buildifier:
   # TODO(b/140761855): Remove native-cc from this list.
   # TODO(b/140761855): Remove native-proto from this list.
   # TODO(b/140761855): Remove native-py from this list.
-  warnings: -native-cc,-native-proto,-native-py
+  # Disable 'bzl-visibility' since it doesn't work properly.
+  #  https://github.com/bazelbuild/buildtools/issues/718
+  warnings: -native-cc,-native-proto,-native-py,-bzl-visibility


### PR DESCRIPTION
Turn off the bzl-visibility check

It was added back to the defaults: https://github.com/bazelbuild/buildtools/pull/795

But the report issue still seems to be open: https://github.com/bazelbuild/buildtools/issues/718

RELNOTES: None
