### PR TITLE
Rename `non_swift_target_aspect` to `swift_clang_module_aspect`.

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -21,7 +21,6 @@ load(":compiling.bzl", "output_groups_from_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
 load(":feature_names.bzl", "SWIFT_FEATURE_BUNDLED_XCTESTS")
 load(":linking.bzl", "register_link_binary_action")
-load(":non_swift_target_aspect.bzl", "non_swift_target_aspect")
 load(":providers.bzl", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "expand_locations")
@@ -37,7 +36,7 @@ def _binary_rule_attrs(stamp_default):
     """
     return dicts.add(
         swift_common.compilation_attrs(
-            additional_deps_aspects = [non_swift_target_aspect],
+            additional_deps_aspects = [swift_common.swift_clang_module_aspect],
         ),
         {
             "linkopts": attr.string_list(

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -231,7 +231,7 @@ def _handle_objc_target(
         swift_infos = swift_infos,
     )]
 
-def _non_swift_target_aspect_impl(target, aspect_ctx):
+def _swift_clang_module_aspect_impl(target, aspect_ctx):
     # Do nothing if the target already propagates `SwiftInfo`.
     if SwiftInfo in target:
         return []
@@ -283,7 +283,7 @@ def _non_swift_target_aspect_impl(target, aspect_ctx):
 
     return []
 
-non_swift_target_aspect = aspect(
+swift_clang_module_aspect = aspect(
     attr_aspects = _MULTIPLE_TARGET_ASPECT_ATTRS + _SINGLE_TARGET_ASPECT_ATTRS,
     attrs = swift_toolchain_attrs(
         toolchain_attr_name = "_toolchain_for_aspect",
@@ -321,7 +321,7 @@ library's attribute and then merge its `SwiftInfo` provider with any others that
 it propagates for its targets.
 """,
     fragments = ["cpp"],
-    implementation = _non_swift_target_aspect_impl,
+    implementation = _swift_clang_module_aspect_impl,
     required_aspect_providers = [
         [apple_common.Objc],
         [CcInfo],

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -38,16 +38,13 @@ load(
 )
 load(":linking.bzl", "swift_runtime_linkopts")
 load(
-    ":non_swift_target_aspect.bzl",
-    "non_swift_target_aspect",
-)
-load(
     ":providers.bzl",
     "create_clang_module",
     "create_module",
     "create_swift_info",
     "create_swift_module",
 )
+load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -64,7 +61,7 @@ swift_common = struct(
     get_implicit_deps = get_implicit_deps,
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
-    swift_clang_module_aspect = non_swift_target_aspect,
+    swift_clang_module_aspect = swift_clang_module_aspect,
     swift_runtime_linkopts = swift_runtime_linkopts,
     toolchain_attrs = swift_toolchain_attrs,
 )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -29,7 +29,6 @@ load(
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
 )
 load(":linking.bzl", "register_libraries_to_link")
-load(":non_swift_target_aspect.bzl", "non_swift_target_aspect")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(
@@ -274,11 +273,11 @@ def _swift_library_impl(ctx):
 swift_library = rule(
     attrs = dicts.add(
         swift_common.library_rule_attrs(additional_deps_aspects = [
-            non_swift_target_aspect,
+            swift_common.swift_clang_module_aspect,
         ]),
         {
             "private_deps": swift_deps_attr(
-                aspects = [non_swift_target_aspect],
+                aspects = [swift_common.swift_clang_module_aspect],
                 doc = """\
 A list of targets that are implementation-only dependencies of the target being
 built. Libraries/linker flags from these dependencies will be propagated to


### PR DESCRIPTION
Rename `non_swift_target_aspect` to `swift_clang_module_aspect`.

This is already the public name of the aspect as exposed through `swift_common`; this change makes its internal name consistent with that.

RELNOTES: None.
