### PR TITLE
LSC: Change for loops to use const refs, per performance-for-range-copy clang-tidy.

### DIFF
--- a/tools/common/string_utils.cc
+++ b/tools/common/string_utils.cc
@@ -34,7 +34,7 @@ bool MakeSubstitutions(std::string *arg,
   bool changed = false;
 
   // Replace placeholders in the string with their actual values.
-  for (std::pair<std::string, std::string> mapping : mappings) {
+  for (const std::pair<const std::string, std::string> &mapping : mappings) {
     changed |= FindAndReplace(mapping.first, mapping.second, arg);
   }
 

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -42,7 +42,7 @@ static std::unique_ptr<TempFile> WriteResponseFile(
   auto response_file = TempFile::Create("swiftc_params.XXXXXX");
   std::ofstream response_file_stream(response_file->GetPath());
 
-  for (auto arg : args) {
+  for (const auto &arg : args) {
     // When Clang/Swift write out a response file to communicate from driver to
     // frontend, they just quote every argument to be safe; we duplicate that
     // instead of trying to be "smarter" and only quoting when necessary.

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -112,7 +112,8 @@ void WorkProcessor::ProcessWorkRequest(
   params_file_stream.close();
 
   if (!is_wmo) {
-    for (auto expected_object_pair : output_file_map.incremental_outputs()) {
+    for (const auto &expected_object_pair :
+         output_file_map.incremental_outputs()) {
       // Bazel creates the intermediate directories for the files declared at
       // analysis time, but we need to manually create the ones for the
       // incremental storage area.
@@ -132,7 +133,8 @@ void WorkProcessor::ProcessWorkRequest(
   if (!is_wmo) {
     // Copy the output files from the incremental storage area back to the
     // locations where Bazel declared the files.
-    for (auto expected_object_pair : output_file_map.incremental_outputs()) {
+    for (const auto &expected_object_pair :
+         output_file_map.incremental_outputs()) {
       if (!CopyFile(expected_object_pair.second, expected_object_pair.first)) {
         std::cerr << "Could not copy " << expected_object_pair.second << " to "
                   << expected_object_pair.first << " (errno " << errno << ")\n";


### PR DESCRIPTION
LSC: Change for loops to use const refs, per performance-for-range-copy clang-tidy.

This CL optimizes C++11 range-based for loops where the variable is copied in each iteration but it would suffice to obtain it by const reference.  This is only applied to loop variables of types that are expensive to copy which means they are not trivially copyable or have a non-trivial copy constructor or destructor.

To ensure that it is safe to replace the copy with a const reference the following heuristic is employed:
  The loop variable is const qualified.
  The loop variable is not const, but only const methods or operators are invoked on it, or it is used as const reference or value argument in constructors or function calls.
