### PR TITLE
Replace custom implementation of link stamping with the new `cc_common.link` stamp argument.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -156,6 +156,7 @@ def register_link_binary_action(
         name,
         objects,
         output_type,
+        stamp,
         swift_toolchain,
         user_link_flags):
     """Registers an action that invokes the linker to produce a binary.
@@ -177,10 +178,13 @@ def register_link_binary_action(
         objects: A list of object (.o) files that will be passed to the linker.
         output_type: A string indicating the output type; "executable" or
             "dynamic_library".
+        stamp: A tri-state value (-1, 0, or 1) that specifies whether link
+            stamping is enabled. See `cc_common.link` for details about the
+            behavior of this argument.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
         user_link_flags: Additional flags passed to the linker. Any
             `$(location ...)` placeholders are assumed to have already been
             expanded.
-        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
 
     Returns:
         A `CcLinkingOutputs` object that contains the `executable` or
@@ -240,6 +244,7 @@ def register_link_binary_action(
         linking_contexts = linking_contexts,
         link_deps_statically = True,
         output_type = output_type,
+        stamp = stamp,
     )
 
 def swift_runtime_linkopts(is_static, toolchain, is_test = False):

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -173,31 +173,6 @@ target.
         "root_dir": """\
 `String`. The workspace-relative root directory of the toolchain.
 """,
-        "stamp_producer": """\
-Skylib `partial`. A partial function that compiles build data that should be
-stamped into binaries. This value may be `None` if the toolchain does not
-support link stamping.
-
-The `swift_binary` and `swift_test` rules call this function _whether or not_
-link stamping is enabled for that target. This provides toolchains the option of
-still linking fixed placeholder data into the binary if desired, instead of
-linking nothing at all. Whether stamping is enabled can be checked by inspecting
-`ctx.attr.stamp` inside the partial's implementation.
-
-The rule implementation will call this partial and pass it the following four
-arguments:
-
-*    `ctx`: The rule context of the target being built.
-*    `cc_feature_configuration`: The C++ feature configuration to use when
-     compiling the stamp code.
-*    `cc_toolchain`: The C++ toolchain (`CcToolchainInfo` provider) to use when
-     compiling the stamp code.
-*    `binary_path`: The short path of the binary being linked.
-
-The partial should return a `CcLinkingContext` containing the data (such as
-object files) to be linked into the binary, or `None` if nothing should be
-linked into the binary.
-""",
         "supports_objc_interop": """\
 `Boolean`. Indicates whether or not the toolchain supports Objective-C interop.
 """,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -209,7 +209,6 @@ def _swift_toolchain_impl(ctx):
             requested_features = requested_features,
             required_implicit_deps = [],
             root_dir = toolchain_root,
-            stamp_producer = None,
             supports_objc_interop = False,
             swift_worker = ctx.executable._worker,
             system_name = ctx.attr.os,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -568,7 +568,6 @@ def _xcode_swift_toolchain_impl(ctx):
             optional_implicit_deps = [],
             requested_features = requested_features,
             required_implicit_deps = [],
-            stamp_producer = None,
             supports_objc_interop = True,
             swift_worker = ctx.executable._worker,
             system_name = "darwin",


### PR DESCRIPTION
Replace custom implementation of link stamping with the new `cc_common.link` stamp argument.

This also changes the `stamp` attribute on `swift_{binary,test}` from a Boolean to an integer, in order to support tri-state values (1, 0, -1). The default for `swift_binary` has changed from `True` to `-1`, which means "behavior is determined by the `--[no]stamp` flag". In other words, the interface and behavior are now identical to `cc_binary`.

RELNOTES: Link stamping is now supported uniformly across all toolchains, including Xcode toolchains.
