### PR TITLE
Replace + (plus) in the generated module name with _ (underscore)

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -777,7 +777,7 @@ def derive_module_name(*args):
 
     package_part = (package.lstrip("//").replace("/", "_").replace("-", "_")
         .replace(".", "_"))
-    name_part = name.replace("-", "_")
+    name_part = name.replace("-", "_").replace("+", "_")
     if package_part:
         return package_part + "_" + name_part
     return name_part


### PR DESCRIPTION
We had a problem trying to import `objc_library` dependency with a `+` in the package name (the package was category-only source) since `import` statement in Swift doesn't support special characters other than `_`. I can confirm that the generated module name contains `+` by looking at the generated module map file.