### PR TITLE
Fix incorrect doc for `no_generated_module_map` feature

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -102,8 +102,8 @@ SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD = "swift.module_map_home_is_cwd"
 SWIFT_FEATURE_NO_GENERATED_HEADER = "swift.no_generated_header"
 
 # If enabled, the compilation action for a library target will not generate a
-# module map for the Objective-C generated header. note that his feature is 
-# ignored if `swift.no_generated_header` is present.
+# module map for the Objective-C generated header. Note that this feature
+# is ignored if `swift.no_generated_header` is present.
 SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 
 # If enabled, builds using the "opt" compilation mode will invoke `swiftc` with

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -102,8 +102,8 @@ SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD = "swift.module_map_home_is_cwd"
 SWIFT_FEATURE_NO_GENERATED_HEADER = "swift.no_generated_header"
 
 # If enabled, the compilation action for a library target will not generate a
-# module map for the Objective-C generated header. This feature is ignored if
-# `swift.no_generated_header` is not present.
+# module map for the Objective-C generated header. note that his feature is 
+# ignored if `swift.no_generated_header` is present.
 SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 
 # If enabled, builds using the "opt" compilation mode will invoke `swiftc` with


### PR DESCRIPTION
According to the actual implementation [line 1091 of compiling.bzl](https://github.com/bazelbuild/rules_swift/blob/master/swift/internal/compiling.bzl#L1091), deciding whether to generate module map depends on whether we have generated headers to start with. In practice we have this feature enabled without the need to pass `no_generated_header`, therefore the documentation is stated the opposite.

**I know I suppose to create an issue but this is trivial (?) that I decide to just open up a PR instead. Let me know what should I do since I am newbie to contributing to open source :)** 