### PR TITLE
Add feature to use absolute source file paths when compiling

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -61,6 +61,12 @@ SWIFT_FEATURE_COMPILE_STATS = "swift.compile_stats"
 # builds.
 SWIFT_FEATURE_DEBUG_PREFIX_MAP = "swift.debug_prefix_map"
 
+# If enabled, Swift compilation actions will pass absolute paths, resolved with
+# realpath, for source files. This will allow `#file` (in Swift < 5.3) and
+# `#filePath` (in Swift >= 5.3) to match Xcode's behavior. Remote or sandboxed
+# builds probably shouldn't enable this feature.
+SWIFT_FEATURE_ABSOLUTE_SOURCE_FILES = "swift.absolute_source_files"
+
 # If enabled, C and Objective-C libraries that are direct or transitive
 # dependencies of a Swift library will emit explicit precompiled modules that
 # are compatible with Swift's ClangImporter and propagate them up the build

--- a/tools/common/file_system.h
+++ b/tools/common/file_system.h
@@ -23,6 +23,11 @@ std::string GetCurrentDirectory();
 // Copies the file at src to dest. Returns true if successful.
 bool CopyFile(const std::string &src, const std::string &dest);
 
+// If "__BAZEL_PWD__/"" is at the start of the path it's replaced with the
+// current directory and is then realpath'ed. This implements the
+// swift.absolute_source_files feature.
+std::string MakePathAbsolute(const std::string &path);
+
 // Creates a directory at the given path, along with any parent directories that
 // don't already exist. Returns true if successful.
 bool MakeDirs(const std::string &path, int mode);

--- a/tools/common/string_utils.cc
+++ b/tools/common/string_utils.cc
@@ -40,3 +40,41 @@ bool MakeSubstitutions(std::string *arg,
 
   return changed;
 }
+
+std::string Unescape(const std::string &arg) {
+  std::string result;
+  auto length = arg.size();
+  for (size_t i = 0; i < length; ++i) {
+    auto ch = arg[i];
+
+    // If it's a backslash, consume it and append the character that follows.
+    if (ch == '\\' && i + 1 < length) {
+      ++i;
+      result.push_back(arg[i]);
+      continue;
+    }
+
+    // If it's a quote, process everything up to the matching quote, unescaping
+    // backslashed characters as needed.
+    if (ch == '"' || ch == '\'') {
+      auto quote = ch;
+      ++i;
+      while (i != length && arg[i] != quote) {
+        if (arg[i] == '\\' && i + 1 < length) {
+          ++i;
+        }
+        result.push_back(arg[i]);
+        ++i;
+      }
+      if (i == length) {
+        break;
+      }
+      continue;
+    }
+
+    // It's a regular character.
+    result.push_back(ch);
+  }
+
+  return result;
+}

--- a/tools/common/string_utils.h
+++ b/tools/common/string_utils.h
@@ -22,4 +22,7 @@
 bool MakeSubstitutions(std::string *arg,
                        const std::map<std::string, std::string> &mappings);
 
+// Unescape and unquote an argument read from a line of a response file.
+std::string Unescape(const std::string &arg);
+
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_STRING_UTILS_H_

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -42,10 +42,18 @@ cc_library(
 
 cc_library(
     name = "compile_without_worker",
-    srcs = ["compile_without_worker.cc"],
+    srcs = [
+        "compile_without_worker.cc",
+        "output_file_map.cc",
+        "output_file_map.h",
+    ],
     hdrs = ["compile_without_worker.h"],
     deps = [
         ":swift_runner",
+        "//tools/common:path_utils",
+        "//tools/common:string_utils",
+        "//tools/common:temp_file",
+        "@com_github_nlohmann_json//:json",
     ],
 )
 

--- a/tools/worker/compile_without_worker.cc
+++ b/tools/worker/compile_without_worker.cc
@@ -14,12 +14,117 @@
 
 #include "tools/worker/compile_without_worker.h"
 
-#include <iostream>
+#include <fstream>
 #include <string>
 #include <vector>
 
+#include "tools/common/path_utils.h"
+#include "tools/common/string_utils.h"
+#include "tools/common/temp_file.h"
+#include "tools/worker/output_file_map.h"
 #include "tools/worker/swift_runner.h"
 
+namespace {
+
+static void ProcessPossibleResponseFile(
+    const std::string &arg, std::function<void(const std::string &)> consumer) {
+  auto path = arg.substr(1);
+  std::ifstream original_file(path);
+  // If we couldn't open it, maybe it's not a file; maybe it's just some other
+  // argument that starts with "@". (Unlikely, but it's safer to check.)
+  if (!original_file.good()) {
+    consumer(arg);
+    return;
+  }
+
+  std::string arg_from_file;
+  while (std::getline(original_file, arg_from_file)) {
+    // Arguments in response files might be quoted/escaped, so we need to
+    // unescape them ourselves.
+    consumer(Unescape(arg_from_file));
+  }
+}
+
+static std::tuple<std::vector<std::string>, std::string>
+    ArgumentsIncludingParamsContent(const std::vector<std::string> &args) {
+  std::vector<std::string> full_args;
+  std::string prev_arg;
+  std::string output_file_map_path;
+  bool use_absolute_paths = false;
+
+  auto consumer = [&](const std::string &arg) {
+    if (arg == "-output-file-map") {
+      // Peel off the `-output-file-map` argument, so we can rewrite it if
+      // necessary later.
+    } else if (prev_arg == "-output-file-map") {
+      output_file_map_path = arg;
+    } else if (arg == "-Xwrapped-swift=-use-absolute-paths") {
+      use_absolute_paths = true;
+      full_args.push_back(arg);
+    } else {
+      full_args.push_back(arg);
+    }
+
+    prev_arg = arg;
+  };
+
+  for (auto arg : args) {
+    if (arg[0] == '@') {
+      ProcessPossibleResponseFile(arg, consumer);
+    } else {
+      consumer(arg);
+    }
+  }
+
+  std::string process_output_file_map_path;
+  if (use_absolute_paths) {
+    process_output_file_map_path = output_file_map_path;
+  }
+
+  return std::make_tuple(full_args, process_output_file_map_path);
+}
+
+}  // end namespace
+
 int CompileWithoutWorker(const std::vector<std::string> &args) {
-  return SwiftRunner(args).Run(&std::cerr, /*stdout_to_stderr=*/false);
+  std::vector<std::string> actual_args(args.begin() + 1, args.end());
+  auto arguments = ArgumentsIncludingParamsContent(actual_args);
+
+  // output_file_map_path will be non-empty if we need to process it.
+  std::string output_file_map_path = std::get<1>(arguments);
+  if (output_file_map_path.empty()) {
+    return SwiftRunner(args).Run(&std::cerr, /*stdout_to_stderr=*/false);
+  }
+
+  // We have to rewrite the arguments to include a rewritten object_file_map.
+  // This means that if we just try to pass the new arguments verbatim to
+  // swiftc, we might end up with a command line that's too long. Rather than
+  // try to figure out these limits (which is very OS-specific and easy to get
+  // wrong), we unconditionally write the processed arguments out to a params
+  // file.
+  auto params_file = TempFile::Create("swiftc_params.XXXXXX");
+  std::ofstream params_file_stream(params_file->GetPath());
+
+  // Write out all non-output_file_map arguments
+  for (auto arg : std::get<0>(arguments)) {
+    params_file_stream << arg << '\n';
+  }
+
+  OutputFileMap output_file_map;
+  output_file_map.ReadFromPath(output_file_map_path);
+  output_file_map.UpdateForAbsolutePaths();
+
+  // Rewrite the output file map.
+  auto new_path = ReplaceExtension(output_file_map_path, ".processed.json");
+  output_file_map.WriteToPath(new_path);
+
+  // Pass the compiler the path to the rewritten file.
+  params_file_stream << "-output-file-map\n";
+  params_file_stream << new_path << '\n';
+
+  std::vector<std::string> new_args(args.begin(), args.begin() + 1);
+  new_args.push_back("@" + params_file->GetPath());
+  params_file_stream.close();
+
+  return SwiftRunner(new_args).Run(&std::cerr, /*stdout_to_stderr=*/false);
 }

--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -20,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
+#include "tools/common/file_system.h"
 #include "tools/common/path_utils.h"
 
 namespace {
@@ -46,12 +47,22 @@ static std::string MakeIncrementalOutputPath(std::string path) {
 void OutputFileMap::ReadFromPath(const std::string &path) {
   std::ifstream stream(path);
   stream >> json_;
-  UpdateForIncremental(path);
 }
 
 void OutputFileMap::WriteToPath(const std::string &path) {
   std::ofstream stream(path);
   stream << json_;
+}
+
+void OutputFileMap::UpdateForAbsolutePaths() {
+  nlohmann::json new_output_file_map;
+
+  for (auto &element : json_.items()) {
+    auto absolute_src = MakePathAbsolute(element.key());
+    new_output_file_map[absolute_src] = element.value();
+  }
+
+  json_ = new_output_file_map;
 }
 
 void OutputFileMap::UpdateForIncremental(const std::string &path) {

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -43,14 +43,18 @@ class OutputFileMap {
   // it to support incremental builds.
   void ReadFromPath(const std::string &path);
 
-  // Writes the output file map as JSON to the file at the given path.
-  void WriteToPath(const std::string &path);
+  // Modifies the output file map's JSON structure in-place to convert source
+  // file paths to absolute paths.
+  void UpdateForAbsolutePaths();
 
- private:
   // Modifies the output file map's JSON structure in-place to replace file
   // paths with equivalents in the incremental storage area.
   void UpdateForIncremental(const std::string &path);
 
+  // Writes the output file map as JSON to the file at the given path.
+  void WriteToPath(const std::string &path);
+
+ private:
   nlohmann::json json_;
   std::map<std::string, std::string> incremental_outputs_;
 };

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -48,11 +48,18 @@
 //     the directory afterwards. This should resolve issues where the module
 //     cache state is not refreshed correctly in all situations, which
 //     sometimes results in hard-to-diagnose crashes in `swiftc`.
+//
+// -Xwrapped-swift=-use-absolute-paths
+//     When specified, the spawner will pass in absolute paths to `swiftc`.
+//     This is needed for some Xcode integrations, where it requires `#filePath`
+//     to return an absolute path.
 class SwiftRunner {
  public:
   // Create a new spawner that launches a Swift tool with the given arguments.
-  // The first argument is assumed to be that tool. If force_response_file is
-  // true, then the remaining arguments will be unconditionally written into a
+  // The first argument is assumed to be that tool. if use_absolute_paths is
+  // true, then source file paths are transformed to absolute paths, to support
+  // the swift.absolute_source_files feature. If force_response_file is true,
+  // then the remaining arguments will be unconditionally written into a
   // response file instead of being passed on the command line.
   SwiftRunner(const std::vector<std::string> &args,
               bool force_response_file = false);
@@ -122,6 +129,11 @@ class SwiftRunner {
   // Arguments will be unconditionally written into a response file and passed
   // to the tool that way.
   bool force_response_file_;
+
+  // Source file with "__BAZEL_PWD__" at the start of their path will be
+  // rewritten to include the process working directory, then run through
+  // realpath.
+  bool use_absolute_paths_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -72,7 +72,6 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (prev_arg == "-output-file-map") {
       output_file_map_path = arg;
-      output_file_map.ReadFromPath(output_file_map_path);
       arg.clear();
     } else if (ArgumentEnablesWMO(arg)) {
       is_wmo = true;
@@ -87,6 +86,8 @@ void WorkProcessor::ProcessWorkRequest(
 
   if (!output_file_map_path.empty()) {
     if (!is_wmo) {
+      output_file_map.ReadFromPath(output_file_map_path);
+
       // Rewrite the output file map to use the incremental storage area and
       // pass the compiler the path to the rewritten file.
       auto new_path =


### PR DESCRIPTION
This feature is useful if you need `#file`/`#filePath` to return an absolute path, which is required by Xcode for some functionality.