### PR TITLE
Remove propagating cc libs with objc provider

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -56,7 +56,6 @@ load(":providers.bzl", "SwiftInfo", "create_swift_info")
 load(":toolchain_config.bzl", "swift_toolchain_config")
 load(
     ":utils.bzl",
-    "collect_cc_libraries",
     "compact",
     "get_providers",
     "struct_fields",
@@ -1483,20 +1482,8 @@ def new_objc_provider(
         "uses_swift": True,
     }
 
-    # The link action registered by `apple_binary` only looks at `Objc`
-    # providers, not `CcInfo`, for libraries to link. Until that rule is
-    # migrated over, we need to collect libraries from `CcInfo` (which will
-    # include Swift and C++) and put them into the new `Objc` provider.
-    transitive_cc_libs = []
-    for cc_info in get_providers(deps, CcInfo):
-        static_libs = collect_cc_libraries(
-            cc_info = cc_info,
-            include_static = True,
-        )
-        transitive_cc_libs.append(depset(static_libs, order = "topological"))
     objc_provider_args["library"] = depset(
         static_archives,
-        transitive = transitive_cc_libs,
         order = "topological",
     )
 


### PR DESCRIPTION
When using a rule tree like this:

```
ios_static_framework
swift_library
objc_library
cc_library
```

Including these libraries in the objc provider leads them to being
included twice in the produced static binary. It appears the comment
here was outdated and that apple_binary does collect libraries directly
from the CcInfo.