### PR TITLE
Add swiftmodule and swiftdoc to output_groups

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1890,9 +1890,19 @@ def output_groups_from_compilation_outputs(compilation_outputs):
             compilation_outputs.stats_directory,
         ])
 
+    if compilation_outputs.swiftdoc:
+        output_groups["swiftdoc"] = depset([
+            compilation_outputs.swiftdoc,
+        ])
+
     if compilation_outputs.swiftinterface:
         output_groups["swiftinterface"] = depset([
             compilation_outputs.swiftinterface,
+        ])
+
+    if compilation_outputs.swiftmodule:
+        output_groups["swiftmodule"] = depset([
+            compilation_outputs.swiftmodule,
         ])
 
     return output_groups


### PR DESCRIPTION
Some Xcode integrations need these, and by having them as output groups (along with the use of aspects) remote build without the bytes can be enabled properly.