### PR TITLE
Add feature to disable default -D flags

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -34,6 +34,7 @@ load(
     "SWIFT_FEATURE_COVERAGE",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
+    "SWIFT_FEATURE_DISABLE_DEFAULT_D_FLAGS",
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
@@ -179,6 +180,7 @@ def compile_action_configs():
                 swift_toolchain_config.add_arg("-DDEBUG"),
             ],
             features = [[SWIFT_FEATURE_DBG], [SWIFT_FEATURE_FASTBUILD]],
+            not_features = [SWIFT_FEATURE_DISABLE_DEFAULT_D_FLAGS],
         ),
         swift_toolchain_config.action_config(
             actions = [swift_action_names.COMPILE],
@@ -186,6 +188,7 @@ def compile_action_configs():
                 swift_toolchain_config.add_arg("-DNDEBUG"),
             ],
             features = [SWIFT_FEATURE_OPT],
+            not_features = [SWIFT_FEATURE_DISABLE_DEFAULT_D_FLAGS],
         ),
 
         # Set the optimization mode. For dbg/fastbuild, use `-O0`. For opt, use

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -200,3 +200,7 @@ SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
 # numbers of `-Wl,-add_ast_path,<path>` flags to the linker do not overrun the
 # system command line limit.
 SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE = "swift.no_embed_debug_module"
+
+# If enabled rules_swift will not add default -D flags, such as -DDEBUG,
+# to swiftc invocations
+SWIFT_FEATURE_DISABLE_DEFAULT_D_FLAGS = "swift.disable_default_d_flags"

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -26,6 +26,14 @@ DBG_CONFIG_SETTINGS = {
     ],
 }
 
+DISABLE_D_FLAGS_DBG_CONFIG_SETTINGS = {
+    "//command_line_option:compilation_mode": "dbg",
+    "//command_line_option:features": [
+        "swift.debug_prefix_map",
+        "swift.disable_default_d_flags",
+    ],
+}
+
 CACHEABLE_DBG_CONFIG_SETTINGS = {
     "//command_line_option:compilation_mode": "dbg",
     "//command_line_option:features": [
@@ -38,6 +46,14 @@ FASTBUILD_CONFIG_SETTINGS = {
     "//command_line_option:compilation_mode": "fastbuild",
     "//command_line_option:features": [
         "swift.debug_prefix_map",
+    ],
+}
+
+DISABLE_D_FLAGS_FASTBUILD_CONFIG_SETTINGS = {
+    "//command_line_option:compilation_mode": "fastbuild",
+    "//command_line_option:features": [
+        "swift.debug_prefix_map",
+        "swift.disable_default_d_flags",
     ],
 }
 
@@ -58,8 +74,30 @@ OPT_CONFIG_SETTINGS = {
     ],
 }
 
+DISABLE_D_FLAGS_OPT_CONFIG_SETTINGS = {
+    "//command_line_option:compilation_mode": "opt",
+    "//command_line_option:features": [
+        # This feature indicates *support*, not unconditional enablement, which
+        # is why it is present for `opt` mode as well.
+        "swift.debug_prefix_map",
+        "swift.disable_default_d_flags",
+    ],
+}
+
+CACHEABLE_OPT_CONFIG_SETTINGS = {
+    "//command_line_option:compilation_mode": "opt",
+    "//command_line_option:features": [
+        "swift.cacheable_swiftmodules",
+        "swift.debug_prefix_map",
+    ],
+}
+
 dbg_action_command_line_test = make_action_command_line_test_rule(
     config_settings = DBG_CONFIG_SETTINGS,
+)
+
+disable_d_flags_dbg_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = DISABLE_D_FLAGS_DBG_CONFIG_SETTINGS,
 )
 
 cacheable_dbg_action_command_line_test = make_action_command_line_test_rule(
@@ -70,12 +108,20 @@ fastbuild_action_command_line_test = make_action_command_line_test_rule(
     config_settings = FASTBUILD_CONFIG_SETTINGS,
 )
 
+disable_d_flags_fastbuild_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = DISABLE_D_FLAGS_FASTBUILD_CONFIG_SETTINGS,
+)
+
 fastbuild_full_di_action_command_line_test = make_action_command_line_test_rule(
     config_settings = FASTBUILD_FULL_DI_CONFIG_SETTINGS,
 )
 
 opt_action_command_line_test = make_action_command_line_test_rule(
     config_settings = OPT_CONFIG_SETTINGS,
+)
+
+disable_d_flags_opt_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = DISABLE_D_FLAGS_OPT_CONFIG_SETTINGS,
 )
 
 def debug_settings_test_suite():
@@ -96,6 +142,19 @@ def debug_settings_test_suite():
             "-DNDEBUG",
             "-Xfrontend -no-serialize-debugging-options",
             "-gline-tables-only",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that no default `-D` flags are passed when the disable feature
+    # is passed
+    disable_d_flags_dbg_action_command_line_test(
+        name = "{}_disable_d_flags_dbg_build".format(name),
+        not_expected_argv = [
+            "-DDEBUG",
+            "-DNDEBUG",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],
@@ -143,6 +202,19 @@ def debug_settings_test_suite():
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
+    # Verify that no default `-D` flags are passed when the disable feature
+    # is passed
+    disable_d_flags_fastbuild_action_command_line_test(
+        name = "{}_disable_d_flags_fastbuild_build".format(name),
+        not_expected_argv = [
+            "-DDEBUG",
+            "-DNDEBUG",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
     # Verify that `-c fastbuild` builds with `swift.full_debug_info` use `-g`
     # instead of `-gline-tables-only` (this is required for Apple dSYM support).
     fastbuild_full_di_action_command_line_test(
@@ -176,6 +248,19 @@ def debug_settings_test_suite():
             "-Xwrapped-swift=-debug-prefix-pwd-is-dot",
             "-g",
             "-gline-tables-only",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that no default `-D` flags are passed when the disable feature
+    # is passed
+    disable_d_flags_opt_action_command_line_test(
+        name = "{}_disable_d_flags_opt_build".format(name),
+        not_expected_argv = [
+            "-DDEBUG",
+            "-DNDEBUG",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],


### PR DESCRIPTION
In some cases the default `-D` flags are not desirable since users
prefer to control them themselves.