### PR TITLE
Allow swift_library to have empty srcs

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1844,27 +1844,6 @@ def output_groups_from_compilation_outputs(compilation_outputs):
 
     return output_groups
 
-def swift_library_output_map(name, alwayslink):
-    """Returns the dictionary of implicit outputs for a `swift_library`.
-
-    This function is used to specify the `outputs` of the `swift_library` rule;
-    as such, its arguments must be named exactly the same as the attributes to
-    which they refer.
-
-    Args:
-        name: The name of the target being built.
-        alwayslink: Indicates whether the object files in the library should
-            always be always be linked into any binaries that depend on it, even
-            if some contain no symbols referenced by the binary.
-
-    Returns:
-        The implicit outputs dictionary for a `swift_library`.
-    """
-    extension = "lo" if alwayslink else "a"
-    return {
-        "archive": "lib{}.{}".format(name, extension),
-    }
-
 def _write_objc_header_module_map(
         actions,
         module_name,

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -20,7 +20,6 @@ load(
     "find_swift_version_copt_value",
     "new_objc_provider",
     "output_groups_from_compilation_outputs",
-    "swift_library_output_map",
 )
 load(
     ":feature_names.bzl",
@@ -147,6 +146,16 @@ def _swift_library_impl(ctx):
     else:
         deps = ctx.attr.deps
         private_deps = []
+
+    if not srcs:
+        return [
+            swift_common.create_swift_info(
+                # Note that private_deps are explicitly omitted here; they should
+                # not propagate.
+                swift_infos = get_providers(deps, SwiftInfo),
+                swift_version = find_swift_version_copt_value(copts),
+            ),
+        ]
 
     compilation_outputs = swift_common.compile(
         actions = ctx.actions,
@@ -290,7 +299,6 @@ dependent for linking, but artifacts/flags required for compilation (such as
     doc = """\
 Compiles and links Swift code into a static library and Swift module.
 """,
-    outputs = swift_library_output_map,
     implementation = _swift_library_impl,
     fragments = ["cpp"],
 )


### PR DESCRIPTION
This mirrors the behavior of `cc_library` to allow `swift_library`
targets to have empty `srcs`. This is valuable when you want to
optionally have source files based on some `select()` statement.