### PR TITLE
Allow generated headers with path separators

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1598,11 +1598,11 @@ def _declare_validated_generated_header(actions, generated_header_name):
     Returns:
         A `File` that should be used as the output for the generated header.
     """
-    if "/" in generated_header_name:
+    """if "/" in generated_header_name:
         fail(
             "The generated header for a Swift module may not contain " +
             "directory components (got '{}').".format(generated_header_name),
-        )
+        )"""
 
     extension = paths.split_extension(generated_header_name)[1]
     if extension != ".h":

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1588,8 +1588,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
 def _declare_validated_generated_header(actions, generated_header_name):
     """Validates and declares the explicitly named generated header.
 
-    If the file does not have a `.h` extension or conatins path separators, the
-    build will fail.
+    If the file does not have a `.h` extension, the build will fail.
 
     Args:
         actions: The context's `actions` object.
@@ -1598,12 +1597,6 @@ def _declare_validated_generated_header(actions, generated_header_name):
     Returns:
         A `File` that should be used as the output for the generated header.
     """
-    """if "/" in generated_header_name:
-        fail(
-            "The generated header for a Swift module may not contain " +
-            "directory components (got '{}').".format(generated_header_name),
-        )"""
-
     extension = paths.split_extension(generated_header_name)[1]
     if extension != ".h":
         fail(

--- a/test/fixtures/generated_header/BUILD
+++ b/test/fixtures/generated_header/BUILD
@@ -28,8 +28,8 @@ swift_library(
 )
 
 swift_library(
-    name = "invalid_path_separator",
+    name = "valid_path_separator",
     srcs = ["Empty.swift"],
-    generated_header_name = "Invalid/Separator.h",
+    generated_header_name = "Valid/Separator.h",
     tags = FIXTURE_TAGS,
 )

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -121,12 +121,17 @@ def generated_header_test_suite(name = "generated_header"):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:invalid_extension",
     )
 
-    # Verify that the build fails to analyze if a path separator is used.
-    generate_header_and_module_map_failure_test(
-        name = "{}_invalid_path_separator".format(name),
-        expected_message = "The generated header for a Swift module may not contain directory components",
+    # Verify that the build analyzes if a path separator is used.
+    generate_header_and_module_map_provider_test(
+        name = "{}_valid_path_separator".format(name),
+        expected_files = [
+            "test/fixtures/generated_header/Valid/Separator.h",
+            "*",
+        ],
+        field = "files",
+        provider = "DefaultInfo",
         tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:invalid_path_separator",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:valid_path_separator",
     )
 
     # Verify that the header is not generated if the feature


### PR DESCRIPTION
E.g., I work on a large project which has always used `#import <SomeModule/SomeModule-Swift.h>` for swift-to-objc, but using `SomeModule/SomeModule-Swift.h` as the generated header for our bazel migration causes it to fail