### PR TITLE
Fix passing -num-threads with -wmo

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2029,7 +2029,10 @@ def _emitted_output_nature(is_wmo_implied_by_features, user_compile_flags):
     # `-num-threads 12` to the command line. We need to stage that as our
     # initial default here to ensure that we return the right value if the user
     # compile flags don't otherwise override it.
-    num_threads = _DEFAULT_WMO_THREAD_COUNT if is_wmo else 1
+    #
+    # 0 is the only option that makes swift emit a single object file, anything
+    # greater and it uses that number of threads to emit multiple objects
+    num_threads = _DEFAULT_WMO_THREAD_COUNT if is_wmo else 0
 
     for copt in user_compile_flags:
         if saw_space_separated_num_threads:
@@ -2040,11 +2043,11 @@ def _emitted_output_nature(is_wmo_implied_by_features, user_compile_flags):
         elif copt.startswith("-num-threads="):
             num_threads = _safe_int(copt.split("=")[1])
 
-    if not num_threads:
+    if num_threads == None or num_threads < 0:
         fail("The value of '-num-threads' must be a positive integer.")
 
     return struct(
-        emits_multiple_objects = not (is_wmo and num_threads == 1),
+        emits_multiple_objects = not (is_wmo and num_threads == 0),
         emits_partial_modules = not is_wmo,
     )
 


### PR DESCRIPTION
Previously the assumption was that if `-num-threads` is `1`, only a
single object is emitted. It turns out in swiftc there is a difference
between 0 and 1 to this value, so even with 1 multiple objects are
emitted.

Without this change linking fails when passing this flag like:

```
bazel build examples/xplatform/xctest --swiftcopt=-num-threads --swiftcopt=1 --swiftcopt=-wmo
```