### PR TITLE
Add `swift.use_tmpdir_for_module_cache` feature

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -59,6 +59,7 @@ load(
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
+    "SWIFT_FEATURE_USE_TMPDIR_FOR_MODULE_CACHE",
     "SWIFT_FEATURE_VFSOVERLAY",
 )
 load(":features.bzl", "are_all_features_enabled", "is_feature_enabled")
@@ -446,7 +447,21 @@ def compile_action_configs():
             ],
             configurators = [_global_module_cache_configurator],
             features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
-            not_features = [SWIFT_FEATURE_USE_C_MODULES],
+            not_features = [
+                SWIFT_FEATURE_USE_C_MODULES,
+                SWIFT_FEATURE_USE_TMPDIR_FOR_MODULE_CACHE,
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE],
+            configurators = [_use_tmpdir_for_module_cache_configurator],
+            features = [
+                SWIFT_FEATURE_USE_TMPDIR_FOR_MODULE_CACHE,
+            ],
+            not_features = [
+                SWIFT_FEATURE_USE_C_MODULES,
+                SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
+            ],
         ),
         swift_toolchain_config.action_config(
             actions = [
@@ -461,6 +476,7 @@ def compile_action_configs():
             not_features = [
                 [SWIFT_FEATURE_USE_C_MODULES],
                 [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+                [SWIFT_FEATURE_USE_TMPDIR_FOR_MODULE_CACHE],
             ],
         ),
         swift_toolchain_config.action_config(
@@ -817,6 +833,13 @@ def _global_module_cache_configurator(prerequisites, args):
             "-module-cache-path",
             paths.join(prerequisites.bin_dir.path, "_swift_module_cache"),
         )
+
+def _use_tmpdir_for_module_cache_configurator(prerequisites, args):
+    """Adds flags to use a pre-defined module cache path."""
+    args.add(
+        "-module-cache-path",
+        "/private/tmp/__build_bazel_rules_swift_module_cache",
+    )
 
 def _batch_mode_configurator(prerequisites, args):
     """Adds flags to enable batch compilation mode."""

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -155,6 +155,20 @@ SWIFT_FEATURE_USE_C_MODULES = "swift.use_c_modules"
 # crashes.
 SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
 
+# If enabled, Swift compilation actions will use the shared Clang module cache
+# path written to `/private/tmp/__build_bazel_rules_swift`. This makes the embedded Clang
+# module breadcrumbs deterministic between Bazel instances, because they are
+# always embedded as absolute paths. Note that the use of this cache is
+# non-hermetic--the cached modules are not wiped between builds, and won't be
+# cleaned when invoking `bazel clean`; the user is responsible for manually
+# cleaning them.
+#
+# Additionally, this can be used as a workaround for a bug in the Swift
+# compiler that causes the module breadcrumbs to be embedded even though the
+# `-no-clang-module-breadcrumbs` flag is passed
+# (https://bugs.swift.org/browse/SR-13275).
+SWIFT_FEATURE_USE_TMPDIR_FOR_MODULE_CACHE = "swift.use_tmpdir_for_module_cache"
+
 # If enabled, actions invoking the Swift driver or frontend may write argument
 # lists into response files (i.e., "@args.txt") to avoid passing command lines
 # that exceed the system limit. Toolchains typically set this automatically if

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":debug_settings_tests.bzl", "debug_settings_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
+load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
 load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
@@ -13,6 +14,8 @@ debug_settings_test_suite()
 coverage_settings_test_suite()
 
 generated_header_test_suite()
+
+module_cache_settings_test_suite()
 
 private_deps_test_suite()
 

--- a/test/module_cache_settings_tests.bzl
+++ b/test/module_cache_settings_tests.bzl
@@ -1,0 +1,81 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for module cache related command line flags under various configs."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+
+use_global_module_cache_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_global_module_cache",
+        ],
+    },
+)
+
+use_tmpdir_for_module_cache_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_tmpdir_for_module_cache",
+        ],
+    },
+)
+
+def module_cache_settings_test_suite(name = "module_cache_settings"):
+    """Test suite for module cache options.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
+
+    # Verify that a global module cache path is passed to swiftc.
+    use_global_module_cache_action_command_line_test(
+        name = "{}_global_module_cache_build".format(name),
+        expected_argv = [
+            "-module-cache-path",
+            # Starlark doesn't have support for regular expression yet, so we
+            # can't verify the whole argument here.
+            "/bin/_swift_module_cache",
+        ],
+        not_expected_argv = [
+            "-Xwrapped-swift=-ephemeral-module-cache",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that a pre-defined shared module cache path in `/private/tmp` is
+    # passed to swiftc.
+    use_tmpdir_for_module_cache_action_command_line_test(
+        name = "{}_tmpdir_module_cache_build".format(name),
+        expected_argv = [
+            "-module-cache-path",
+            "/private/tmp/__build_bazel_rules_swift_module_cache",
+        ],
+        not_expected_argv = [
+            "-Xwrapped-swift=-ephemeral-module-cache",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )


### PR DESCRIPTION
Add `swift.use_tmpdir_for_module_cache` feature

This adds a new feature, that can be enabled by passing
`--features=swift.use_tmpdir_for_module_cache` to the build
command.

This feature, when enabled, will makes the Swift compilation actions use
the shared Clang module cache path written to
`/private/tmp/__build_bazel_rules_swift`. This makes the embedded Clang
module breadcrumbs deterministic between Bazel instances, because they
are always embedded as absolute paths. Note that the use of this cache
is non-hermetic--the cached modules are not wiped between builds, and
won't be cleaned when invoking `bazel clean`; the user is responsible
for manually cleaning them.

Additionally, this can be used as a workaround for a bug in the Swift
compiler that causes the module breadcrumbs to be embedded even though the
`-no-clang-module-breadcrumbs` flag is passed
(https://bugs.swift.org/browse/SR-13275).
