### PR TITLE
Fix buildifier warnings

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -70,11 +70,3 @@ tasks:
 
 buildifier:
   version: latest
-  # TODO(b/140761855): Remove native-cc from this list.
-  # TODO(b/140761855): Remove native-proto from this list.
-  # TODO(b/140761855): Remove native-py from this list.
-  # Disable 'bzl-visibility' since it doesn't work properly.
-  #  https://github.com/bazelbuild/buildtools/issues/718
-  # TODO(b/155657940): Remove unnamed-macro from this list.
-  # TODO(b/158011388): Remove skylark-{comment,docstring} from this list.
-  warnings: -native-cc,-native-proto,-native-py,-bzl-visibility,-unnamed-macro,-skylark-comment,-skylark-docstring

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -68,5 +68,4 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *linux_common
 
-buildifier:
-  version: latest
+buildifier: latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,15 @@
 workspace(name = "build_bazel_rules_swift")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_cc",
+    sha256 = "b87996d308549fc3933f57a786004ef65b44b83fd63f1b0303a4bbc3fd26bbaf",
+    # Latest 08-10-20
+    strip_prefix = "rules_cc-1477dbab59b401daa94acedbeaefe79bf9112167",
+    url = "https://github.com/bazelbuild/rules_cc/archive/1477dbab59b401daa94acedbeaefe79bf9112167.tar.gz",
+)
+
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
     "swift_rules_dependencies",

--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -2,6 +2,7 @@
 # vice versa when it is linked into the existing native linking rules for Apple
 # platforms.
 
+load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//swift:swift.bzl",
     "swift_binary",

--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_binary", "swift_library")
 
 licenses(["notice"])

--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -10,6 +10,7 @@
 # 3.  Run the `echo_client` binary in the same terminal. It will send a request
 #     to this service and then print the response that it received.
 
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//swift:swift.bzl",
     "swift_binary",

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//swift:swift.bzl",
     "swift_binary",

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -14,6 +14,7 @@
 
 """A Swift library rule that generates gRPC services defined in protos."""
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     ":compiling.bzl",

--- a/swift/internal/swift_proto_library.bzl
+++ b/swift/internal/swift_proto_library.bzl
@@ -14,6 +14,7 @@
 
 """A rule that generates a Swift library from protocol buffer sources."""
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo")
 load(
     ":swift_protoc_gen_aspect.bzl",

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -14,6 +14,7 @@
 
 """An aspect attached to `proto_library` targets to generate Swift artifacts."""
 
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":attrs.bzl", "swift_config_attrs")

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -90,9 +90,12 @@ cacheable_opt_action_command_line_test = make_action_command_line_test_rule(
     config_settings = CACHEABLE_OPT_CONFIG_SETTINGS,
 )
 
-def debug_settings_test_suite():
-    """Test suite for serializing debugging options."""
-    name = "debug_settings"
+def debug_settings_test_suite(name = "debug_settings"):
+    """Test suite for serializing debugging options.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # Verify that `-c dbg` builds serialize debugging options, remap paths, and
     # have other appropriate debug flags.

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 

--- a/test/fixtures/swift_through_non_swift/BUILD
+++ b/test/fixtures/swift_through_non_swift/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -52,9 +52,12 @@ no_generate_header_provider_test = make_provider_test_rule(
     config_settings = NO_GENERATE_HEADER_CONFIG_SETTINGS,
 )
 
-def generated_header_test_suite():
-    """Test suite for `swift_library.generated_header`."""
-    name = "generated_header"
+def generated_header_test_suite(name = "generated_header"):
+    """Test suite for `swift_library.generated_header`.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # Verify that the generated header by default gets an automatically
     # generated name and is an output of the rule.

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -27,9 +27,12 @@ private_deps_provider_test = make_provider_test_rule(
     },
 )
 
-def private_deps_test_suite():
-    """Test suite for propagation behavior of `swift_library.private_deps`."""
-    name = "private_deps"
+def private_deps_test_suite(name = "private_deps"):
+    """Test suite for propagation behavior of `swift_library.private_deps`.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # Each of the two leaf libraries should propagate their own modules.
     private_deps_provider_test(

--- a/test/swift_through_non_swift_tests.bzl
+++ b/test/swift_through_non_swift_tests.bzl
@@ -19,9 +19,12 @@ load(
     "provider_test",
 )
 
-def swift_through_non_swift_test_suite():
-    """Test suite for propagation of `SwiftInfo` through non-Swift targets."""
-    name = "swift_through_non_swift"
+def swift_through_non_swift_test_suite(name = "swift_through_non_swift"):
+    """Test suite for propagation of `SwiftInfo` through non-Swift targets.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
 
     # The lower swiftmodule should get propagated through the `objc_library` (by
     # the aspect) and up to the upper target. Make sure it wasn't dropped.

--- a/third_party/bazel_protos/BUILD
+++ b/third_party/bazel_protos/BUILD
@@ -1,3 +1,6 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+
 licenses(["notice"])
 
 proto_library(

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_binary",
@@ -49,7 +50,7 @@ cc_library(
     tags = ["swift_module=CgRPC"],
     deps = [
         ":BoringSSL",
-        "@zlib//:zlib",
+        "@zlib",
     ],
 )
 

--- a/third_party/com_github_nlohmann_json/BUILD.overlay
+++ b/third_party/com_github_nlohmann_json/BUILD.overlay
@@ -1,10 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "json",
     srcs = glob(
         ["include/nlohmann/**/*.hpp"],
-        exclude = ["include/nlohmann/json.hpp"]),
+        exclude = ["include/nlohmann/json.hpp"],
+    ),
     hdrs = ["include/nlohmann/json.hpp"],
     includes = ["include"],
 )

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 package(
     default_visibility = [
         "//tools/worker:__pkg__",

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
 licenses(["notice"])
 
 # Workaround for the rules_apple integration tests to force the use of a


### PR DESCRIPTION
Some of these are imports that were being avoided. The name warning is still an issue https://github.com/bazelbuild/buildtools/issues/821 but I think it's preferred to move it to the default arg instead of having a disable for it.