### PR TITLE
Add error for no Linux swiftc path

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -203,6 +203,9 @@ def _create_linux_toolchain(repository_ctx):
              "in your environment before invoking Bazel.")
 
     path_to_swiftc = repository_ctx.which("swiftc")
+    if not path_to_swiftc:
+        fail("No 'swiftc' executable found in $PATH")
+
     root = path_to_swiftc.dirname.dirname
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
     version_file = _write_swift_version(repository_ctx, path_to_swiftc)


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_swift/issues/16