### PR TITLE
Update dump_toolchains to support home dir

### DIFF
--- a/tools/dump_toolchains/dump_toolchains.sh
+++ b/tools/dump_toolchains/dump_toolchains.sh
@@ -21,22 +21,23 @@ if [[ "$(uname)" != Darwin ]]; then
   exit 1
 fi
 
-toolchain_directory=/Library/Developer/Toolchains
-if [[ ! -d "$toolchain_directory" ]]; then
-  echo "error: '$toolchain_directory' doesn't exist"
-  exit 1
-fi
+readonly toolchain_directories=(
+  /Library/Developer/Toolchains
+  ~/Library/Developer/Toolchains
+)
 
-for toolchain in "$toolchain_directory"/*.xctoolchain
+for toolchain_directory in "${toolchain_directories[@]}"
 do
-  plist_path="$toolchain/Info.plist"
+  for toolchain in "$toolchain_directory"/*.xctoolchain
+  do
+    plist_path="$toolchain/Info.plist"
 
-  if [[ ! -f "$plist_path" ]]; then
-    echo "error: '$toolchain' is missing Info.plist"
-    exit 1
-  fi
+    if [[ ! -f "$plist_path" ]]; then
+      echo "error: '$toolchain' is missing Info.plist"
+      exit 1
+    fi
 
-  bundle_id=$(/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" "$plist_path")
-  toolchain_name=$(basename "$toolchain")
-  echo "$toolchain_name -> $bundle_id"
+    bundle_id=$(/usr/libexec/PlistBuddy -c "print :CFBundleIdentifier" "$plist_path")
+    echo "$toolchain -> $bundle_id"
+  done
 done


### PR DESCRIPTION
Before:

```
swift-DEVELOPMENT-SNAPSHOT-2020-01-29-a.xctoolchain -> org.swift.50202001291a
swift-TEST-SNAPSHOT-2020-01-23-a.xctoolchain -> org.swift.50202001231a
swift-latest.xctoolchain -> org.swift.50202001291a
```

After:

```
/Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2020-01-29-a.xctoolchain -> org.swift.50202001291a
/Library/Developer/Toolchains/swift-TEST-SNAPSHOT-2020-01-23-a.xctoolchain -> org.swift.50202001231a
/Library/Developer/Toolchains/swift-latest.xctoolchain -> org.swift.50202001291a
/Users/ksmiley/Library/Developer/Toolchains/swift-5.2-DEVELOPMENT-SNAPSHOT-2020-04-28-a.xctoolchain -> org.swift.52202004281a
/Users/ksmiley/Library/Developer/Toolchains/swift-latest.xctoolchain -> org.swift.52202004281a
```