### PR TITLE
Use a parameter file when linking Swift libraries when the host machine is macOS

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -58,7 +58,15 @@ def _register_static_library_link_action(
     )
     args = actions.args()
     args.add_all(command_line)
-    args.add_all(objects)
+
+    filelist_args = actions.args()
+    if swift_toolchain.linker_supports_filelist:
+        args.add("-filelist")
+        filelist_args.set_param_file_format("multiline")
+        filelist_args.use_param_file("%s", use_always = True)
+        filelist_args.add_all(objects)
+    else:
+        args.add_all(objects)
 
     env = cc_common.get_environment_variables(
         action_name = CPP_LINK_STATIC_LIBRARY_ACTION_NAME,
@@ -73,7 +81,7 @@ def _register_static_library_link_action(
     execution_requirements = {req: "1" for req in execution_requirements_list}
 
     actions.run(
-        arguments = [args],
+        arguments = [args, filelist_args],
         env = env,
         executable = archiver_path,
         execution_requirements = execution_requirements,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -162,6 +162,10 @@ The partial should be called with two arguments:
 *   `is_test`: A `Boolean` value indicating whether the target being linked is a
     test target.
 """,
+        "linker_supports_filelist": """\
+`Boolean`. Indicates whether or not the toolchain's linker supports the input
+files passed to it via a file list.
+""",
         "object_format": """\
 `String`. The object file format of the platform that the toolchain is
 targeting. The currently supported values are `"elf"` and `"macho"`.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -168,6 +168,12 @@ def _swift_toolchain_impl(ctx):
         toolchain_root,
     )
 
+    # The static archiver on Linux doesn't currently support the `-filelist`
+    # flag. This should be handled by the C++ toolchain once we migrate away
+    # from invoking the linker directly for static linking.
+    # See https://github.com/bazelbuild/rules_swift/pull/349#issuecomment-550353580.
+    linker_supports_filelist = True if ctx.attr.os == "darwin" else False
+
     # Combine build mode features, autoconfigured features, and required
     # features.
     requested_features = features_for_build_modes(ctx)
@@ -204,6 +210,7 @@ def _swift_toolchain_impl(ctx):
             command_line_copts = ctx.fragments.swift.copts(),
             cpu = ctx.attr.arch,
             linker_opts_producer = linker_opts_producer,
+            linker_supports_filelist = linker_supports_filelist,
             object_format = "elf",
             optional_implicit_deps = [],
             requested_features = requested_features,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -635,6 +635,7 @@ def _xcode_swift_toolchain_impl(ctx):
             command_line_copts = command_line_copts,
             cpu = cpu,
             linker_opts_producer = linker_opts_producer,
+            linker_supports_filelist = True,
             object_format = "macho",
             optional_implicit_deps = [],
             requested_features = requested_features,


### PR DESCRIPTION
This is to prevent the linking failures if a `swift_library` target has
too many files that can cause its linking args to become longer than the
system's command length limits. This does not change the behavior when
building on Linux yet, since `ar` does not support passing arguments
using a parameter file.

Redo of https://github.com/bazelbuild/rules_swift/pull/349 with platform-awareness. This is critical if you have a very large Swift target.