### PR TITLE
Ensure that intermediate outputs created for Swift source files (such as object files) do not have spaces in their names.

### DIFF
--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -80,11 +80,10 @@ def _intermediate_frontend_file_path(target_name, src):
         target and source file should be stored.
     """
     objs_dir = "{}_objs".format(target_name)
-    owner_rel_path = owner_relative_path(src)
 
-    # TODO(b/131185317): Remove this once ar_wrapper handles filenames with
-    # spaces correctly.
-    safe_name = src.basename.replace(" ", "__SPACE__")
+    owner_rel_path = owner_relative_path(src).replace(" ", "__SPACE__")
+    safe_name = paths.basename(owner_rel_path)
+
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
 
 def _intermediate_object_file(actions, target_name, src):


### PR DESCRIPTION
This was already handled for basenames, but not for directory names between the target's package and the file; for example, if one had `swift_library(name = "ArgumentParser", ...)` in a `BUILD` file that also contained `Sources/ArgumentParser/Parsable Types/ParsableCommand.swift`.

PiperOrigin-RevId: 329799243