### PR TITLE
Update bzl_library targets

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -6,28 +6,34 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 bzl_library(
-    name = "swift",
-    srcs = ["swift.bzl"],
+    name = "repositories",
+    srcs = ["repositories.bzl"],
     deps = [
-        "//swift/internal:build_defs",
-        "//swift/internal:rules",
-        "//swift/internal:swift_common",
+        "//swift/internal:swift_autoconfiguration",
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
     ],
 )
 
 bzl_library(
     name = "stats",
     srcs = ["stats.bzl"],
-    deps = [
-        "//swift/internal:build_defs",
-    ],
+    deps = ["//swift/internal:utils"],
 )
 
 bzl_library(
-    name = "repositories",
-    srcs = ["repositories.bzl"],
+    name = "swift",
+    srcs = ["swift.bzl"],
     deps = [
-        "//swift/internal:toolchain_support",
+        "//swift/internal:providers",
+        "//swift/internal:swift_binary_test",
+        "//swift/internal:swift_c_module",
+        "//swift/internal:swift_common",
+        "//swift/internal:swift_grpc_library",
+        "//swift/internal:swift_import",
+        "//swift/internal:swift_library",
+        "//swift/internal:swift_module_alias",
+        "//swift/internal:swift_proto_library",
+        "//swift/internal:swift_usage_aspect",
     ],
 )
 

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])
 bzl_library(
     name = "actions",
     srcs = ["actions.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":features",
         ":toolchain_config",
@@ -17,7 +17,7 @@ bzl_library(
 bzl_library(
     name = "attrs",
     srcs = ["attrs.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":providers",
         "@bazel_skylib//lib:dicts",
@@ -27,7 +27,7 @@ bzl_library(
 bzl_library(
     name = "autolinking",
     srcs = ["autolinking.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":actions",
         ":toolchain_config",
@@ -37,7 +37,7 @@ bzl_library(
 bzl_library(
     name = "compiling",
     srcs = ["compiling.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":actions",
         ":autolinking",
@@ -59,7 +59,7 @@ bzl_library(
 bzl_library(
     name = "debugging",
     srcs = ["debugging.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":actions",
         ":derived_files",
@@ -70,7 +70,7 @@ bzl_library(
 bzl_library(
     name = "derived_files",
     srcs = ["derived_files.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":utils",
         "@bazel_skylib//lib:paths",
@@ -80,7 +80,7 @@ bzl_library(
 bzl_library(
     name = "features",
     srcs = ["features.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":feature_names",
         "@bazel_skylib//lib:collections",
@@ -91,7 +91,7 @@ bzl_library(
 bzl_library(
     name = "linking",
     srcs = ["linking.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":derived_files",
         "@bazel_skylib//lib:collections",
@@ -103,14 +103,14 @@ bzl_library(
 bzl_library(
     name = "module_maps",
     srcs = ["module_maps.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = ["@bazel_skylib//lib:paths"],
 )
 
 bzl_library(
     name = "proto_gen_utils",
     srcs = ["proto_gen_utils.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":utils",
         "@bazel_skylib//lib:paths",
@@ -120,7 +120,7 @@ bzl_library(
 bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         "@bazel_skylib//lib:sets",
         "@bazel_skylib//lib:types",
@@ -130,14 +130,14 @@ bzl_library(
 bzl_library(
     name = "swift_autoconfiguration",
     srcs = ["swift_autoconfiguration.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = ["@build_bazel_rules_swift//swift/internal:feature_names"],
 )
 
 bzl_library(
     name = "swift_c_module",
     srcs = ["swift_c_module.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":swift_common",
         ":utils",
@@ -146,7 +146,7 @@ bzl_library(
 
 bzl_library(
     name = "swift_binary_test",
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":compiling",
         ":derived_files",
@@ -163,7 +163,7 @@ bzl_library(
 bzl_library(
     name = "swift_clang_module_aspect",
     srcs = ["swift_clang_module_aspect.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":attrs",
         ":compiling",
@@ -179,7 +179,7 @@ bzl_library(
 bzl_library(
     name = "swift_common",
     srcs = ["swift_common.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":attrs",
         ":compiling",
@@ -193,7 +193,7 @@ bzl_library(
 bzl_library(
     name = "swift_grpc_library",
     srcs = ["swift_grpc_library.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":compiling",
         ":feature_names",
@@ -210,7 +210,7 @@ bzl_library(
 bzl_library(
     name = "swift_import",
     srcs = ["swift_import.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":attrs",
         ":compiling",
@@ -224,7 +224,7 @@ bzl_library(
 bzl_library(
     name = "swift_library",
     srcs = ["swift_library.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":attrs",
         ":compiling",
@@ -242,7 +242,7 @@ bzl_library(
 bzl_library(
     name = "swift_module_alias",
     srcs = ["swift_module_alias.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":compiling",
         ":derived_files",
@@ -257,7 +257,7 @@ bzl_library(
 bzl_library(
     name = "swift_proto_library",
     srcs = ["swift_proto_library.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":providers",
         ":swift_protoc_gen_aspect",
@@ -268,7 +268,7 @@ bzl_library(
 bzl_library(
     name = "swift_protoc_gen_aspect",
     srcs = ["swift_protoc_gen_aspect.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":attrs",
         ":compiling",
@@ -287,7 +287,7 @@ bzl_library(
 bzl_library(
     name = "swift_toolchain",
     srcs = ["swift_toolchain.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":actions",
         ":attrs",
@@ -308,14 +308,14 @@ bzl_library(
 bzl_library(
     name = "swift_usage_aspect",
     srcs = ["swift_usage_aspect.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [":providers"],
 )
 
 bzl_library(
     name = "toolchain_config",
     srcs = ["toolchain_config.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
@@ -326,14 +326,14 @@ bzl_library(
 bzl_library(
     name = "utils",
     srcs = ["utils.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = ["@bazel_skylib//lib:paths"],
 )
 
 bzl_library(
     name = "xcode_swift_toolchain",
     srcs = ["xcode_swift_toolchain.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
     deps = [
         ":actions",
         ":attrs",
@@ -354,13 +354,13 @@ bzl_library(
 bzl_library(
     name = "feature_names",
     srcs = ["feature_names.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
 )
 
 bzl_library(
     name = "vfsoverlay",
     srcs = ["vfsoverlay.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//swift:__subpackages__"],
 )
 
 # Consumed by Bazel integration tests.

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -362,3 +362,18 @@ bzl_library(
     srcs = ["vfsoverlay.bzl"],
     visibility = ["//visibility:public"],
 )
+
+# Consumed by Bazel integration tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]) + [
+        # We should be depending on a filegroup here that represents this file
+        # and its dependencies, but it doesn't exist yet.
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+        "@bazel_tools//tools/build_defs/cc:action_names_test_files",
+    ],
+    visibility = [
+        "//swift:__pkg__",
+    ],
+)

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -3,107 +3,362 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 licenses(["notice"])
 
 bzl_library(
-    name = "rules",
-    srcs = [
-        "swift_binary_test.bzl",
-        "swift_c_module.bzl",
-        "swift_grpc_library.bzl",
-        "swift_import.bzl",
-        "swift_library.bzl",
-        "swift_module_alias.bzl",
-        "swift_proto_library.bzl",
-        "swift_protoc_gen_aspect.bzl",
-    ],
-    visibility = [
-        "//swift:__pkg__",
-    ],
+    name = "actions",
+    srcs = ["actions.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
-        ":build_defs",
-        ":swift_common",
+        ":features",
+        ":toolchain_config",
+        "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:types",
+    ],
+)
+
+bzl_library(
+    name = "attrs",
+    srcs = ["attrs.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":providers",
         "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:new_sets",
+    ],
+)
+
+bzl_library(
+    name = "autolinking",
+    srcs = ["autolinking.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actions",
+        ":toolchain_config",
+    ],
+)
+
+bzl_library(
+    name = "compiling",
+    srcs = ["compiling.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actions",
+        ":autolinking",
+        ":debugging",
+        ":derived_files",
+        ":feature_names",
+        ":features",
+        ":providers",
+        ":toolchain_config",
+        ":utils",
+        ":vfsoverlay",
+        "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
-        "@bazel_skylib//rules:common_settings",
+        "@bazel_skylib//lib:types",
+    ],
+)
+
+bzl_library(
+    name = "debugging",
+    srcs = ["debugging.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actions",
+        ":derived_files",
+        ":toolchain_config",
+    ],
+)
+
+bzl_library(
+    name = "derived_files",
+    srcs = ["derived_files.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "features",
+    srcs = ["features.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":feature_names",
+        "@bazel_skylib//lib:collections",
+        "@bazel_skylib//lib:new_sets",
+    ],
+)
+
+bzl_library(
+    name = "linking",
+    srcs = ["linking.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":derived_files",
+        "@bazel_skylib//lib:collections",
+        "@bazel_skylib//lib:partial",
+        "@bazel_tools//tools/build_defs/cc:action_names.bzl",
+    ],
+)
+
+bzl_library(
+    name = "module_maps",
+    srcs = ["module_maps.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_skylib//lib:paths"],
+)
+
+bzl_library(
+    name = "proto_gen_utils",
+    srcs = ["proto_gen_utils.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":utils",
+        "@bazel_skylib//lib:paths",
+    ],
+)
+
+bzl_library(
+    name = "providers",
+    srcs = ["providers.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_skylib//lib:sets",
+        "@bazel_skylib//lib:types",
+    ],
+)
+
+bzl_library(
+    name = "swift_autoconfiguration",
+    srcs = ["swift_autoconfiguration.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@build_bazel_rules_swift//swift/internal:feature_names"],
+)
+
+bzl_library(
+    name = "swift_c_module",
+    srcs = ["swift_c_module.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":swift_common",
+        ":utils",
+    ],
+)
+
+bzl_library(
+    name = "swift_binary_test",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":compiling",
+        ":derived_files",
+        ":feature_names",
+        ":linking",
+        ":providers",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:partial",
+    ],
+)
+
+bzl_library(
+    name = "swift_clang_module_aspect",
+    srcs = ["swift_clang_module_aspect.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attrs",
+        ":compiling",
+        ":derived_files",
+        ":feature_names",
+        ":features",
+        ":module_maps",
+        ":providers",
+        ":utils",
     ],
 )
 
 bzl_library(
     name = "swift_common",
     srcs = ["swift_common.bzl"],
-    visibility = [
-        "//swift:__pkg__",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attrs",
+        ":compiling",
+        ":features",
+        ":linking",
+        ":providers",
+        ":swift_clang_module_aspect",
     ],
-    deps = [":build_defs"],
 )
 
 bzl_library(
-    name = "build_defs",
-    srcs = [
-        "actions.bzl",
-        "attrs.bzl",
-        "autolinking.bzl",
-        "compiling.bzl",
-        "debugging.bzl",
-        "derived_files.bzl",
-        "feature_names.bzl",
-        "features.bzl",
-        "linking.bzl",
-        "module_maps.bzl",
-        "proto_gen_utils.bzl",
-        "providers.bzl",
-        "swift_clang_module_aspect.bzl",
-        "swift_usage_aspect.bzl",
-        "toolchain_config.bzl",
-        "utils.bzl",
-        "vfsoverlay.bzl",
-    ],
-    visibility = [
-        "//swift:__pkg__",
-    ],
+    name = "swift_grpc_library",
+    srcs = ["swift_grpc_library.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
-        "@bazel_skylib//lib:collections",
+        ":compiling",
+        ":feature_names",
+        ":linking",
+        ":proto_gen_utils",
+        ":providers",
+        ":swift_common",
+        ":utils",
         "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:new_sets",
-        "@bazel_skylib//lib:partial",
-        "@bazel_skylib//lib:paths",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "swift_import",
+    srcs = ["swift_import.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attrs",
+        ":compiling",
+        ":providers",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+    ],
+)
+
+bzl_library(
+    name = "swift_library",
+    srcs = ["swift_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attrs",
+        ":compiling",
+        ":feature_names",
+        ":linking",
+        ":providers",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:sets",
-        "@bazel_skylib//lib:types",
         "@bazel_skylib//rules:common_settings",
-        "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     ],
 )
 
 bzl_library(
-    name = "toolchain_support",
-    srcs = [
-        "swift_autoconfiguration.bzl",
-        "swift_toolchain.bzl",
-        "xcode_swift_toolchain.bzl",
-    ],
-    visibility = [
-        "//swift:__pkg__",
-    ],
+    name = "swift_module_alias",
+    srcs = ["swift_module_alias.bzl"],
+    visibility = ["//visibility:public"],
     deps = [
-        ":build_defs",
+        ":compiling",
+        ":derived_files",
+        ":linking",
+        ":providers",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+    ],
+)
+
+bzl_library(
+    name = "swift_proto_library",
+    srcs = ["swift_proto_library.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":providers",
+        ":swift_protoc_gen_aspect",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "swift_protoc_gen_aspect",
+    srcs = ["swift_protoc_gen_aspect.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":attrs",
+        ":compiling",
+        ":feature_names",
+        ":linking",
+        ":proto_gen_utils",
+        ":providers",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//rules:common_settings",
+        "@rules_proto//proto:defs",
+    ],
+)
+
+bzl_library(
+    name = "swift_toolchain",
+    srcs = ["swift_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actions",
+        ":attrs",
+        ":autolinking",
+        ":compiling",
+        ":debugging",
+        ":feature_names",
+        ":features",
+        ":providers",
+        ":toolchain_config",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:partial",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+    ],
+)
+
+bzl_library(
+    name = "swift_usage_aspect",
+    srcs = ["swift_usage_aspect.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [":providers"],
+)
+
+bzl_library(
+    name = "toolchain_config",
+    srcs = ["toolchain_config.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:types",
+    ],
+)
+
+bzl_library(
+    name = "utils",
+    srcs = ["utils.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_skylib//lib:paths"],
+)
+
+bzl_library(
+    name = "xcode_swift_toolchain",
+    srcs = ["xcode_swift_toolchain.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":actions",
+        ":attrs",
+        ":compiling",
+        ":feature_names",
+        ":features",
+        ":providers",
+        ":toolchain_config",
+        ":utils",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
+        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
 
-# Consumed by Bazel integration tests.
-filegroup(
-    name = "for_bazel_tests",
-    testonly = 1,
-    srcs = glob(["**"]) + [
-        # We should be depending on a filegroup here that represents this file
-        # and its dependencies, but it doesn't exist yet.
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
-        "@bazel_tools//tools/build_defs/cc:action_names_test_files",
-    ],
-    visibility = [
-        "//swift:__pkg__",
-    ],
+bzl_library(
+    name = "feature_names",
+    srcs = ["feature_names.bzl"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "vfsoverlay",
+    srcs = ["vfsoverlay.bzl"],
+    visibility = ["//visibility:public"],
 )

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -98,6 +98,18 @@ def swift_rules_dependencies():
 
     _maybe(
         http_archive,
+        name = "rules_proto",
+        # latest as of 2020-09-01
+        urls = [
+            "https://github.com/bazelbuild/rules_proto/archive/40298556293ae502c66579620a7ce867d5f57311.zip",
+        ],
+        sha256 = "37d32b789be90fead9ab108dbe4fe4df463d26c122dc896dc1bf134252d3c49a",
+        strip_prefix = "rules_proto-40298556293ae502c66579620a7ce867d5f57311",
+        type = "zip",
+    )
+
+    _maybe(
+        http_archive,
         name = "com_google_protobuf",
         # latest as of 2020-09-01
         urls = [

--- a/test/fixtures/BUILD
+++ b/test/fixtures/BUILD
@@ -7,3 +7,9 @@ bzl_library(
         "//test:__pkg__",
     ],
 )
+
+bzl_library(
+    name = "common",
+    srcs = ["common.bzl"],
+    visibility = ["//visibility:public"],
+)

--- a/test/fixtures/BUILD
+++ b/test/fixtures/BUILD
@@ -11,5 +11,5 @@ bzl_library(
 bzl_library(
     name = "common",
     srcs = ["common.bzl"],
-    visibility = ["//visibility:public"],
+    visibility = ["//test:__pkg__"],
 )


### PR DESCRIPTION
Mostly so depending on them from a stardoc rule works now we load rules_proto

Mostly autogenerated & then tweaked based on the gazelle in bazelbuild/bazel-skylib#271
