### PR TITLE
Add a feature flag to enable generation from raw proto sources.

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -208,3 +208,17 @@ SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
 # numbers of `-Wl,-add_ast_path,<path>` flags to the linker do not overrun the
 # system command line limit.
 SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE = "swift.no_embed_debug_module"
+
+# If enabled, the toolchain will directly generate from the raw proto files
+# and not from the DescriptorSets.
+#
+# The DescriptorSets ProtoInfo exposes don't have source info, so comments in
+# the .proto files don't get carried over to the generated Swift sources as
+# documentation comments. https://github.com/bazelbuild/bazel/issues/9337
+# is open to attempt to get that, but this provides a way to opt into forcing
+# it.
+#
+# This does come with a minor risk for cross repository and/or generated proto
+# files where the protoc command line might not be crafted correctly, so it
+# remains opt in.
+SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES = "swift.generate_from_raw_proto_files"

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -31,6 +31,7 @@ load(
     ":proto_gen_utils.bzl",
     "declare_generated_files",
     "extract_generated_dir_path",
+    "proto_import_path",
     "register_module_mapping_write_action",
 )
 load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo", "SwiftToolchainInfo")
@@ -40,7 +41,6 @@ load(
     "compact",
     "create_cc_info",
     "get_providers",
-    "proto_import_path",
 )
 
 def _register_grpcswift_generate_action(

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -330,36 +330,3 @@ def struct_fields(s):
         # TODO(b/36412967): Remove the `to_json` and `to_proto` checks.
         if field not in ("to_json", "to_proto")
     }
-
-def _workspace_relative_path(file):
-    """Returns the path of a file relative to its workspace.
-
-    Args:
-        file: The `File` object.
-
-    Returns:
-        The path of the file relative to its workspace.
-    """
-    workspace_path = paths.join(file.root.path, file.owner.workspace_root)
-    return paths.relativize(file.path, workspace_path)
-
-def proto_import_path(f, proto_source_root):
-    """ Returns the import path of a `.proto` file given its path.
-
-    Args:
-        f: The `File` object representing the `.proto` file.
-        proto_source_root: The source root for the `.proto` file.
-
-    Returns:
-        The path the `.proto` file should be imported at.
-    """
-
-    # The simple repo case seems to say this branch is never happening as the
-    # proto_source_root seems to always be ".". So the general logic here likely
-    # needs a revisit.
-    if f.path.startswith(proto_source_root):
-        return f.path[len(proto_source_root) + 1:]
-    else:
-        # Happens before Bazel 1.0, where proto_source_root was not
-        # guaranteed to be a parent of the .proto file
-        return _workspace_relative_path(f)


### PR DESCRIPTION
The DescriptorSets ProtoInfo exposes don't have source info, so the generated
source don't have the comment. https://github.com/bazelbuild/bazel/issues/9337
is open to attempt to get that, but this provides a way to opt into forcing it.

This does come with a minor risk for cross repository and/or generated proto
files where the protoc command line might not be crafted correctly, so it
remains opt in.

RELNOTES: None
PiperOrigin-RevId: 330538313