### PR TITLE
Don't propagate an empty module map for `{cc,objc}_library` targets t…

### DIFF
--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -179,6 +179,16 @@ def _module_info_for_target(
         if not aspect_ctx.rule.kind == "objc_library":
             return None, module_maps[0]
 
+        # If an `objc_library` doesn't have any headers (and doesn't specify an
+        # explicit module map), then don't generate or propagate a module map
+        # for it. Such modules define nothing and only waste space on the
+        # compilation command line and add more work for the compiler.
+        if not getattr(attr, "module_map", None) and not (
+            compilation_context.direct_headers or
+            compilation_context.direct_textual_headers
+        ):
+            return None, None
+
         module_name = getattr(attr, "module_name", None)
         if not module_name:
             module_name = derive_module_name(target.label)


### PR DESCRIPTION
…hat don't have any headers (and that don't specify an explicit module map using the `module_map` attribute).

This is typically the case for libraries that group other libraries via their `deps`. Users mistakenly import these thinking they're required to use the underlying declarations, but they do nothing (except make more work for the compiler).

PiperOrigin-RevId: 332246632
(cherry picked from commit 639ecfa9a164fc94ed205c25e6e43353ca0699c1)