### PR TITLE
Restore docs until next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,18 @@ load(
 swift_rules_dependencies()
 
 load(
-    "@build_bazel_rules_swift//swift:extras.bzl",
-    "swift_rules_extra_dependencies",
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
 )
 
-swift_rules_extra_dependencies()
+apple_support_dependencies()
+
+load(
+    "@com_google_protobuf//:protobuf_deps.bzl",
+    "protobuf_deps",
+)
+
+protobuf_deps()
 ```
 
 The `swift_rules_dependencies` macro creates a toolchain appropriate for your


### PR DESCRIPTION
@keith Hey, super sorry to ping you a bunch and then have you merge something that's not good. The docs shouldn't have been updated in #488 because because that macro is not in that release and there's no way to know what the commit/sha will be in adavance. This restores docs so users don't end up copy/pasing the wrong thing. Though, in the next release, this should be reverted.