### PR TITLE
Add use_default_shell_env to run / run_shell

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -240,6 +240,7 @@ def run_toolchain_action(
     actions.run(
         arguments = [tool_executable_args, args],
         env = tool_config.env,
+        use_default_shell_env = True,
         executable = executable,
         execution_requirements = execution_requirements,
         inputs = depset(

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -83,6 +83,7 @@ def _register_static_library_link_action(
     actions.run(
         arguments = [args, filelist_args],
         env = env,
+        use_default_shell_env = True,
         executable = archiver_path,
         execution_requirements = execution_requirements,
         inputs = depset(

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -278,6 +278,7 @@ def _create_xctest_bundle(name, actions, binary):
 
     actions.run_shell(
         arguments = [args],
+        use_default_shell_env = True,
         command = (
             'mkdir -p "$1/Contents/MacOS" && ' +
             'cp "$2" "$1/Contents/MacOS"'

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -187,6 +187,7 @@ def _register_grpcswift_generate_action(
             protoc_executable,
             protoc_plugin_executable,
         ],
+        use_default_shell_env = True,
         mnemonic = "ProtocGenSwiftGRPC",
         outputs = generated_files,
         progress_message = "Generating Swift sources for {}".format(label),

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -227,6 +227,7 @@ def _register_pbswift_generate_action(
             protoc_executable,
             protoc_plugin_executable,
         ],
+        use_default_shell_env = True,
     )
 
     return generated_files


### PR DESCRIPTION
This fixes https://github.com/bazelbuild/bazel/issues/12049 and
apparently is the recommendation wherever possible.