### PR TITLE
Update rules_swift to use the toolchain transition.

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -275,5 +275,6 @@ for incremental compilation using a persistent mode.
     doc = "Represents a Swift compiler toolchain.",
     fragments = ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -692,5 +692,6 @@ for incremental compilation using a persistent mode.
         "swift",
     ],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     implementation = _xcode_swift_toolchain_impl,
 )


### PR DESCRIPTION
This is phase 2 of of the switch to toolchain transitions. See https://github.com/bazelbuild/bazel/issues/11584 for details.

This shouldn't be merged into rules_swift's master branch until https://cs.opensource.google/bazel/bazel/+/58fdf63d81cc71f0315918b111fc56f4c039f1a5 is in a Bazel release (which should be 3.7, https://github.com/bazelbuild/bazel/issues/12188).

PiperOrigin-RevId: 334610489