### PR TITLE
Pass default_shell_env through actions

### DIFF
--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -300,6 +300,7 @@ def _swift_grpc_library_impl(ctx):
             feature_configuration = feature_configuration,
         ),
         compilation_outputs = compilation_outputs,
+        env = ctx.configuration.default_shell_env,
         is_dynamic = False,
         is_static = True,
         library_name = ctx.label.name,

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -211,6 +211,7 @@ def _swift_library_impl(ctx):
             feature_configuration = feature_configuration,
         ),
         compilation_outputs = compilation_outputs,
+        env = ctx.configuration.default_shell_env,
         is_dynamic = False,
         is_static = True,
         library_name = ctx.label.name,

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -80,6 +80,7 @@ def _swift_module_alias_impl(ctx):
             feature_configuration = feature_configuration,
         ),
         compilation_outputs = compilation_outputs,
+        env = ctx.configuration.default_shell_env,
         is_dynamic = False,
         is_static = True,
         library_name = ctx.label.name,

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -433,6 +433,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
                 feature_configuration = feature_configuration,
             ),
             compilation_outputs = compilation_outputs,
+            env = aspect_ctx.configuration.default_shell_env,
             is_dynamic = False,
             is_static = True,
             # Prevent conflicts with C++ protos in the same output directory,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -742,7 +742,10 @@ def _xcode_swift_toolchain_impl(ctx):
     if _is_xcode_at_least_version(xcode_config, "12.5"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
 
-    env = _xcode_env(platform = platform, xcode_config = xcode_config)
+    env = dicts.add(
+        ctx.configuration.default_shell_env,
+        _xcode_env(platform = platform, xcode_config = xcode_config),
+    )
     execution_requirements = xcode_config.execution_info()
     generated_header_rewriter = ctx.executable.generated_header_rewriter
 


### PR DESCRIPTION
Through the investigation of
https://github.com/bazelbuild/bazel/issues/12049 one of the things I
discovered was that when using `actions.run` there are 2 options for
environment variables. `use_default_shell_env = True` is recommended,
but cannot be used if you want to also pass `env` to the actions. To
support Xcode version selection we have to pass `env` with those
variables. Without the default shell env, we only get the environment
variables defined in the crosstool, but not those passed with
`--action_env`. This now adds variables passed as
`--action_env=FOO=BAR`, but not those passed as `--action_env=FOO`
(where the value is supposed to pass through).

This is useful to ensure a few things:

1. The default PATH things are executed with includes /usr/local/bin.
   This can result in pollution of binaries from homebrew. Previously
   there was no way to limit this
2. This should be a good replacement for using custom Swift toolchains.
   Currently those environment variables only apply to some actions
   (excluding those from bazel) using `--action_env=TOOLCHAINS=foo`
   should work better than the current solution (this change can be made
   as a followup)