### PR TITLE
Fix incremental compilation with derived files

### DIFF
--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -224,6 +224,24 @@ def _swiftc_output_file_map(actions, target_name):
     """
     return actions.declare_file("{}.output_file_map.json".format(target_name))
 
+def _swiftc_derived_output_file_map(actions, target_name):
+    """Declares a file for the output file map for a swiftmodule only action.
+
+    This JSON-formatted output map file allows us to supply our own paths and
+    filenames for the intermediate artifacts produced by multiple frontend
+    invocations, rather than using the temporary defaults.
+
+    Args:
+        actions: The context's actions object.
+        target_name: The name of the target being built.
+
+    Returns:
+        The declared `File`.
+    """
+    return actions.declare_file(
+        "{}.derived_output_file_map.json".format(target_name),
+    )
+
 def _swiftdoc(actions, module_name):
     """Declares a file for the Swift doc file created by a compilation rule.
 
@@ -330,6 +348,7 @@ derived_files = struct(
     static_archive = _static_archive,
     stats_directory = _stats_directory,
     swiftc_output_file_map = _swiftc_output_file_map,
+    swiftc_derived_output_file_map = _swiftc_derived_output_file_map,
     swiftdoc = _swiftdoc,
     swiftinterface = _swiftinterface,
     swiftmodule = _swiftmodule,

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -76,6 +76,11 @@ def split_derived_files_test_suite(name = "split_derived_files"):
         expected_argv = [
             "-emit-module-path",
             "-emit-object",
+            "-enable-batch-mode",
+            "simple.output_file_map.json",
+        ],
+        not_expected_argv = [
+            "simple.derived_output_file_map.json",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],
@@ -108,10 +113,13 @@ def split_derived_files_test_suite(name = "split_derived_files"):
         name = "{}_object_only".format(name),
         expected_argv = [
             "-emit-object",
+            "-enable-batch-mode",
+            "simple.output_file_map.json",
         ],
         mnemonic = "SwiftCompile",
         not_expected_argv = [
             "-emit-module-path",
+            "simple.derived_output_file_map.json",
         ],
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
@@ -121,10 +129,13 @@ def split_derived_files_test_suite(name = "split_derived_files"):
         name = "{}_swiftmodule_only".format(name),
         expected_argv = [
             "-emit-module-path",
+            "-enable-batch-mode",
+            "simple.derived_output_file_map.json",
         ],
         mnemonic = "SwiftDeriveFiles",
         not_expected_argv = [
             "-emit-object",
+            "simple.output_file_map.json",
         ],
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",


### PR DESCRIPTION
For incremental compilation we pass an output file map to compile
actions. Since we have 2 actions with the derived files feature, they
were fighting to write the same set of files. In this case we now pass a
separate output file map to the derived files action that only contains
the swiftmodules, and one that only contains the objects to the standard
compile.