### PR TITLE
Output command lines of failed action command line tests

### DIFF
--- a/test/rules/action_command_line_test.bzl
+++ b/test/rules/action_command_line_test.bzl
@@ -69,18 +69,20 @@ def _action_command_line_test_impl(ctx):
         if expected + " " not in concatenated_args:
             unittest.fail(
                 env,
-                "{}expected argv to contain '{}', but it did not".format(
+                "{}expected argv to contain '{}', but it did not: {}".format(
                     message_prefix,
                     expected,
+                    concatenated_args,
                 ),
             )
     for not_expected in ctx.attr.not_expected_argv:
         if not_expected + " " in concatenated_args:
             unittest.fail(
                 env,
-                "{}expected argv to not contain '{}', but it did".format(
+                "{}expected argv to not contain '{}', but it did: {}".format(
                     message_prefix,
                     not_expected,
+                    concatenated_args,
                 ),
             )
 


### PR DESCRIPTION
This is helpful when debugging what does or doesn't exist