### PR TITLE
Fix derive files with bitcode

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -319,7 +319,6 @@ def _all_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
-                swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
             ],
             configurators = [swift_toolchain_config.add_arg("-embed-bitcode")],
@@ -328,7 +327,6 @@ def _all_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
-                swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
             ],
             configurators = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -32,3 +32,11 @@ bzl_library(
         "//test/rules:starlark_tests_bzls",
     ],
 )
+
+# TODO: Remove once https://github.com/bazelbuild/bazel/pull/10945 lands
+config_setting(
+    name = "linux",
+    constraint_values = [
+        "@bazel_tools//platforms:linux",
+    ],
+)

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -274,9 +274,12 @@ def split_derived_files_test_suite(name = "split_derived_files"):
 
     split_swiftmodule_bitcode_test(
         name = "{}_bitcode_compile".format(name),
-        expected_argv = [
-            "-embed-bitcode",
-        ],
+        expected_argv = select({
+            "//test:linux": [],
+            "//conditions:default": [
+                "-embed-bitcode",
+            ],
+        }),
         mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
@@ -294,9 +297,12 @@ def split_derived_files_test_suite(name = "split_derived_files"):
 
     split_swiftmodule_bitcode_markers_test(
         name = "{}_bitcode_markers_compile".format(name),
-        expected_argv = [
-            "-embed-bitcode-marker",
-        ],
+        expected_argv = select({
+            "//test:linux": [],
+            "//conditions:default": [
+                "-embed-bitcode-marker",
+            ],
+        }),
         mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -64,6 +64,22 @@ split_swiftmodule_indexing_test = make_action_command_line_test_rule(
         ],
     },
 )
+split_swiftmodule_bitcode_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:apple_bitcode": "embedded",
+        "//command_line_option:features": [
+            "swift.split_derived_files_generation",
+        ],
+    },
+)
+split_swiftmodule_bitcode_markers_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:apple_bitcode": "embedded_markers",
+        "//command_line_option:features": [
+            "swift.split_derived_files_generation",
+        ],
+    },
+)
 
 def split_derived_files_test_suite(name = "split_derived_files"):
     """Test suite for split derived files options.
@@ -252,6 +268,46 @@ def split_derived_files_test_suite(name = "split_derived_files"):
             "-emit-object",
             "-index-store-path",
         ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_bitcode_test(
+        name = "{}_bitcode_compile".format(name),
+        expected_argv = [
+            "-embed-bitcode",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_bitcode_test(
+        name = "{}_bitcode_derive_files".format(name),
+        not_expected_argv = [
+            "-embed-bitcode",
+        ],
+        mnemonic = "SwiftDeriveFiles",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_bitcode_markers_test(
+        name = "{}_bitcode_markers_compile".format(name),
+        expected_argv = [
+            "-embed-bitcode-marker",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_bitcode_markers_test(
+        name = "{}_bitcode_markers_derive_files".format(name),
+        not_expected_argv = [
+            "-embed-bitcode-marker",
+        ],
+        mnemonic = "SwiftDeriveFiles",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
The bitcode flags should not be passed to these actions otherwise you
get this warning:

```
ignoring -embed-bitcode since no object file is being generated
```