### PR TITLE
Fix swift build rules not recognizing "licenses" attribute.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -41,6 +41,9 @@ If the Swift toolchain supports implementation-only imports (`private_deps` on
 indirect (transitive) dependents.
 """,
         ),
+        # Deprecated, but Starlark rules do not inherit `licenses` by default
+        # (see b/169635467).
+        "licenses": attr.license(),  # buildifier: disable=attr-license
     }
 
 def swift_compilation_attrs(additional_deps_aspects = []):


### PR DESCRIPTION
I'm reluctantly taking this even though no one should use it just so we
can ideally reduce future conflicts with upstream changes.

PiperOrigin-RevId: 338254161
(cherry picked from commit ef51377b00ac29b509733bc9ec20fce9ffe28e33)