### PR TITLE
Add swift.remap_xcode_path feature

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -239,4 +239,4 @@ SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES = "swift.skip_function_bodies_for_deri
 
 # If enabled remap the absolute path to Xcode in debug info. When used with
 # swift.coverage_prefix_map also remap the path in coverage data.
-SWIFT_REMAP_XCODE_PATH = "swift.remap_xcode_path"
+SWIFT_FEATURE_REMAP_XCODE_PATH = "swift.remap_xcode_path"

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -236,3 +236,7 @@ SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION = "swift.split_derived_files_genera
 # If enabled the skip function bodies frontend flag is passed when using derived
 # files generation. This requires Swift 5.2
 SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES = "swift.skip_function_bodies_for_derived_files"
+
+# If enabled remap the absolute path to Xcode in debug info. When used with
+# swift.coverage_prefix_map also remap the path in coverage data.
+SWIFT_REMAP_XCODE_PATH = "swift.remap_xcode_path"

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -39,10 +39,10 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
+    "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
-    "SWIFT_REMAP_XCODE_PATH",
 )
 load(":features.bzl", "features_for_build_modes")
 load(":toolchain_config.bzl", "swift_toolchain_config")
@@ -351,7 +351,7 @@ def _all_action_configs(
                 ),
             ],
             features = [
-                [SWIFT_REMAP_XCODE_PATH, SWIFT_FEATURE_DEBUG_PREFIX_MAP],
+                [SWIFT_FEATURE_REMAP_XCODE_PATH, SWIFT_FEATURE_DEBUG_PREFIX_MAP],
             ],
         ),
         swift_toolchain_config.action_config(
@@ -367,7 +367,7 @@ def _all_action_configs(
             ],
             features = [
                 [
-                    SWIFT_REMAP_XCODE_PATH,
+                    SWIFT_FEATURE_REMAP_XCODE_PATH,
                     SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
                     SWIFT_FEATURE_COVERAGE,
                 ],

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -32,6 +32,8 @@ load(
     "SWIFT_FEATURE_BITCODE_EMBEDDED",
     "SWIFT_FEATURE_BITCODE_EMBEDDED_MARKERS",
     "SWIFT_FEATURE_BUNDLED_XCTESTS",
+    "SWIFT_FEATURE_COVERAGE",
+    "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
@@ -40,6 +42,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
+    "SWIFT_REMAP_XCODE_PATH",
 )
 load(":features.bzl", "features_for_build_modes")
 load(":toolchain_config.bzl", "swift_toolchain_config")
@@ -333,6 +336,42 @@ def _all_action_configs(
                 swift_toolchain_config.add_arg("-embed-bitcode-marker"),
             ],
             features = [SWIFT_FEATURE_BITCODE_EMBEDDED_MARKERS],
+        ),
+
+        # Xcode path remapping
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-debug-prefix-map",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                ),
+            ],
+            features = [
+                [SWIFT_REMAP_XCODE_PATH, SWIFT_FEATURE_DEBUG_PREFIX_MAP],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-coverage-prefix-map",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                ),
+            ],
+            features = [
+                [
+                    SWIFT_REMAP_XCODE_PATH,
+                    SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
+                    SWIFT_FEATURE_COVERAGE,
+                ],
+            ],
         ),
     ]
 

--- a/test/coverage_settings_tests.bzl
+++ b/test/coverage_settings_tests.bzl
@@ -20,6 +20,16 @@ coverage_prefix_map_test = make_action_command_line_test_rule(
     },
 )
 
+coverage_xcode_prefix_map_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:collect_code_coverage": "true",
+        "//command_line_option:features": [
+            "swift.coverage_prefix_map",
+            "swift.remap_xcode_path",
+        ],
+    },
+)
+
 def coverage_settings_test_suite(name = "coverage_settings"):
     """Test suite for coverage options.
 
@@ -48,6 +58,20 @@ def coverage_settings_test_suite(name = "coverage_settings"):
             "-profile-coverage-mapping",
             "-Xwrapped-swift=-coverage-prefix-pwd-is-dot",
         ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    coverage_xcode_prefix_map_test(
+        name = "{}_xcode_prefix_map".format(name),
+        tags = [name],
+        expected_argv = select({
+            "//test:linux": [],
+            "//conditions:default": [
+                "-coverage-prefix-map",
+                "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+            ],
+        }),
         mnemonic = "SwiftCompile",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -218,6 +218,7 @@ def debug_settings_test_suite(name = "debug_settings"):
         not_expected_argv = [
             "-Xfrontend -serialize-debugging-options",
         ],
+        mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -90,6 +90,16 @@ cacheable_opt_action_command_line_test = make_action_command_line_test_rule(
     config_settings = CACHEABLE_OPT_CONFIG_SETTINGS,
 )
 
+xcode_remap_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:features": [
+            "swift.debug_prefix_map",
+            "swift.remap_xcode_path",
+        ],
+    },
+)
+
 def debug_settings_test_suite(name = "debug_settings"):
     """Test suite for serializing debugging options.
 
@@ -208,6 +218,19 @@ def debug_settings_test_suite(name = "debug_settings"):
         not_expected_argv = [
             "-Xfrontend -serialize-debugging-options",
         ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    xcode_remap_command_line_test(
+        name = "{}_remap_xcode_path".format(name),
+        expected_argv = select({
+            "//test:linux": [],
+            "//conditions:default": [
+                "-debug-prefix-map",
+                "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+            ],
+        }),
         mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",


### PR DESCRIPTION
This is analogous to https://github.com/bazelbuild/bazel/commit/bc5883a04ef5148038edd0080e1565a0cb1688b0

It leads to more hermetic binaries and shouldn't have any impact on
debugging.