### PR TITLE
Only read output_file_map if it's going to be written

### DIFF
--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -72,7 +72,6 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (prev_arg == "-output-file-map") {
       output_file_map_path = arg;
-      output_file_map.ReadFromPath(output_file_map_path);
       arg.clear();
     } else if (ArgumentEnablesWMO(arg)) {
       is_wmo = true;
@@ -87,6 +86,8 @@ void WorkProcessor::ProcessWorkRequest(
 
   if (!output_file_map_path.empty()) {
     if (!is_wmo) {
+      output_file_map.ReadFromPath(output_file_map_path);
+
       // Rewrite the output file map to use the incremental storage area and
       // pass the compiler the path to the rewritten file.
       auto new_path =


### PR DESCRIPTION
The output_file_map is only written to disk in a transformed state if an incremental build is happening. This change causes the output_file_map to only be read and processed in that case as well, leading to less work in the WMO case.

This was part of #413, but since that's dropped I'm proposing we include it on its own.