### PR TITLE
Create a build setting to allow forcing a Swift target to Apple with bazel transitions.

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -55,6 +55,14 @@ bool_setting(
     build_setting_default = False,
 )
 
+# Configuration setting for forcing generation of Apple targets.
+# NOTE: this is only intended for use with transitions that want to force
+# building of an Apple target when building for Linux.
+bool_setting(
+    name = "force_apple_target",
+    build_setting_default = False,
+)
+
 # Allows a user to override the default Swift driver during a build, if the
 # toolchain is using the default.
 label_flag(

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -347,6 +347,7 @@ bzl_library(
         "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
+        "@bazel_skylib//rules:common_settings",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -325,7 +325,7 @@ def swift_toolchain_driver_attrs():
     return {
         "swift_executable": attr.label(
             allow_single_file = True,
-            cfg = "host",
+            cfg = "exec",
             doc = """\
 A replacement Swift driver executable.
 
@@ -337,7 +337,7 @@ that it is invoked in the correct mode (i.e., `swift`, `swiftc`,
         ),
         "_default_swift_executable": attr.label(
             allow_files = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label(
                 "@build_bazel_rules_swift//swift:default_swift_executable",
             ),


### PR DESCRIPTION
PiperOrigin-RevId: 339779917
(cherry picked from commit e4ad1cc258a33946d506f1ed8805b2bdbcaeff17)