### PR TITLE
Remove the `swift.implicit_modules` feature.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -43,7 +43,6 @@ load(
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
-    "SWIFT_FEATURE_IMPLICIT_MODULES",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_MINIMAL_DEPS",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
@@ -445,10 +444,8 @@ def compile_action_configs():
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [_global_module_cache_configurator],
-            features = [
-                SWIFT_FEATURE_IMPLICIT_MODULES,
-                SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
-            ],
+            features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+            not_features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
         swift_toolchain_config.action_config(
             actions = [
@@ -460,8 +457,10 @@ def compile_action_configs():
                     "-Xwrapped-swift=-ephemeral-module-cache",
                 ),
             ],
-            features = [SWIFT_FEATURE_IMPLICIT_MODULES],
-            not_features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+            not_features = [
+                [SWIFT_FEATURE_USE_C_MODULES],
+                [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+            ],
         ),
         swift_toolchain_config.action_config(
             actions = [

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -99,12 +99,6 @@ SWIFT_FEATURE_ENABLE_TESTING = "swift.enable_testing"
 # warnings otherwise.
 SWIFT_FEATURE_FULL_DEBUG_INFO = "swift.full_debug_info"
 
-# If enabled, ClangImporter will perform implicit search for module maps and
-# compile modules in the implicit module cache for any that were not provided
-# explicitly on the command line. Otherwise, all modules must be provided
-# explicitly.
-SWIFT_FEATURE_IMPLICIT_MODULES = "swift.implicit_modules"
-
 # If enabled, the compilation action for a target will produce an index store.
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -29,7 +29,6 @@ load(
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
-    "SWIFT_FEATURE_IMPLICIT_MODULES",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
@@ -221,12 +220,6 @@ def _create_linux_toolchain(repository_ctx):
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
     version_file = _write_swift_version(repository_ctx, path_to_swiftc)
 
-    # TODO: This is being enabled here, rather than in the toolchain rule
-    # implementations, so that we can provide a way to optionally turn it off
-    # later when we have a way to model modules from outside Bazel workspaces
-    # (i.e., from the Swift toolchain) as explicit modules.
-    feature_values.append(SWIFT_FEATURE_IMPLICIT_MODULES)
-
     # TODO: This should be removed so that private headers can be used with
     # explicit modules, but the build targets for CgRPC need to be cleaned up
     # first because they contain C++ code.
@@ -267,12 +260,6 @@ def _create_xcode_toolchain(repository_ctx):
       repository_ctx: The repository rule context.
     """
     feature_values = [
-        # TODO: This is being enabled here, rather than in the toolchain rule
-        # implementations, so that we can provide a way to optionally turn it
-        # off later when we have a way to model modules from outside Bazel
-        # workspaces (i.e., from the Swift toolchain and Xcode SDKs) as explicit
-        # modules.
-        SWIFT_FEATURE_IMPLICIT_MODULES,
         # TODO: This should be removed so that private headers can be used with
         # explicit modules, but the build targets for CgRPC need to be cleaned
         # up first because they contain C++ code.


### PR DESCRIPTION
This feature permitted an odd three-state situation around the way the implicit module cache is handled:

1. The so-called "global module cache", which is placed in `bazel-out`
2. The ephemeral module cache, which is created and destroyed around each compile action
3. A state where no flags related to the implicit module cache are passed to the compiler, meaning "do whatever the compiler does by default".

This third state is the one we want to get rid of, since the default is to place the module cache in a temp location outside the sandbox.

PiperOrigin-RevId: 344942165
(cherry picked from commit 575b819f0bc7d06e1844c0721b8470707a7b4239)