### PR TITLE
Make the `srcs` attribute of `swift_library` mandatory and non-empty.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -43,7 +43,9 @@ indirect (transitive) dependents.
         ),
     }
 
-def swift_compilation_attrs(additional_deps_aspects = []):
+def swift_compilation_attrs(
+        additional_deps_aspects = [],
+        requires_srcs = True):
     """Returns an attribute dictionary for rules that compile Swift code.
 
     The returned dictionary contains the subset of attributes that are shared by
@@ -76,6 +78,8 @@ def swift_compilation_attrs(additional_deps_aspects = []):
             by the individual rules to avoid potential circular dependencies
             between the API and the aspects; the API loaded the aspects
             directly, then those aspects would not be able to load the API.
+        requires_srcs: Indicates whether the `srcs` attribute should be marked
+            as mandatory and non-empty. Defaults to `True`.
 
     Returns:
         A new attribute dictionary that can be added to the attributes of a
@@ -89,11 +93,13 @@ def swift_compilation_attrs(additional_deps_aspects = []):
         swift_toolchain_attrs(),
         {
             "srcs": attr.label_list(
-                flags = ["DIRECT_COMPILE_TIME_INPUT"],
+                allow_empty = not requires_srcs,
                 allow_files = ["swift"],
                 doc = """\
 A list of `.swift` source files that will be compiled into the library.
 """,
+                flags = ["DIRECT_COMPILE_TIME_INPUT"],
+                mandatory = requires_srcs,
             ),
             "copts": attr.string_list(
                 doc = """\
@@ -186,7 +192,9 @@ Linux), those dependencies will be **ignored.**
         **kwargs
     )
 
-def swift_library_rule_attrs(additional_deps_aspects = []):
+def swift_library_rule_attrs(
+        additional_deps_aspects = [],
+        requires_srcs = True):
     """Returns an attribute dictionary for `swift_library`-like rules.
 
     The returned dictionary contains the same attributes that are defined by the
@@ -221,6 +229,8 @@ def swift_library_rule_attrs(additional_deps_aspects = []):
             by the individual rules to avoid potential circular dependencies
             between the API and the aspects; the API loaded the aspects
             directly, then those aspects would not be able to load the API.
+        requires_srcs: Indicates whether the `srcs` attribute should be marked
+            as mandatory and non-empty. Defaults to `True`.
 
     Returns:
         A new attribute dictionary that can be added to the attributes of a
@@ -229,6 +239,7 @@ def swift_library_rule_attrs(additional_deps_aspects = []):
     return dicts.add(
         swift_compilation_attrs(
             additional_deps_aspects = additional_deps_aspects,
+            requires_srcs = requires_srcs,
         ),
         swift_config_attrs(),
         {

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -36,6 +36,7 @@ def _binary_rule_attrs(stamp_default):
     return dicts.add(
         swift_common.compilation_attrs(
             additional_deps_aspects = [swift_common.swift_clang_module_aspect],
+            requires_srcs = False,
         ),
         {
             "linkopts": attr.string_list(


### PR DESCRIPTION
PiperOrigin-RevId: 345120894
(cherry picked from commit c21080442fe664cfa3f4a35fc654e10af8791b37)