### PR TITLE
Migration off SwiftInfo.module_name.

### DIFF
--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -350,6 +350,8 @@ def create_swift_info(
         # was one, and if the legacy `module_name` parameter wasn't already
         # given.
         module_name = modules[0].name
+    elif module_name and modules and module_name != modules[0].name:
+        fail("Explicit module name should be the first provided module.")
 
     transitive_defines = []
     transitive_modules = []

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -29,10 +29,17 @@ load(":utils.bzl", "compact", "create_cc_info", "get_providers")
 def _swift_module_alias_impl(ctx):
     deps = ctx.attr.deps
     module_mapping = {
-        dep[SwiftInfo].module_name: dep.label
+        module.name: dep.label
         for dep in deps
-        if dep[SwiftInfo].module_name
+        for module in dep[SwiftInfo].direct_modules
     }
+
+    # TODO(b/149999519): remove the support for SwiftInfo.module_name that
+    # didn't have any direct_modules.
+    for dep in deps:
+        swift_info = dep[SwiftInfo]
+        if not swift_info.direct_modules and swift_info.module_name:
+            module_mapping[swift_info.module_name] = dep.label
 
     module_name = ctx.attr.module_name
     if not module_name:


### PR DESCRIPTION
- Make module alias use the direct modules instead with legacy fall back for the
  existing support.
- Validate during creation of SwiftInfo that any provided module_name matches the
  first module (if any modules are provided).

RELNOTES: None
PiperOrigin-RevId: 345237478
(cherry picked from commit 46613b2f6056cfd9b0c491f72f1faa57c938e3db)