### PR TITLE
Require `name` to be a named argument.

### DIFF
--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -202,7 +202,7 @@ provider.
     },
 )
 
-def create_module(name, *, clang = None, swift = None):
+def create_module(*, name, clang = None, swift = None):
     """Creates a value containing Clang/Swift module artifacts of a dependency.
 
     At least one of the `clang` and `swift` arguments must not be `None`. It is


### PR DESCRIPTION
RELNOTES: None
PiperOrigin-RevId: 347033042
(cherry picked from commit 3355e61c8cddd33e2e3158d61a3ddefd06368b38)