### PR TITLE
Fix XCTest -I for derived files

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -392,6 +392,7 @@ def _all_action_configs(
             swift_toolchain_config.action_config(
                 actions = [
                     swift_action_names.COMPILE,
+                    swift_action_names.DERIVE_FILES,
                     swift_action_names.PRECOMPILE_C_MODULE,
                 ],
                 configurators = [


### PR DESCRIPTION
In 768bfe3fe885f92fbaea75488268e2612ab9ef9c this was moved and this wasn't added (since it isn't used inside Google)