### PR TITLE
Work around https://github.com/bazelbuild/stardoc/issues/78.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -177,6 +177,7 @@ Allowed kinds of dependencies are:
 
 *   `swift_c_module`, `swift_import` and `swift_library` (or anything
     propagating `SwiftInfo`)
+
 *   `cc_library` (or anything propagating `CcInfo`)
 
 Additionally, on platforms that support Objective-C interop, `objc_library`

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -107,6 +107,7 @@ The partial should be called with two arguments:
 
 *   `is_static`: A `Boolean` value indicating whether to link against the static
     or dynamic runtime libraries.
+
 *   `is_test`: A `Boolean` value indicating whether the target being linked is a
     test target.
 """,
@@ -157,6 +158,7 @@ compiles).
 
 *   `env`: A `dict` of environment variables to be set when running tests
     that were built with this toolchain.
+
 *   `execution_requirements`: A `dict` of execution requirements for tests
     that were built with this toolchain.
 

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -67,8 +67,10 @@ into the binary. Possible values are:
 * `stamp = 1`: Stamp the build information into the binary. Stamped binaries are
   only rebuilt when their dependencies change. Use this if there are tests that
   depend on the build information.
+
 * `stamp = 0`: Always replace build information by constant values. This gives
   good build result caching.
+
 * `stamp = -1`: Embedding of build information is controlled by the
   `--[no]stamp` flag.
 """,

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -384,7 +384,9 @@ on the `swift_grpc_library` implementing the service.
 The kind of definitions that should be generated:
 
 *   `"client"` to generate client definitions.
+
 *   `"client_stubs"` to generate client test stubs.
+
 *   `"server"` to generate server definitions.
 """,
             ),


### PR DESCRIPTION
Markdown bullet lists work fine in the general descriptions block of macros/rules/providers, but for rule attributes and provider fields the the markdown is a table, and `*` has no means (and stardoc transforms the content to remove newlines). The above issue is to support catch these and marking html bullet lists out of them, but until that is done, adding a blank line between each bullet gets slightly more readable generated/render documents.

PiperOrigin-RevId: 348682502
(cherry picked from commit 5383052ecc5e008dd9e4a42edf2570c60bd6dc5c)