### PR TITLE
Remove DEBUG flag from fastbuild compilation

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -213,7 +213,7 @@ def compile_action_configs():
             configurators = [
                 swift_toolchain_config.add_arg("-DDEBUG"),
             ],
-            features = [[SWIFT_FEATURE_DBG], [SWIFT_FEATURE_FASTBUILD]],
+            features = [[SWIFT_FEATURE_DBG]],
         ),
         swift_toolchain_config.action_config(
             actions = [


### PR DESCRIPTION
I suggest that the flag should be only included in dbg compilation mode and not in fastbuild since I consider it should be used specifically for debugging purposes