### PR TITLE
Remove swift_version.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2056,28 +2056,6 @@ def _register_post_compile_actions(
         linker_inputs = linker_inputs,
     )
 
-def find_swift_version_copt_value(copts):
-    """Returns the value of the `-swift-version` argument, if found.
-
-    Args:
-        copts: The list of copts to be scanned.
-
-    Returns:
-        The value of the `-swift-version` argument, or None if it was not found
-        in the copt list.
-    """
-
-    # Note that the argument can occur multiple times, and the last one wins.
-    last_swift_version = None
-
-    count = len(copts)
-    for i in range(count):
-        copt = copts[i]
-        if copt == "-swift-version" and i + 1 < count:
-            last_swift_version = copts[i + 1]
-
-    return last_swift_version
-
 def new_objc_provider(
         deps,
         link_inputs,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -28,14 +28,6 @@ has reasonable defaults for any fields not explicitly set.
 `List` of values returned from `swift_common.create_module`. The modules (both
 Swift and C/Objective-C) emitted by the library that propagated this provider.
 """,
-        "swift_version": """\
-`String`. The version of the Swift language that was used when compiling the
-propagating target; that is, the value passed via the `-swift-version` compiler
-flag. This will be `None` if the flag was not set.
-
-This field is deprecated; the Swift version should be obtained by inspecting the
-arguments passed to specific compilation actions.
-""",
         "transitive_modules": """\
 `Depset` of values returned from `swift_common.create_module`. The transitive
 modules (both Swift and C/Objective-C) emitted by the library that propagated
@@ -296,8 +288,7 @@ def create_swift_module(
 def create_swift_info(
         *,
         modules = [],
-        swift_infos = [],
-        swift_version = None):
+        swift_infos = []):
     """Creates a new `SwiftInfo` provider with the given values.
 
     This function is recommended instead of directly creating a `SwiftInfo`
@@ -317,9 +308,6 @@ def create_swift_info(
         swift_infos: A list of `SwiftInfo` providers from dependencies, whose
             transitive fields should be merged into the new one. If omitted, no
             transitive data is collected.
-        swift_version: A string containing the value of the `-swift-version`
-            flag used when compiling this target, or `None` (the default) if it
-            was not set or is not relevant.
 
     Returns:
         A new `SwiftInfo` provider with the given values.
@@ -329,6 +317,5 @@ def create_swift_info(
 
     return SwiftInfo(
         direct_modules = modules,
-        swift_version = swift_version,
         transitive_modules = depset(modules, transitive = transitive_modules),
     )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -17,7 +17,6 @@
 load(":attrs.bzl", "swift_deps_attr")
 load(
     ":compiling.bzl",
-    "find_swift_version_copt_value",
     "new_objc_provider",
     "output_groups_from_compilation_outputs",
     "swift_library_output_map",
@@ -246,7 +245,6 @@ def _swift_library_impl(ctx):
             # Note that private_deps are explicitly omitted here; they should
             # not propagate.
             swift_infos = get_providers(deps, SwiftInfo),
-            swift_version = find_swift_version_copt_value(copts),
         ),
     ]
 


### PR DESCRIPTION
It was deprecated a while ago, and it avoids the collection in swift_library now.

RELNOTES: None
PiperOrigin-RevId: 351595739
(cherry picked from commit 5b1aabd92e93e38d0e98dcaa6ce062f9476d9d86)