### PR TITLE
Lessen restrictions on when implicit modules can be used:

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -463,6 +463,9 @@ def compile_action_configs():
                 [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
             ],
         ),
+        # When using C modules, disable the implicit search for module map files
+        # because all of them, including system dependencies, will be provided
+        # explicitly.
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
@@ -470,17 +473,33 @@ def compile_action_configs():
                 swift_action_names.PRECOMPILE_C_MODULE,
             ],
             configurators = [
-                # If we're consuming explicit modules of C dependencies, disable
-                # all implicit module usage (both searching for module maps and
-                # implicit compilation) to ensure that all modules must be
-                # explicitly provided.
-                swift_toolchain_config.add_arg(
-                    "-Xcc",
-                    "-fno-implicit-modules",
-                ),
                 swift_toolchain_config.add_arg(
                     "-Xcc",
                     "-fno-implicit-module-maps",
+                ),
+            ],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ),
+        # Do not allow implicit modules to be used at all when emitting an
+        # explicit C/Objective-C module. Consider the case of two modules A and
+        # B, where A depends on B. If B does not emit an explicit module, then
+        # when A is compiled it would contain a hardcoded reference to B via its
+        # path in the implicit module cache. Thus, A would not be movable; some
+        # library importing A would try to resolve B at that path, which may no
+        # longer exist when the upstream library is built.
+        #
+        # This implies that for a C/Objective-C library to build as an explicit
+        # module, all of its dependencies must as well. On the other hand, a
+        # Swift library can be compiled with some of its Objective-C
+        # dependencies still using implicit modules, as long as no Objective-C
+        # library wants to import that Swift library's generated header and
+        # build itself as an explicit module.
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.PRECOMPILE_C_MODULE],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-Xcc",
+                    "-fno-implicit-modules",
                 ),
             ],
             features = [SWIFT_FEATURE_USE_C_MODULES],


### PR DESCRIPTION
- Allow Swift compiles to use implicit modules even if `swift.use_c_modules` is enabled (a necessary fallback if some dependencies don't emit explicit modules).
- Continue to disallow usage of implicit modules when compiling explicit C/Objective-C modules because those implicit module paths would become embedded in the `.pcm` files, making them immovable.

PiperOrigin-RevId: 353665654
(cherry picked from commit 2711a2b930108e48c1b22541efb5408989d2eac0)