### PR TITLE
Use released protoc binaries where possible

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,18 +8,11 @@ load(
 swift_rules_dependencies()
 
 load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
+    "@build_bazel_rules_swift//swift:extras.bzl",
+    "swift_rules_extra_dependencies",
 )
 
-apple_support_dependencies()
-
-load(
-    "@com_google_protobuf//:protobuf_deps.bzl",
-    "protobuf_deps",
-)
-
-protobuf_deps()
+swift_rules_extra_dependencies()
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/swift/extras.bzl
+++ b/swift/extras.bzl
@@ -17,17 +17,23 @@ dependencies of the Swift rules.
 """
 
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load(
+    "@rules_proto//proto:repositories.bzl",
+    "rules_proto_dependencies",
+    "rules_proto_toolchains",
+)
 
 def swift_rules_extra_dependencies():
     """Fetches transitive repositories of the dependencies of `rules_swift`.
 
     Users should call this macro in their `WORKSPACE` following the use of
-    `swift_rules_dependencies` to ensure that all of the dependencies of 
-    the Swift rules are downloaded and that they are isolated from changes 
+    `swift_rules_dependencies` to ensure that all of the dependencies of
+    the Swift rules are downloaded and that they are isolated from changes
     to those dependencies.
     """
 
     apple_support_dependencies()
 
-    protobuf_deps()
+    rules_proto_dependencies()
+
+    rules_proto_toolchains()

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -99,23 +99,12 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "rules_proto",
-        # latest as of 2020-09-01
+        # latest as of 2021-01-27
         urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/40298556293ae502c66579620a7ce867d5f57311.zip",
+            "https://github.com/bazelbuild/rules_proto/archive/a0761ed101b939e19d83b2da5f59034bffc19c12.zip",
         ],
-        sha256 = "37d32b789be90fead9ab108dbe4fe4df463d26c122dc896dc1bf134252d3c49a",
-        strip_prefix = "rules_proto-40298556293ae502c66579620a7ce867d5f57311",
-        type = "zip",
-    )
-
-    _maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v3.14.0.zip",
-        ],
-        sha256 = "bf0e5070b4b99240183b29df78155eee335885e53a8af8683964579c214ad301",
-        strip_prefix = "protobuf-3.14.0",
+        sha256 = "32c9deb114c9e2d6ea3afd48a4d203d775b60a01876186d1ad52d752a8be439f",
+        strip_prefix = "rules_proto-a0761ed101b939e19d83b2da5f59034bffc19c12",
         type = "zip",
     )
 


### PR DESCRIPTION
This updates `rules_proto`, which has been configured to use released
protoc binaries where it can.

This can be a breaking change if users have a call to `protobuf_deps()`
_before_ `swift_rules_extra_dependencies()` in their WORKSPACE. To
fix, remove `load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")`
and `protobuf_deps()` from the WORKSPACE file, and use the following
instead:

```
load(
    "@build_bazel_rules_swift//swift:extras.bzl",
    "swift_rules_extra_dependencies",
)

swift_rules_extra_dependencies()
```
