### PR TITLE
Simplify the paths to module maps generated by the Swift build rules.

### DIFF
--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -108,7 +108,11 @@ def _intermediate_object_file(actions, target_name, src):
     )
 
 def _module_map(actions, target_name):
-    """Declares the module map for the generated header of a target.
+    """Declares the module map for a target.
+
+    These module maps are used when generating a Swift-compatible module map for
+    a C/Objective-C target, and also when generating the module map for the
+    generated header of a Swift target.
 
     Args:
         actions: The context's actions object.
@@ -117,9 +121,7 @@ def _module_map(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(
-        "{}.modulemaps/module.modulemap".format(target_name),
-    )
+    return actions.declare_file("{}.swift.modulemap".format(target_name))
 
 def _modulewrap_object(actions, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -94,8 +94,8 @@ def private_deps_test_suite(name = "private_deps"):
     private_deps_provider_test(
         name = "{}_client_cc_deps_modulemaps".format(name),
         expected_files = [
-            "/test/fixtures/private_deps/public_cc.modulemaps/module.modulemap",
-            "-/test/fixtures/private_deps/private_cc.modulemaps/module.modulemap",
+            "/test/fixtures/private_deps/public_cc.swift.modulemap",
+            "-/test/fixtures/private_deps/private_cc.swift.modulemap",
         ],
         field = "transitive_modules.clang!.module_map",
         provider = "SwiftInfo",


### PR DESCRIPTION
Since we pass these module maps directly to the compiler with `-fmodule-map-file`, we don't need them to be named exactly `module.modulemap`, so the extra subdirectory is also unnecessary.

PiperOrigin-RevId: 354151400
(cherry picked from commit 71998c865b827828c17dbd24bf48bb856523d4f5)