### PR TITLE
Simplify the paths to module maps generated by the Swift build rules.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -62,6 +62,7 @@ load(
     "SWIFT_FEATURE_VFSOVERLAY",
 )
 load(":features.bzl", "are_all_features_enabled", "is_feature_enabled")
+load(":module_maps.bzl", "write_module_map")
 load(":providers.bzl", "SwiftInfo", "create_swift_info")
 load(":toolchain_config.bzl", "swift_toolchain_config")
 load(
@@ -1774,11 +1775,11 @@ def _declare_compile_outputs(
             actions = actions,
             target_name = target_name,
         )
-        _write_objc_header_module_map(
+        write_module_map(
             actions = actions,
+            module_map_file = generated_module_map,
             module_name = module_name,
-            objc_header = generated_header,
-            output = generated_module_map,
+            public_headers = [generated_header],
         )
     else:
         generated_module_map = None
@@ -2242,29 +2243,6 @@ def swift_library_output_map(name, alwayslink):
     return {
         "archive": "lib{}.{}".format(name, extension),
     }
-
-def _write_objc_header_module_map(
-        actions,
-        module_name,
-        objc_header,
-        output):
-    """Writes a module map for a generated Swift header to a file.
-
-    Args:
-        actions: The context's actions object.
-        module_name: The name of the Swift module.
-        objc_header: The `File` representing the generated header.
-        output: The `File` to which the module map should be written.
-    """
-    actions.write(
-        content = ('module "{module_name}" {{\n' +
-                   '  header "../{header_name}"\n' +
-                   "}}\n").format(
-            header_name = objc_header.basename,
-            module_name = module_name,
-        ),
-        output = output,
-    )
 
 def _index_store_path_overridden(copts):
     """Checks if index_while_building must be disabled.

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -108,7 +108,11 @@ def _intermediate_object_file(actions, target_name, src):
     )
 
 def _module_map(actions, target_name):
-    """Declares the module map for the generated header of a target.
+    """Declares the module map for a target.
+
+    These module maps are used when generating a Swift-compatible module map for
+    a C/Objective-C target, and also when generating the module map for the
+    generated header of a Swift target.
 
     Args:
         actions: The context's actions object.
@@ -117,9 +121,7 @@ def _module_map(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(
-        "{}.modulemaps/module.modulemap".format(target_name),
-    )
+    return actions.declare_file("{}.swift.modulemap".format(target_name))
 
 def _modulewrap_object(actions, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.

--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -115,6 +115,13 @@ def _header_path(header_file, module_map_file, workspace_relative):
     if workspace_relative:
         return header_file.path
 
+    # Minor optimization for the generated Objective-C header of a Swift module,
+    # which will be in the same directory as the module map file -- we can just
+    # use the header's basename instead of the elaborate relative path
+    # computation below.
+    if header_file.dirname == module_map_file.dirname:
+        return header_file.basename
+
     # Otherwise, since the module map is generated, we need to get the full path
     # to it rather than just its short path (that is, the path starting with
     # bazel-out/). Then, we can simply walk up the same number of parent

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -94,8 +94,8 @@ def private_deps_test_suite(name = "private_deps"):
     private_deps_provider_test(
         name = "{}_client_cc_deps_modulemaps".format(name),
         expected_files = [
-            "/test/fixtures/private_deps/public_cc.modulemaps/module.modulemap",
-            "-/test/fixtures/private_deps/private_cc.modulemaps/module.modulemap",
+            "/test/fixtures/private_deps/public_cc.swift.modulemap",
+            "-/test/fixtures/private_deps/private_cc.swift.modulemap",
         ],
         field = "transitive_modules.clang!.module_map",
         provider = "SwiftInfo",


### PR DESCRIPTION
Since we pass these module maps directly to the compiler with `-fmodule-map-file`, we don't need them to be named exactly `module.modulemap`, so the extra subdirectory is also unnecessary.

This change also migrates generation of the modulemap file content for the generated header's module to the same code (`module_maps.bzl`) already used by `swift_clang_module_aspect`, instead of having its own separate code path.

PiperOrigin-RevId: 354324121
(cherry picked from commit 5f51ca9c5149122f41cada6122c61788d880fee9)