### PR TITLE
Allow controlling whether to include `export *` in the generated module maps

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1780,6 +1780,7 @@ def _declare_compile_outputs(
             module_map_file = generated_module_map,
             module_name = module_name,
             public_headers = [generated_header],
+            reexports_all = False,
         )
     else:
         generated_module_map = None

--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -25,6 +25,7 @@ def write_module_map(
         public_textual_headers = [],
         private_headers = [],
         private_textual_headers = [],
+        reexports_all = True,
         workspace_relative = False):
     """Writes the content of the module map to a file.
 
@@ -42,12 +43,16 @@ def write_module_map(
             headers of the target whose module map is being written.
         private_textual_headers: The `list` of `File`s representing the private
             textual headers of the target whose module map is being written.
+        reexports_all: A Boolean value indicating whether to re-export all of
+            the modules that were imported via the headers.
         workspace_relative: A Boolean value indicating whether the header paths
             written in the module map file should be relative to the workspace
             or relative to the module map file.
     """
     content = 'module "{}" {{\n'.format(module_name)
-    content += "    export *\n\n"
+
+    if reexports_all:
+        content += "    export *\n\n"
 
     content += "".join([
         '    header "{}"\n'.format(_header_path(


### PR DESCRIPTION
The content of the generated module maps was changed in
aa542252a2ea9c11a77b45de314350838d554747, by always adding `export *`
which wasn't previously included. This change reverts that back, and
adds a new parameter - `reexports_all` - to the `write_module_map`
helper, that allows controlling whether it should include `export *` in
the generated module map.
