### PR TITLE
Don't re-export the modules imported by a Swift generated header.

### DIFF
--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -21,6 +21,7 @@ def write_module_map(
         module_map_file,
         module_name,
         dependent_module_names = [],
+        exported_module_ids = [],
         public_headers = [],
         public_textual_headers = [],
         private_headers = [],
@@ -34,6 +35,14 @@ def write_module_map(
         module_name: The name of the module being generated.
         dependent_module_names: A `list` of names of Clang modules that are
             direct dependencies of the target whose module map is being written.
+        exported_module_ids: A `list` of Clang wildcard module identifiers that
+            will be re-exported as part of the API of the module being written.
+            The values in this list should match `wildcard-module-id` as
+            described by
+            https://clang.llvm.org/docs/Modules.html#export-declaration. Common
+            values include the empty list to re-export nothing (except the
+            module's own API), or `["*"]` to re-export all modules that were
+            imported by the header files in the module.
         public_headers: The `list` of `File`s representing the public modular
             headers of the target whose module map is being written.
         public_textual_headers: The `list` of `File`s representing the public
@@ -47,7 +56,12 @@ def write_module_map(
             or relative to the module map file.
     """
     content = 'module "{}" {{\n'.format(module_name)
-    content += "    export *\n\n"
+    if exported_module_ids:
+        content += "".join([
+            "    export {}\n".format(module_id)
+            for module_id in exported_module_ids
+        ])
+        content += "\n"
 
     content += "".join([
         '    header "{}"\n'.format(_header_path(

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -131,6 +131,7 @@ def _generate_module_map(
     write_module_map(
         actions = actions,
         dependent_module_names = dependent_module_names,
+        exported_module_ids = ["*"],
         module_map_file = module_map_file,
         module_name = module_name,
         private_headers = private_headers,


### PR DESCRIPTION
This was an unintentional change in behavior from https://github.com/bazelbuild/rules_swift/commit/5f51ca9c5149122f41cada6122c61788d880fee9; this puts us back to the original behavior, but leaves an API in place for finer-grained control over re-exporting modules in the future. (But the BUILD rules today don't really have the flexibility to support it yet.)

PiperOrigin-RevId: 356338982
(cherry picked from commit f45eea8c02a87c3077e5209f471fe4a193b5b0ba)