### PR TITLE
Explicitly set --macos_minimum_os=10.15 to make `swift_{binary,test}` runnable on macOS Catalina (which is the macOS version used by Bazel CI) when building with Xcode 12 or above

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --macos_minimum_os=10.15

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,4 @@
+# Since there's no way to set the deployment version for swift_{binary,test},
+# this forces all targets' minimum macOS to Catalina until Bazel CI has
+# upgraded their Mac machines to Big Sur.
 build --macos_minimum_os=10.15


### PR DESCRIPTION
Since there's no way to set the deployment version for
`*_{binary,test}`, this makes rules_swift on CI green again without
having to go back to using Xcode 11.7.
