### PR TITLE
Implement global index store cache

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -58,6 +58,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
+    "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
@@ -805,6 +806,14 @@ def compile_action_configs(
             ],
             features = [SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES],
         ),
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE],
+            configurators = [_global_index_store_configurator],
+            features = [
+                SWIFT_FEATURE_INDEX_WHILE_BUILDING,
+                SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE,
+            ],
+        ),
 
         # Configure index-while-building.
         swift_toolchain_config.action_config(
@@ -1418,6 +1427,12 @@ def _index_while_building_configurator(prerequisites, args):
     """Adds flags for index-store generation to the command line."""
     if not _index_store_path_overridden(prerequisites.user_compile_flags):
         args.add("-index-store-path", prerequisites.indexstore_directory.path)
+
+def _global_index_store_configurator(prerequisites, args):
+    """Adds flags for index-store generation to the command line."""
+    out_dir = prerequisites.indexstore_directory.dirname.split("/")[0]
+    path = out_dir + "/_global_index_store"
+    args.add("-Xwrapped-swift=-global-index-store-import-path=" + path)
 
 def _conditional_compilation_flag_configurator(prerequisites, args):
     """Adds (non-Clang) conditional compilation flags to the command line."""

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -99,10 +99,14 @@ SWIFT_FEATURE_ENABLE_TESTING = "swift.enable_testing"
 SWIFT_FEATURE_FULL_DEBUG_INFO = "swift.full_debug_info"
 
 # If enabled, the compilation action for a target will produce an index store.
+# https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 
 # If enabled the compilation action will not produce indexes for system modules.
 SWIFT_FEATURE_DISABLE_SYSTEM_INDEX = "swift.disable_system_index"
+
+# Index while building - using a global index store cache
+SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE = "swift.use_global_index_store"
 
 # If enabled, compilation actions and module map generation will assume that the
 # header paths in module maps are relative to the current working directory

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -108,6 +108,27 @@ def swift_rules_dependencies():
         type = "zip",
     )
 
+    # It relies on `index-import` to import indexes into Bazel's remote
+    # cache and allow using a global index internally in workers.
+    # Note: this is only loaded if swift.index_while_building_v2 is enabled
+    _maybe(
+        http_archive,
+        name = "build_bazel_rules_swift_index_import",
+        build_file_content = """\
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "index_import",
+    src = "index-import",
+    out = "index-import",
+    visibility = ["//visibility:public"],
+)
+""",
+        canonical_id = "index-import-5.3.2.6",
+        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.3.2.6/index-import.zip"],
+        sha256 = "61a58363f56c5fd84d4ebebe0d9b5dd90c74ae170405a7b9018e8cf698e679de",
+    )
+
     _maybe(
         swift_autoconfiguration,
         name = "build_bazel_rules_swift_local_config",

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -18,12 +18,18 @@ config_setting(
     },
 )
 
+# Internal hinge for index while building V2 feature
+config_setting(
+    name = "use_global_index_store",
+    values = {
+        "features": "swift.use_global_index_store",
+    },
+)
+
 cc_library(
     name = "compile_with_worker",
     srcs = [
         "compile_with_worker.cc",
-        "output_file_map.cc",
-        "output_file_map.h",
         "work_processor.cc",
         "work_processor.h",
     ],
@@ -34,7 +40,6 @@ cc_library(
         "//tools/common:file_system",
         "//tools/common:path_utils",
         "//tools/common:temp_file",
-        "@com_github_nlohmann_json//:json",
         "@com_google_protobuf//:protobuf",
     ],
 )
@@ -50,13 +55,30 @@ cc_library(
 
 cc_library(
     name = "swift_runner",
-    srcs = ["swift_runner.cc"],
+    srcs = [
+        "output_file_map.cc",
+        "output_file_map.h",
+        "swift_runner.cc",
+    ],
     hdrs = ["swift_runner.h"],
+    copts = select({
+        ":use_global_index_store": [
+            "-DINDEX_IMPORT_PATH=\\\"$(rootpath @build_bazel_rules_swift_index_import//:index_import)\\\"",
+        ],
+        "//conditions:default": [],
+    }),
+    data = select({
+        ":use_global_index_store": [
+            "@build_bazel_rules_swift_index_import//:index_import",
+        ],
+        "//conditions:default": [],
+    }),
     deps = [
         "//tools/common:bazel_substitutions",
         "//tools/common:file_system",
         "//tools/common:process",
         "//tools/common:temp_file",
+        "@com_github_nlohmann_json//:json",
     ],
 )
 

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -97,8 +97,14 @@ class SwiftRunner {
   //
   // This method has file system side effects, creating temporary files and
   // directories as needed for a particular substitution.
-  bool ProcessArgument(const std::string &arg,
+  template <typename Iterator>
+  bool ProcessArgument(Iterator &itr, const std::string &arg,
                        std::function<void(const std::string &)> consumer);
+
+  // Parses arguments to ivars and returns a vector of strings from the iterator.
+  // This method doesn't actually mutate any of the arguments.
+  template <typename Iterator>
+  std::vector<std::string> ParseArguments(Iterator itr);
 
   // Applies substitutions to the given command line arguments, returning the
   // results in a new vector.
@@ -128,6 +134,18 @@ class SwiftRunner {
   // The path to the generated header rewriter tool, if one is being used for
   // this compilation.
   std::string generated_header_rewriter_path_;
+
+  // The path of the output map file
+  std::string output_file_map_path_;
+
+  // The index store path argument passed to the runner
+  std::string index_store_path_;
+
+  // The path of the global index store  when using
+  // swift.use_global_index_store. When set, this is passed to `swiftc` as the
+  // `-index-store-path`. After running `swiftc` `index-import` copies relevant
+  // index outputs into the `index_store_path` to integrate outputs with Bazel.
+  std::string global_index_store_import_path_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_


### PR DESCRIPTION
swift and clang write index data based on the status of what resides in
`index-store-path`. When using a transient per-swift-library index, it
writes O( M imports * N libs) indexer data and slows down compilation
significantly: to the tune of 300% slow down and 6GB+ index data in my
testing. Bazel likes to use per `swift_library` data in order to remote
cache them, which needs extra consideration to work with the design of
swift and clang and preserve the performance

This PR does 2 things to make index while building use the original
model of the index-store so we don't have to patch clang and swift for
this yet. When the flag `-Xwrapped-swift-enable-global-index-store` is
set:

1. it writes to a global index cache, `bazel-out/global_index_store`
2. it copies indexstore data (records and units) to where Bazel
   expected them for caching: e.g. the original location with
   `swift.index_while_building`

Note that while this uses a `index-import` binary, it is very different
than how index-import currently works. In the variant this expects, it
is program that can _copy_ index data for specific compiler outputs.
This has the effect fo remote caching the subset that was used in
compilation for this library.

I added a detailed description of this feature in the RFC to add it
there https://github.com/lyft/index-import/pull/53.  In practice,
transitive imports will be indexed by deps and if they aren't cached
then the fallback is Xcode.