### PR TITLE
Move toolchain- and command-line-provided compiler flags into action configurators.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -135,7 +135,17 @@ def _apply_action_configs(
                     prerequisites,
                     args,
                 )
-                if action_inputs:
+
+                # If we create an action configurator from a lambda that calls
+                # `Args.add*`, the result will be the `Args` objects (rather
+                # than `None`) because those methods return the same `Args`
+                # object for chaining. We can guard against this (and possibly
+                # other errors) by checking that the value is a struct. If it
+                # is, then it's not `None` and it probably came from the
+                # provider used by `swift_toolchain_config.config_result`. If
+                # it's some other kind of struct, then we'll error out trying to
+                # access the fields.
+                if type(action_inputs) == "struct":
                     inputs.extend(action_inputs.inputs)
                     transitive_inputs.extend(action_inputs.transitive_inputs)
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -830,7 +830,7 @@ def compile_action_configs(
                     # TODO(#568): Switch to using lambda when the minimum
                     # supported Bazel version by rules_swift supports it.
                     partial.make(
-                        _additional_swift_copts_configurator,
+                        _additional_swiftc_copts_configurator,
                         additional_swiftc_copts,
                     ),
                 ],
@@ -1364,7 +1364,7 @@ def _additional_objc_copts_configurator(additional_objc_copts, prerequisites, ar
         before_each = "-Xcc",
     )
 
-def _additional_swift_copts_configurator(additional_swiftc_copts, prerequisites, args):
+def _additional_swiftc_copts_configurator(additional_swiftc_copts, prerequisites, args):
     """Adds additional Swift compiler flags to the command line."""
     _unused = [prerequisites]
     args.add_all(additional_swiftc_copts)

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -61,7 +61,7 @@ load(
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_VFSOVERLAY",
-    "SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS",
+    "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
 load(":features.bzl", "are_all_features_enabled", "is_feature_enabled")
@@ -706,7 +706,7 @@ def compile_action_configs(
                 [SWIFT_FEATURE_OPT, SWIFT_FEATURE_OPT_USES_WMO],
                 [SWIFT_FEATURE__WMO_IN_SWIFTCOPTS],
             ],
-            not_features = [SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS],
+            not_features = [SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS],
         ),
         swift_toolchain_config.action_config(
             actions = [
@@ -723,7 +723,7 @@ def compile_action_configs(
             ],
             not_features = [
                 [SWIFT_FEATURE_OPT, SWIFT_FEATURE_OPT_USES_WMO],
-                [SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS],
+                [SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS],
             ],
         ),
 
@@ -1319,8 +1319,8 @@ def features_from_swiftcopts(swiftcopts):
     features = []
     if _is_wmo_manually_requested(user_compile_flags = swiftcopts):
         features.append(SWIFT_FEATURE__WMO_IN_SWIFTCOPTS)
-    if _find_num_threads_flag_value(user_compile_flags = swiftcopts) == 1:
-        features.append(SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS)
+    if _find_num_threads_flag_value(user_compile_flags = swiftcopts) == 0:
+        features.append(SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS)
     return features
 
 def _index_while_building_configurator(prerequisites, args):
@@ -2482,14 +2482,14 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
         _is_wmo_manually_requested(user_compile_flags)
     )
 
-    # We check the feature first because that implies that `-num-threads 1` was
+    # We check the feature first because that implies that `-num-threads 0` was
     # present in `--swiftcopt`, which overrides all other flags (like the user
     # compile flags, which come from the target's `copts`). Only fallback to
     # checking the flags if the feature is disabled.
     is_single_threaded = is_feature_enabled(
         feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS,
-    ) or _find_num_threads_flag_value(user_compile_flags) == 1
+        feature_name = SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS,
+    ) or _find_num_threads_flag_value(user_compile_flags) == 0
 
     return struct(
         emits_multiple_objects = not (is_wmo and is_single_threaded),

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -237,3 +237,13 @@ SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES = "swift.skip_function_bodies_for_deri
 # If enabled remap the absolute path to Xcode in debug info. When used with
 # swift.coverage_prefix_map also remap the path in coverage data.
 SWIFT_FEATURE_REMAP_XCODE_PATH = "swift.remap_xcode_path"
+
+# A private feature that is set by the toolchain if a flag enabling WMO was
+# passed on the command line using `--swiftcopt`. Users should never manually
+# enable, disable, or query this feature.
+SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
+
+# A private feature that is set by the toolchain if the flags `-num-threads 1`
+# were passed on the command line using `--swiftcopt`. Users should never
+# manually enable, disable, or query this feature.
+SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS = "swift._num_threads_1_in_swiftcopts"

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -243,7 +243,7 @@ SWIFT_FEATURE_REMAP_XCODE_PATH = "swift.remap_xcode_path"
 # enable, disable, or query this feature.
 SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
 
-# A private feature that is set by the toolchain if the flags `-num-threads 1`
+# A private feature that is set by the toolchain if the flags `-num-threads 0`
 # were passed on the command line using `--swiftcopt`. Users should never
 # manually enable, disable, or query this feature.
-SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS = "swift._num_threads_1_in_swiftcopts"
+SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts"

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -70,13 +70,6 @@ using this toolchain.
 The `cc_common.CcToolchainInfo` provider from the Bazel C++ toolchain that this
 Swift toolchain depends on.
 """,
-        "command_line_copts": """\
-`List` of `strings`. Flags that were passed to Bazel using the `--swiftcopt`
-command line flag. These flags have the highest precedence; they are added to
-compilation command lines after the toolchain default flags
-(`SwiftToolchainInfo.swiftc_copts`) and after flags specified in the `copts`
-attributes of Swift targets.
-""",
         "cpu": """\
 `String`. The CPU architecture that the toolchain is targeting.
 """,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -101,7 +101,7 @@ def _all_action_configs(additional_swiftc_copts):
     """
     return (
         compile_action_configs(
-            additional_swift_copts = additional_swiftc_copts,
+            additional_swiftc_copts = additional_swiftc_copts,
         ) +
         modulewrap_action_configs() +
         autolink_extract_action_configs()

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -25,7 +25,7 @@ load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
 load(":autolinking.bzl", "autolink_extract_action_configs")
-load(":compiling.bzl", "compile_action_configs")
+load(":compiling.bzl", "compile_action_configs", "features_from_swiftcopts")
 load(":debugging.bzl", "modulewrap_action_configs")
 load(
     ":feature_names.bzl",
@@ -89,14 +89,20 @@ def _all_tool_configs(
         ),
     }
 
-def _all_action_configs():
+def _all_action_configs(additional_swiftc_copts):
     """Returns the action configurations for the Swift toolchain.
+
+    Args:
+        additional_swiftc_copts: Additional Swift compiler flags obtained from
+            the `swift` configuration fragment.
 
     Returns:
         A list of action configurations for the toolchain.
     """
     return (
-        compile_action_configs() +
+        compile_action_configs(
+            additional_swift_copts = additional_swiftc_copts,
+        ) +
         modulewrap_action_configs() +
         autolink_extract_action_configs()
     )
@@ -173,7 +179,10 @@ def _swift_toolchain_impl(ctx):
 
     # Combine build mode features, autoconfigured features, and required
     # features.
-    requested_features = features_for_build_modes(ctx)
+    requested_features = (
+        features_for_build_modes(ctx) +
+        features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
+    )
     requested_features.extend([
         SWIFT_FEATURE_NO_GENERATED_HEADER,
         SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
@@ -194,7 +203,9 @@ def _swift_toolchain_impl(ctx):
         use_param_file = SWIFT_FEATURE_USE_RESPONSE_FILES in ctx.features,
         additional_tools = [ctx.file.version_file],
     )
-    all_action_configs = _all_action_configs()
+    all_action_configs = _all_action_configs(
+        additional_swiftc_copts = ctx.fragments.swift.copts(),
+    )
 
     # TODO(allevato): Move some of the remaining hardcoded values, like object
     # format and Obj-C interop support, to attributes so that we can remove the
@@ -204,7 +215,6 @@ def _swift_toolchain_impl(ctx):
             action_configs = all_action_configs,
             all_files = depset(all_files),
             cc_toolchain_info = cc_toolchain,
-            command_line_copts = ctx.fragments.swift.copts(),
             cpu = ctx.attr.arch,
             linker_opts_producer = linker_opts_producer,
             linker_supports_filelist = False,


### PR DESCRIPTION
This change removes of the `SwiftToolchainInfo.command_line_copts` field, no longer treating those command line flags as an odd special case. It also ensures that flags from the toolchain are passed in a unified manner regardless of which rule registers the action.

For example, Bazel-legacy Objective-C flags determined by compilation mode, like `-fstack-protector`, affect the compatibility of Clang modules and need to be passed both when compiling an explicit module and when compiling the Swift code that consumes those modules.

This required a bit more shuffling around of the way we need to handle differing outptus for WMO, since the `--swiftcopt` flags would no longer be able to be scanned directly after the toolchain configuration.

PiperOrigin-RevId: 355451642
(cherry picked from commit 1bea35e22e18c56818f1c485ab04d2272736ea45)
