### PR TITLE
Unconditionally add `ObjcProvider.umbrella_header` files to compiler inputs, even when preferring explicit modules.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1039,8 +1039,10 @@ def _collect_clang_module_inputs(
 
     # Some rules still use the `umbrella_header` field to propagate a header
     # that they don't also include in `CcInfo.compilation_context.headers`, so
-    # we also need to pull this in for the time being.
-    if not prefer_precompiled_modules and objc_info:
+    # we also need to pull these in for the time being.
+    # TODO(b/142867898): This can be removed once the Swift rules start
+    # generating its own module map for these targets.
+    if objc_info:
         transitive_inputs.append(objc_info.umbrella_header)
 
     for module in modules:


### PR DESCRIPTION
A small number of rules use `umbrella_header` to propagate an umbrella header for their module map that they don't propagate in any other header field. Since there is no `direct_*` version of this field, `swift_clang_module_aspect` can't easily extract the one umbrella header from the `depset` in the provider that may also include transitive umbrella headers.

PiperOrigin-RevId: 355667496
(cherry picked from commit bd8c7d45f3616c83fc54645a069f5aa76e6f3612)
