### PR TITLE
Pass `-no-clang-module-breadcrumbs` to frontend jobs by default

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -37,7 +37,6 @@ load(
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_DISABLE_SYSTEM_INDEX",
-    "SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS",
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
@@ -161,7 +160,6 @@ def compile_action_configs(
                     "-no-clang-module-breadcrumbs",
                 ),
             ],
-            not_features = [SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS],
         ),
 
         # Add the output precompiled module file path to the command line.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -37,6 +37,7 @@ load(
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_DISABLE_SYSTEM_INDEX",
+    "SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS",
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
@@ -149,6 +150,18 @@ def compile_action_configs(
                     "-fmodules-embed-all-files",
                 ),
             ],
+        ),
+
+        # Don't embed Clang module breadcrumbs in debug info.
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-Xfrontend",
+                    "-no-clang-module-breadcrumbs",
+                ),
+            ],
+            not_features = [SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS],
         ),
 
         # Add the output precompiled module file path to the command line.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -211,6 +211,13 @@ SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
 # system command line limit.
 SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE = "swift.no_embed_debug_module"
 
+# If enabled, embed absolute paths to the dependent pcm files in the debug
+# info. This is used as a fallback path for LLDB to reconstruct Clang types
+# from DWARF, when it wasn't able to import a dependent Clang module from
+# source. This feature is disabled by default to make the compilation outputs
+# more cacheable.
+SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS = "swift.embed_clang_module_breadcrumbs"
+
 # If enabled, the toolchain will directly generate from the raw proto files
 # and not from the DescriptorSets.
 #

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -211,13 +211,6 @@ SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS = "swift.supports_private_deps"
 # system command line limit.
 SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE = "swift.no_embed_debug_module"
 
-# If enabled, embed absolute paths to the dependent pcm files in the debug
-# info. This is used as a fallback path for LLDB to reconstruct Clang types
-# from DWARF, when it wasn't able to import a dependent Clang module from
-# source. This feature is disabled by default to make the compilation outputs
-# more cacheable.
-SWIFT_FEATURE_EMBED_CLANG_MODULE_BREADCRUMBS = "swift.embed_clang_module_breadcrumbs"
-
 # If enabled, the toolchain will directly generate from the raw proto files
 # and not from the DescriptorSets.
 #


### PR DESCRIPTION
This adds a feature `swift.embed_clang_module_breadcrumbs`, if enabled,
embed absolute paths to the dependent pcm files in the debug info. This
is used as a fallback path for LLDB to reconstruct Clang types from
DWARF, when it wasn't able to import a dependent Clang module from
source. This feature is disabled by default (by passing `-Xfrontend
-no-clang-module-breadcrumbs` to swiftc) to make the compilation
outputs more cacheable.
