### PR TITLE
Add a `generates_header` attribute to `swift_library` to control Objective-C header generation.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -271,8 +271,27 @@ a `.h` extension and cannot contain any path separators.
 If this attribute is not specified, then the default behavior is to name the
 header `${target_name}-Swift.h`.
 
-This attribute is ignored if the toolchain does not support generating headers
-or if the target has the `swift.no_generated_header` feature enabled.
+It is an error to specify a value for this attribute when `generates_header` is
+False.
+""",
+                mandatory = False,
+            ),
+            "generates_header": attr.bool(
+                # TODO(b/182493307): Make the default False after migrating all
+                # targets to explicitly specify it when needed.
+                default = True,
+                doc = """\
+If True, an Objective-C header will be generated for this target, in the same
+build package where the target is defined. By default, the name of the header is
+`${target_name}-Swift.h`; this can be changed using the `generated_header_name`
+attribute.
+
+Targets should only set this attribute to True if they export Objective-C APIs.
+A header generated for a target that does not export Objective-C APIs will be
+effectively empty (except for a large amount of prologue and epilogue code) and
+this is generally wasteful because the extra file needs to be propagated in the
+build graph and, when explicit modules are enabled, extra actions must be
+executed to compile the Objective-C module for the generated header.
 """,
                 mandatory = False,
             ),

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -29,18 +29,6 @@ def _autolink_flags(actions, target_name):
     """
     return actions.declare_file("{}.autolink".format(target_name))
 
-def _default_generated_header(actions, target_name):
-    """Declares the automatically-named generated header for a Swift target.
-
-    Args:
-        actions: The context's actions object.
-        target_name: The name of the target being built.
-
-    Returns:
-        The declared `File`.
-    """
-    return actions.declare_file("{}-Swift.h".format(target_name))
-
 def _executable(actions, target_name):
     """Declares a file for the executable created by a binary or test rule.
 
@@ -320,7 +308,6 @@ def _xctest_runner_script(actions, target_name):
 
 derived_files = struct(
     autolink_flags = _autolink_flags,
-    default_generated_header = _default_generated_header,
     executable = _executable,
     indexstore_directory = _indexstore_directory,
     intermediate_object_file = _intermediate_object_file,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -126,14 +126,9 @@ SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS = (
     "swift.module_map_no_private_headers"
 )
 
-# If enabled, the compilation action for a library target will not generate an
-# Objective-C header for the module. This feature also implies
-# `swift.no_generated_module_map`.
-SWIFT_FEATURE_NO_GENERATED_HEADER = "swift.no_generated_header"
-
 # If enabled, the compilation action for a library target will not generate a
-# module map for the Objective-C generated header. Note that this feature
-# is ignored if `swift.no_generated_header` is present.
+# module map for the Objective-C generated header. This feature is ignored if
+# the target is not generating a header.
 SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 
 # If enabled, builds using the "opt" compilation mode will invoke `swiftc` with

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -25,7 +25,6 @@ load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES",
-    "SWIFT_FEATURE_NO_GENERATED_HEADER",
 )
 load(":linking.bzl", "create_linker_input")
 load(
@@ -214,7 +213,7 @@ def _swift_grpc_library_impl(ctx):
 
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
-        requested_features = ctx.features + [SWIFT_FEATURE_NO_GENERATED_HEADER],
+        requested_features = ctx.features,
         swift_toolchain = swift_toolchain,
         unsupported_features = unsupported_features,
     )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -147,6 +147,20 @@ def _swift_library_impl(ctx):
         deps = ctx.attr.deps
         private_deps = []
 
+    if ctx.attr.generates_header:
+        generated_header_name = (
+            ctx.attr.generated_header_name or
+            "{}-Swift.h".format(ctx.label.name)
+        )
+    elif not ctx.attr.generated_header_name:
+        generated_header_name = None
+    else:
+        fail(
+            "'generated_header_name' may only be provided when " +
+            "'generates_header' is True.",
+            attr = "generated_header_name",
+        )
+
     compilation_outputs = swift_common.compile(
         actions = ctx.actions,
         additional_inputs = additional_inputs,
@@ -155,7 +169,7 @@ def _swift_library_impl(ctx):
         defines = ctx.attr.defines,
         deps = deps,
         feature_configuration = feature_configuration,
-        generated_header_name = ctx.attr.generated_header_name,
+        generated_header_name = generated_header_name,
         genfiles_dir = ctx.genfiles_dir,
         module_name = module_name,
         private_deps = private_deps,

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -25,7 +25,6 @@ load(
     "SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES",
-    "SWIFT_FEATURE_NO_GENERATED_HEADER",
 )
 load(":linking.bzl", "create_linker_input")
 load(
@@ -370,9 +369,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         # compile action.
         feature_configuration = swift_common.configure_features(
             ctx = aspect_ctx,
-            requested_features = aspect_ctx.features + extra_features + [
-                SWIFT_FEATURE_NO_GENERATED_HEADER,
-            ],
+            requested_features = aspect_ctx.features + extra_features,
             swift_toolchain = swift_toolchain,
             unsupported_features = aspect_ctx.disabled_features + [
                 SWIFT_FEATURE_ENABLE_TESTING,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -30,7 +30,6 @@ load(":debugging.bzl", "modulewrap_action_configs")
 load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
-    "SWIFT_FEATURE_NO_GENERATED_HEADER",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
 )
@@ -183,10 +182,7 @@ def _swift_toolchain_impl(ctx):
         features_for_build_modes(ctx) +
         features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
     )
-    requested_features.extend([
-        SWIFT_FEATURE_NO_GENERATED_HEADER,
-        SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
-    ])
+    requested_features.append(SWIFT_FEATURE_NO_GENERATED_MODULE_MAP)
     requested_features.extend(ctx.features)
 
     # Swift.org toolchains assume everything is just available on the PATH so we

--- a/test/fixtures/generated_header/BUILD
+++ b/test/fixtures/generated_header/BUILD
@@ -8,8 +8,16 @@ package(
 licenses(["notice"])
 
 swift_library(
+    name = "no_header",
+    srcs = ["Empty.swift"],
+    generates_header = False,
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
     name = "auto_header",
     srcs = ["Empty.swift"],
+    generates_header = True,
     tags = FIXTURE_TAGS,
 )
 
@@ -17,6 +25,7 @@ swift_library(
     name = "explicit_header",
     srcs = ["Empty.swift"],
     generated_header_name = "SomeOtherName.h",
+    generates_header = True,
     tags = FIXTURE_TAGS,
 )
 
@@ -24,6 +33,7 @@ swift_library(
     name = "invalid_extension",
     srcs = ["Empty.swift"],
     generated_header_name = "Invalid.extension",
+    generates_header = True,
     tags = FIXTURE_TAGS,
 )
 
@@ -31,5 +41,14 @@ swift_library(
     name = "valid_path_separator",
     srcs = ["Empty.swift"],
     generated_header_name = "Valid/Separator.h",
+    generates_header = True,
+    tags = FIXTURE_TAGS,
+)
+
+swift_library(
+    name = "invalid_attribute_combination",
+    srcs = ["Empty.swift"],
+    generated_header_name = "SomeOtherName.h",
+    generates_header = False,
     tags = FIXTURE_TAGS,
 )

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -14,18 +14,21 @@ licenses(["notice"])
 swift_library(
     name = "private_swift",
     srcs = ["Empty.swift"],
+    generates_header = True,
     tags = FIXTURE_TAGS,
 )
 
 swift_library(
     name = "public_swift",
     srcs = ["Empty.swift"],
+    generates_header = True,
     tags = FIXTURE_TAGS,
 )
 
 swift_library(
     name = "client_swift_deps",
     srcs = ["Empty.swift"],
+    generates_header = True,
     private_deps = [
         ":private_swift",
     ],
@@ -68,13 +71,11 @@ cc_library(
 swift_library(
     name = "client_cc_deps",
     srcs = ["Empty.swift"],
-    features = [
-        # Suppress the generated header/module map on platforms that support
-        # Objective-C interop so that we don't have to worry about
-        # conditionally checking for it in the transitive modules on just those
-        # platforms.
-        "swift.no_generated_header",
-    ],
+    # Suppress the generated header/module map on platforms that support
+    # Objective-C interop so that we don't have to worry about
+    # conditionally checking for it in the transitive modules on just those
+    # platforms.
+    generates_header = False,
     private_deps = [
         ":private_cc",
     ],


### PR DESCRIPTION
Today, `swift_library` unconditionally generates a header and module map for all targets (unless rarely-used features are applied), even if the library has no APIs exported to Objective-C. This creates a small amount of unnecessary work, but that work grows significantly when explicit modules are used in the build, because we also need to compile the explicit modules for those generated headers _just in case_ some `objc_library` further up in the build graph needs to import the header.

This is the first of a few changes that will eventually require the `generates_header` attribute to be set on targets to have the generated header emitted and propagated.

This change also removes the `swift.no_generated_header` feature, since the attribute's behavior supplants it.

PiperOrigin-RevId: 362562962
(cherry picked from commit e621e5e644c7f62f44241da253fb40ea14672451)