### PR TITLE
Add `swift.global_module_cache_uses_tmpdir` feature

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -506,7 +506,7 @@ def compile_action_configs(
             configurators = [_tmpdir_module_cache_configurator],
             features = [
                 SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
-                SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR
+                SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR,
             ],
             not_features = [SWIFT_FEATURE_USE_C_MODULES],
         ),

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -44,6 +44,7 @@ load(
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
+    "SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
@@ -492,6 +493,21 @@ def compile_action_configs(
             ],
             configurators = [_global_module_cache_configurator],
             features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+            not_features = [
+                [SWIFT_FEATURE_USE_C_MODULES],
+                [SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [_tmpdir_module_cache_configurator],
+            features = [
+                SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
+                SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR
+            ],
             not_features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
         swift_toolchain_config.action_config(
@@ -950,6 +966,18 @@ def _global_module_cache_configurator(prerequisites, args):
             "-module-cache-path",
             paths.join(prerequisites.bin_dir.path, "_swift_module_cache"),
         )
+
+def _tmpdir_module_cache_configurator(prerequisites, args):
+    """Adds flags to enable a stable tmp directory module cache."""
+
+    args.add(
+        "-module-cache-path",
+        paths.join(
+            "/tmp/__build_bazel_rules_swift",
+            "swift_module_cache",
+            prerequisites.workspace_name,
+        ),
+    )
 
 def _batch_mode_configurator(prerequisites, args):
     """Adds flags to enable batch compilation mode."""
@@ -1487,6 +1515,7 @@ def compile(
         srcs,
         swift_toolchain,
         target_name,
+        workspace_name,
         additional_inputs = [],
         bin_dir = None,
         copts = [],
@@ -1509,6 +1538,9 @@ def compile(
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
+        workspace_name: The name of the workspace for which the code is being
+             compiled, which is used to determine unique file paths for some
+             outputs.
         additional_inputs: A list of `File`s representing additional input files
             that need to be passed to the Swift compile action because they are
             referenced by compiler flags.
@@ -1703,6 +1735,7 @@ def compile(
         user_compile_flags = copts,
         vfsoverlay_file = vfsoverlay_file,
         vfsoverlay_search_path = _SWIFTMODULES_VFS_ROOT,
+        workspace_name = workspace_name,
         # Merge the compile outputs into the prerequisites.
         **struct_fields(compile_outputs)
     )

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -142,6 +142,29 @@ SWIFT_FEATURE_USE_C_MODULES = "swift.use_c_modules"
 # crashes.
 SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
 
+# If enabled, and Swift compilation actions will use the shared Clang module
+# cache path written to
+# `/private/tmp/__build_bazel_rules_swift/swift_module_cache/REPOSITORY_NAME`.
+# This makes the embedded Clang module breadcrumbs deterministic between Bazel
+# instances, because they are always embedded as absolute paths. Note that the
+# use of this cache is non-hermetic--the cached modules are not wiped between
+# builds, and won't be cleaned when invoking `bazel clean`; the user is
+# responsible for manually cleaning them.
+#
+# Additionally, this can be used as a workaround for a bug in the Swift
+# compiler that causes the module breadcrumbs to be embedded even though the
+# `-no-clang-module-breadcrumbs` flag is passed
+# (https://bugs.swift.org/browse/SR-13275).
+#
+# Since the source path of modulemaps might be different for the same module,
+# (i.e. multiple checkouts of the same repository, or remote execution),
+# multiple modules with different hashes can end up in the cache. This can
+# result in build failures. Don't use this feature with sandboxing (or
+# probably remote execution as well).
+#
+# This feature requires `swift.use_global_module_cache` to be enabled.
+SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR = "swift.global_module_cache_uses_tmpdir"
+
 # If enabled, actions invoking the Swift driver or frontend may write argument
 # lists into response files (i.e., "@args.txt") to avoid passing command lines
 # that exceed the system limit. Toolchains typically set this automatically if

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -199,6 +199,7 @@ def _swift_linking_rule_impl(
             srcs = srcs,
             swift_toolchain = swift_toolchain,
             target_name = ctx.label.name,
+            workspace_name = ctx.workspace_name,
         )
         user_link_flags.extend(compilation_outputs.linker_flags)
         objects_to_link.extend(compilation_outputs.object_files)

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -290,6 +290,7 @@ def _swift_grpc_library_impl(ctx):
         srcs = generated_files,
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
+        workspace_name = ctx.workspace_name,
     )
 
     linker_input, library_to_link = create_linker_input(

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -187,6 +187,7 @@ def _swift_library_impl(ctx):
         srcs = srcs,
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
+        workspace_name = ctx.workspace_name,
     )
 
     # If a module was created for the generated header, propagate it as well so

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -70,6 +70,7 @@ def _swift_module_alias_impl(ctx):
         srcs = [reexport_src],
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
+        workspace_name = ctx.workspace_name,
     )
 
     linker_input, library_to_link = create_linker_input(

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -423,6 +423,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             srcs = pbswift_files,
             swift_toolchain = swift_toolchain,
             target_name = target.label.name,
+            workspace_name = aspect_ctx.workspace_name,
         )
 
         linker_input, library_to_link = create_linker_input(

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":debug_settings_tests.bzl", "debug_settings_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
+load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
 load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
@@ -13,6 +14,8 @@ debug_settings_test_suite()
 coverage_settings_test_suite()
 
 generated_header_test_suite()
+
+module_cache_settings_test_suite()
 
 private_deps_test_suite()
 

--- a/test/module_cache_settings_tests.bzl
+++ b/test/module_cache_settings_tests.bzl
@@ -1,0 +1,103 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for module cache related command line flags under various configs."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+
+use_global_module_cache_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_global_module_cache",
+        ],
+    },
+)
+
+global_module_cache_uses_tmpdir_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.global_module_cache_uses_tmpdir",
+            "swift.use_global_module_cache",
+        ],
+    },
+)
+
+incorrect_global_module_cache_uses_tmpdir_action_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.global_module_cache_uses_tmpdir",
+        ],
+    },
+)
+
+def module_cache_settings_test_suite(name = "module_cache_settings"):
+    """Test suite for module cache options.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
+
+    # Verify that a global module cache path is passed to swiftc.
+    use_global_module_cache_action_command_line_test(
+        name = "{}_global_module_cache_build".format(name),
+        expected_argv = [
+            "-module-cache-path",
+            # Starlark doesn't have support for regular expression yet, so we
+            # can't verify the whole argument here.
+            "/bin/_swift_module_cache",
+        ],
+        not_expected_argv = [
+            "-Xwrapped-swift=-ephemeral-module-cache",
+            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that a pre-defined shared module cache path in `/private/tmp` is
+    # passed to swiftc.
+    global_module_cache_uses_tmpdir_action_command_line_test(
+        name = "{}_tmpdir_module_cache_build".format(name),
+        expected_argv = [
+            "-module-cache-path",
+            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+        ],
+        not_expected_argv = [
+            "-Xwrapped-swift=-ephemeral-module-cache",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that no module cache path is used when only
+    # `swift.global_module_cache_uses_tmpdir` is passed.
+    incorrect_global_module_cache_uses_tmpdir_action_command_line_test(
+        name = "{}_incorrect_tmpdir_module_cache_build".format(name),
+        not_expected_argv = [
+            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/module_cache_settings_tests.bzl
+++ b/test/module_cache_settings_tests.bzl
@@ -62,20 +62,20 @@ def module_cache_settings_test_suite(name = "module_cache_settings"):
         ],
         not_expected_argv = [
             "-Xwrapped-swift=-ephemeral-module-cache",
-            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    # Verify that a pre-defined shared module cache path in `/private/tmp` is
+    # Verify that a pre-defined shared module cache path in `/tmp` is
     # passed to swiftc.
     global_module_cache_uses_tmpdir_action_command_line_test(
         name = "{}_tmpdir_module_cache_build".format(name),
         expected_argv = [
             "-module-cache-path",
-            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
         ],
         not_expected_argv = [
             "-Xwrapped-swift=-ephemeral-module-cache",
@@ -90,7 +90,7 @@ def module_cache_settings_test_suite(name = "module_cache_settings"):
     incorrect_global_module_cache_uses_tmpdir_action_command_line_test(
         name = "{}_incorrect_tmpdir_module_cache_build".format(name),
         not_expected_argv = [
-            "/private/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],


### PR DESCRIPTION
This adds a new feature, that can be enabled by passing `--features=swift.use_global_module_cache` and `--features=swift.global_module_cache_uses_tmpdir` to the build command.

This feature, when enabled, will makes the Swift compilation actions use the shared Clang module cache path written to `/private/tmp/__build_bazel_rules_swift/swift_module_cache/REPOSITORY_NAME`. This makes the embedded Clang module breadcrumbs deterministic between Bazel instances, because they are always embedded as absolute paths. Note that the use of this cache is non-hermetic--the cached modules are not wiped between builds, and won't be cleaned when invoking bazel clean; the user is responsible for manually cleaning them.

Additionally, this can be used as a workaround for a bug in the Swift compiler that causes the module breadcrumbs to be embedded even though the `-no-clang-module-breadcrumbs` flag is passed (https://bugs.swift.org/browse/SR-13275).

Since the source path of modulemaps might be different for the same module, (i.e. multiple checkouts of the same repository, or remote execution), multiple modules with different hashes can end up in the cache. This can result in build failures. Don't use this feature with sandboxing (or probably remote execution as well).

---

This is based on my original commit (106add0a329010d358464955a15dc2836d53f13a) and PR #456.

Closes #456.