### PR TITLE
Update examples/tests with `generates_header = True` where necessary before flipping the attribute.

### DIFF
--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -20,6 +20,7 @@ objc_library(
 swift_library(
     name = "Printer",
     srcs = ["Printer.swift"],
+    generates_header = True,
     deps = [":PrintStream"],
 )
 


### PR DESCRIPTION
PiperOrigin-RevId: 362932692
(cherry picked from commit 1bcdd5756d044a4caa264dab4cac6aa321776478)