### PR TITLE
Distinguish between direct and transitive information when creating the `CcInfo` for a `swift_library`.

### DIFF
--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -126,7 +126,10 @@ def create_cc_info(
             linking_context = full_private_cc_info.linking_context,
         ))
 
-    return cc_common.merge_cc_infos(cc_infos = local_cc_infos + cc_infos)
+    return cc_common.merge_cc_infos(
+        cc_infos = cc_infos,
+        direct_cc_infos = local_cc_infos,
+    )
 
 def expand_locations(ctx, values, targets = []):
     """Expands the `$(location)` placeholders in each of the given values.


### PR DESCRIPTION
This ensures that, for a `swift_library` target `t`, reading from either the direct fields of `t[CcInfo].compilation_context` or `t[SwiftInfo].direct_modules[...].clang.compilation_context` produces consistent results.

PiperOrigin-RevId: 363418185
(cherry picked from commit 027e1801cace2034b75fd9732e6fa8670ea252ea)