### PR TITLE
Make `swift_library` not generate an Objective-C header by default.

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -277,9 +277,7 @@ False.
                 mandatory = False,
             ),
             "generates_header": attr.bool(
-                # TODO(b/182493307): Make the default False after migrating all
-                # targets to explicitly specify it when needed.
-                default = True,
+                default = False,
                 doc = """\
 If True, an Objective-C header will be generated for this target, in the same
 build package where the target is defined. By default, the name of the header is


### PR DESCRIPTION
To generate a header, `generates_header` must be set to `True` on the target.

PiperOrigin-RevId: 367012879
(cherry picked from commit 413cc02802fff11916e5bf4738767f99cb1cf1e3)