### PR TITLE
Simplify and cleanup how implicit toolchain dependencies are managed.

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -105,13 +105,6 @@ SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 # If enabled the compilation action will not produce indexes for system modules.
 SWIFT_FEATURE_DISABLE_SYSTEM_INDEX = "swift.disable_system_index"
 
-# If enabled, Swift libraries, binaries, and tests will only have automatic
-# dependencies on the targets provided by the toolchain's
-# `required_implicit_deps` field but not those in the `optional_implicit_deps`
-# field. Users may still explicitly list the latter in the `deps` of their
-# targets if they are needed.
-SWIFT_FEATURE_MINIMAL_DEPS = "swift.minimal_deps"
-
 # If enabled, compilation actions and module map generation will assume that the
 # header paths in module maps are relative to the current working directory
 # (i.e., the workspace root); if disabled, header paths in module maps are

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -217,13 +217,10 @@ def _swift_linking_rule_impl(
     )
     user_link_flags.extend(toolchain_linker_flags)
 
-    # Collect the dependencies of the target being linked as well as the
-    # toolchain's implicit dependencies (depending on the current feature
-    # configuration).
-    deps_to_link = ctx.attr.deps + swift_common.get_implicit_deps(
-        feature_configuration = feature_configuration,
-        swift_toolchain = swift_toolchain,
-    )
+    # Collect linking contexts from any of the toolchain's implicit
+    # dependencies.
+    for cc_info in swift_toolchain.implicit_deps_providers.cc_infos:
+        additional_linking_contexts.append(cc_info.linking_context)
 
     # If a custom malloc implementation has been provided, pass that to the
     # linker as well.
@@ -244,7 +241,7 @@ def _swift_linking_rule_impl(
         additional_inputs = additional_inputs_to_linker,
         additional_linking_contexts = additional_linking_contexts,
         cc_feature_configuration = cc_feature_configuration,
-        deps = deps_to_link,
+        deps = ctx.attr.deps,
         grep_includes = ctx.file._grep_includes,
         name = ctx.label.name,
         objects = objects_to_link,

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -33,7 +33,6 @@ load(
     ":compiling.bzl",
     "compile",
     "derive_module_name",
-    "get_implicit_deps",
     "precompile_clang_module",
 )
 load(
@@ -64,7 +63,6 @@ swift_common = struct(
     create_swift_info = create_swift_info,
     create_swift_module = create_swift_module,
     derive_module_name = derive_module_name,
-    get_implicit_deps = get_implicit_deps,
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
     precompile_clang_module = precompile_clang_module,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -36,7 +36,11 @@ load(
 load(":features.bzl", "features_for_build_modes")
 load(":providers.bzl", "SwiftToolchainInfo")
 load(":toolchain_config.bzl", "swift_toolchain_config")
-load(":utils.bzl", "get_swift_executable_for_toolchain")
+load(
+    ":utils.bzl",
+    "collect_implicit_deps_providers",
+    "get_swift_executable_for_toolchain",
+)
 
 def _all_tool_configs(
         swift_executable,
@@ -212,13 +216,16 @@ def _swift_toolchain_impl(ctx):
             all_files = depset(all_files),
             cc_toolchain_info = cc_toolchain,
             cpu = ctx.attr.arch,
-            generated_header_module_implicit_deps = [],
+            generated_header_module_implicit_deps_providers = (
+                collect_implicit_deps_providers([])
+            ),
+            implicit_deps_providers = (
+                collect_implicit_deps_providers([])
+            ),
             linker_opts_producer = linker_opts_producer,
             linker_supports_filelist = False,
             object_format = "elf",
-            optional_implicit_deps = [],
             requested_features = requested_features,
-            required_implicit_deps = [],
             root_dir = toolchain_root,
             supports_objc_interop = False,
             swift_worker = ctx.executable._worker,

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -14,6 +14,7 @@
 
 """Common utility definitions used by various BUILD rules."""
 
+load(":providers.bzl", "SwiftInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def collect_cc_libraries(
@@ -57,6 +58,42 @@ def collect_cc_libraries(
                 libraries.append(library.interface_library)
 
     return libraries
+
+def collect_implicit_deps_providers(targets):
+    """Returns a struct with important providers from a list of implicit deps.
+
+    Note that the relationship between each provider in the list and the target
+    it originated from is no longer retained.
+
+    Args:
+        targets: A list (possibly empty) of `Target`s.
+
+    Returns:
+        A `struct` containing three fields:
+
+        *   `cc_infos`: The merged `CcInfo` provider from the given targets.
+        *   `objc_infos`: The merged `apple_common.Objc` provider from the given
+            targets.
+        *   `swift_infos`: The merged `SwiftInfo` provider from the given
+            targets.
+    """
+    cc_infos = []
+    objc_infos = []
+    swift_infos = []
+
+    for target in targets:
+        if CcInfo in target:
+            cc_infos.append(target[CcInfo])
+        if apple_common.Objc in target:
+            objc_infos.append(target[apple_common.Objc])
+        if SwiftInfo in target:
+            swift_infos.append(target[SwiftInfo])
+
+    return struct(
+        cc_infos = cc_infos,
+        objc_infos = objc_infos,
+        swift_infos = swift_infos,
+    )
 
 def compact(sequence):
     """Returns a copy of the sequence with any `None` items removed.

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -46,7 +46,12 @@ load(
 load(":features.bzl", "features_for_build_modes")
 load(":toolchain_config.bzl", "swift_toolchain_config")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
-load(":utils.bzl", "compact", "get_swift_executable_for_toolchain")
+load(
+    ":utils.bzl",
+    "collect_implicit_deps_providers",
+    "compact",
+    "get_swift_executable_for_toolchain",
+)
 
 def _swift_developer_lib_dir(platform_framework_dir):
     """Returns the directory containing extra Swift developer libraries.
@@ -781,15 +786,18 @@ def _xcode_swift_toolchain_impl(ctx):
             all_files = depset(all_files),
             cc_toolchain_info = cc_toolchain,
             cpu = cpu,
-            generated_header_module_implicit_deps = (
-                ctx.attr.generated_header_module_implicit_deps
+            generated_header_module_implicit_deps_providers = (
+                collect_implicit_deps_providers(
+                    ctx.attr.generated_header_module_implicit_deps,
+                )
+            ),
+            implicit_deps_providers = collect_implicit_deps_providers(
+                ctx.attr.implicit_deps,
             ),
             linker_opts_producer = linker_opts_producer,
             linker_supports_filelist = True,
             object_format = "macho",
-            optional_implicit_deps = ctx.attr.optional_implicit_deps,
             requested_features = requested_features,
-            required_implicit_deps = ctx.attr.required_implicit_deps,
             supports_objc_interop = True,
             swift_worker = ctx.executable._worker,
             system_name = "darwin",
@@ -816,22 +824,16 @@ of a Swift module.
 """,
                 providers = [[SwiftInfo]],
             ),
-            "optional_implicit_deps": attr.label_list(
-                allow_files = True,
-                doc = """\
-A list of labels to library targets that should be added as implicit
-dependencies of any Swift compilation or linking target that does not have the
-`swift.minimal_deps` feature applied.
-""",
-                providers = [[CcInfo], [SwiftInfo]],
-            ),
-            "required_implicit_deps": attr.label_list(
+            "implicit_deps": attr.label_list(
                 allow_files = True,
                 doc = """\
 A list of labels to library targets that should be unconditionally added as
 implicit dependencies of any Swift compilation or linking target.
 """,
-                providers = [[CcInfo], [SwiftInfo]],
+                providers = [
+                    [CcInfo],
+                    [SwiftInfo],
+                ],
             ),
             "_cc_toolchain": attr.label(
                 default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),


### PR DESCRIPTION
-   When propagating implicit deps in the toolchain, merge and propagate the providers instead of the `Target` object itself. The `Target` object is fairly heavyweight and not intended to be propagated around the build graph.
-   Remove the `swift.minimal_deps` feature and the distinction between "required" and "optional" implicit deps.

PiperOrigin-RevId: 367044294
(cherry picked from commit 665ea7576e0794dc2d72cc7302714056ba143211)