### PR TITLE
Add `swift_common.create_swift_interop_info`.

### DIFF
--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -49,7 +49,11 @@ load(
     "create_swift_info",
     "create_swift_module",
 )
-load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
+load(
+    ":swift_clang_module_aspect.bzl",
+    "create_swift_interop_info",
+    "swift_clang_module_aspect",
+)
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -61,6 +65,7 @@ swift_common = struct(
     create_clang_module = create_clang_module,
     create_module = create_module,
     create_swift_info = create_swift_info,
+    create_swift_interop_info = create_swift_interop_info,
     create_swift_module = create_swift_module,
     derive_module_name = derive_module_name,
     is_enabled = is_feature_enabled,


### PR DESCRIPTION
This API allows custom rules to opt-in to "lightweight Swift interop". If they are already propagating a `CcInfo` with a compilation context, then `swift_clang_module_aspect` will detect this provider and generate a module name/module map (if necessary), and also compile the explicit module (if enabled). This frees the custom rule from having to understand details of the Swift compilation APIs, or even having to have a dependency on the Swift toolchain at all.

PiperOrigin-RevId: 367251939
(cherry picked from commit 9be992e3d6c696978ea62a5b2def7d7e977b8df1)