### PR TITLE
Move swift_clang_module_aspect out of swift_common and directly expose it.

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -21,6 +21,7 @@ load(":derived_files.bzl", "derived_files")
 load(":feature_names.bzl", "SWIFT_FEATURE_BUNDLED_XCTESTS")
 load(":linking.bzl", "register_link_binary_action")
 load(":providers.bzl", "SwiftToolchainInfo")
+load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "expand_locations")
 
@@ -35,7 +36,7 @@ def _binary_rule_attrs(stamp_default):
     """
     return dicts.add(
         swift_common.compilation_attrs(
-            additional_deps_aspects = [swift_common.swift_clang_module_aspect],
+            additional_deps_aspects = [swift_clang_module_aspect],
             requires_srcs = False,
         ),
         {

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -425,10 +425,10 @@ depends on an `objc_library` that depends on a `swift_library`).
 It also manages module map generation for `cc_library` targets that have the
 `swift_module` tag. This tag may take one of two forms:
 
-    *   `swift_module`: By itself, this indicates that the target is compatible
-        with Swift and should be given a module name that is derived from its
-        target label.
-    *   `swift_module=name`: The module should be given the name `name`.
+*   `swift_module`: By itself, this indicates that the target is compatible
+    with Swift and should be given a module name that is derived from its
+    target label.
+*   `swift_module=name`: The module should be given the name `name`.
 
 Note that the public headers of such `cc_library` targets must be parsable as C,
 since Swift does not support C++ interop at this time.

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -49,7 +49,11 @@ load(
     "create_swift_info",
     "create_swift_module",
 )
+<<<<<<< HEAD
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
+=======
+load(":swift_clang_module_aspect.bzl", "create_swift_interop_info")
+>>>>>>> 132220a (Move swift_clang_module_aspect out of swift_common and directly expose it.)
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -66,7 +70,6 @@ swift_common = struct(
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
     precompile_clang_module = precompile_clang_module,
-    swift_clang_module_aspect = swift_clang_module_aspect,
     swift_runtime_linkopts = swift_runtime_linkopts,
     toolchain_attrs = swift_toolchain_attrs,
 )

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -29,6 +29,7 @@ load(
 )
 load(":linking.bzl", "create_linker_input")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
 load(
     ":utils.bzl",
@@ -289,11 +290,11 @@ def _swift_library_impl(ctx):
 swift_library = rule(
     attrs = dicts.add(
         swift_common.library_rule_attrs(additional_deps_aspects = [
-            swift_common.swift_clang_module_aspect,
+            swift_clang_module_aspect,
         ]),
         {
             "private_deps": swift_deps_attr(
-                aspects = [swift_common.swift_clang_module_aspect],
+                aspects = [swift_clang_module_aspect],
                 doc = """\
 A list of targets that are implementation-only dependencies of the target being
 built. Libraries/linker flags from these dependencies will be propagated to

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -44,6 +44,10 @@ load(
     _swift_c_module = "swift_c_module",
 )
 load(
+    "@build_bazel_rules_swift//swift/internal:swift_clang_module_aspect.bzl",
+    _swift_clang_module_aspect = "swift_clang_module_aspect",
+)
+load(
     "@build_bazel_rules_swift//swift/internal:swift_common.bzl",
     _swift_common = "swift_common",
 )
@@ -92,4 +96,5 @@ swift_module_alias = _swift_module_alias
 swift_proto_library = _swift_proto_library
 
 # Re-export public aspects.
+swift_clang_module_aspect = _swift_clang_module_aspect
 swift_usage_aspect = _swift_usage_aspect


### PR DESCRIPTION
RELNOTES: swift_clang_module_aspect is directly exported instead of being in swift_common.
PiperOrigin-RevId: 367673524
(cherry picked from commit bf8243d1732b7cc48e99c045ebd03387014e620e)