### PR TITLE
Add Xcode toolchain support for an optional binary that can rewrite the generated header of a Swift module after compilation.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -51,7 +51,6 @@ load(
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_OSIZE",
     "SWIFT_FEATURE_OPT_USES_WMO",
-    "SWIFT_FEATURE_REWRITE_GENERATED_HEADER",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
     "SWIFT_FEATURE_STRICT_MODULES",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
@@ -221,24 +220,25 @@ def compile_action_configs(
         ),
     ]
 
-    if generated_header_rewriter:
-        # Only add the generated header rewriter to the command line only if the
-        # toolchain provides one, the relevant feature is requested, and the
-        # particular compilation action is generating a header.
-        def generated_header_rewriter_configurator(prerequisites, args):
-            if prerequisites.generated_header_file:
-                args.add(
-                    generated_header_rewriter,
-                    format = "-Xwrapped-swift=-generated-header-rewriter=%s",
-                )
+    # TODO: Enable once bazel supports nested functions
+    # if generated_header_rewriter:
+    #     # Only add the generated header rewriter to the command line only if the
+    #     # toolchain provides one, the relevant feature is requested, and the
+    #     # particular compilation action is generating a header.
+    #     def generated_header_rewriter_configurator(prerequisites, args):
+    #         if prerequisites.generated_header_file:
+    #             args.add(
+    #                 generated_header_rewriter,
+    #                 format = "-Xwrapped-swift=-generated-header-rewriter=%s",
+    #             )
 
-        action_configs.append(
-            swift_toolchain_config.action_config(
-                actions = [swift_action_names.COMPILE],
-                configurators = [generated_header_rewriter_configurator],
-                features = [SWIFT_FEATURE_REWRITE_GENERATED_HEADER],
-            ),
-        )
+    #     action_configs.append(
+    #         swift_toolchain_config.action_config(
+    #             actions = [swift_action_names.COMPILE],
+    #             configurators = [generated_header_rewriter_configurator],
+    #             features = [SWIFT_FEATURE_REWRITE_GENERATED_HEADER],
+    #         ),
+    #     )
 
     #### Compilation-mode-related flags
     #

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -51,6 +51,7 @@ load(
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_OSIZE",
     "SWIFT_FEATURE_OPT_USES_WMO",
+    "SWIFT_FEATURE_REWRITE_GENERATED_HEADER",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
     "SWIFT_FEATURE_STRICT_MODULES",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
@@ -95,7 +96,8 @@ _WMO_FLAGS = {
 def compile_action_configs(
         *,
         additional_objc_copts = [],
-        additional_swiftc_copts = []):
+        additional_swiftc_copts = [],
+        generated_header_rewriter = None):
     """Returns the list of action configs needed to perform Swift compilation.
 
     Toolchains must add these to their own list of action configs so that
@@ -109,6 +111,9 @@ def compile_action_configs(
         additional_swiftc_copts: An optional list of additional Swift compiler
             flags that should be passed to Swift compile actions only after any
             other toolchain- or user-provided flags.
+        generated_header_rewriter: An executable that will be invoked after
+            compilation to rewrite the generated header, or None if this is not
+            desired.
 
     Returns:
         The list of action configs needed to perform compilation.
@@ -215,6 +220,25 @@ def compile_action_configs(
             configurators = [_emit_objc_header_path_configurator],
         ),
     ]
+
+    if generated_header_rewriter:
+        # Only add the generated header rewriter to the command line only if the
+        # toolchain provides one, the relevant feature is requested, and the
+        # particular compilation action is generating a header.
+        def generated_header_rewriter_configurator(prerequisites, args):
+            if prerequisites.generated_header_file:
+                args.add(
+                    generated_header_rewriter,
+                    format = "-Xwrapped-swift=-generated-header-rewriter=%s",
+                )
+
+        action_configs.append(
+            swift_toolchain_config.action_config(
+                actions = [swift_action_names.COMPILE],
+                configurators = [generated_header_rewriter_configurator],
+                features = [SWIFT_FEATURE_REWRITE_GENERATED_HEADER],
+            ),
+        )
 
     #### Compilation-mode-related flags
     #

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -123,6 +123,11 @@ SWIFT_FEATURE_OPT_USES_WMO = "swift.opt_uses_wmo"
 # the `-Osize` flag instead of `-O`.
 SWIFT_FEATURE_OPT_USES_OSIZE = "swift.opt_uses_osize"
 
+# If enabled, and if the toolchain specifies a generated header rewriting tool,
+# that tool will be invoked after compilation to rewrite the generated header in
+# place.
+SWIFT_FEATURE_REWRITE_GENERATED_HEADER = "swift.rewrite_generated_header"
+
 # If enabled, Swift compiler invocations will use precompiled modules from
 # dependencies instead of module maps and headers, if those dependencies provide
 # them.

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -86,6 +86,17 @@ static std::string Unescape(const std::string &arg) {
   return result;
 }
 
+// If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
+// function returns true. Otherwise, `str` is left unmodified and the function
+// returns `false`.
+static bool StripPrefix(const std::string &prefix, std::string &str) {
+  if (str.find(prefix) != 0) {
+    return false;
+  }
+  str.erase(0, prefix.size());
+  return true;
+}
+
 }  // namespace
 
 SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
@@ -96,6 +107,28 @@ SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
 
 int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
   int exit_code = RunSubProcess(args_, stderr_stream, stdout_to_stderr);
+  if (exit_code != 0) {
+    return exit_code;
+  }
+
+  if (!generated_header_rewriter_path_.empty()) {
+#if __APPLE__
+    // Skip the `xcrun` argument that's added when running on Apple platforms.
+    int initial_args_to_skip = 1;
+#else
+    int initial_args_to_skip = 0;
+#endif
+
+    std::vector<std::string> rewriter_args;
+    rewriter_args.reserve(args_.size() + 2 - initial_args_to_skip);
+    rewriter_args.push_back(generated_header_rewriter_path_);
+    rewriter_args.push_back("--");
+    rewriter_args.insert(rewriter_args.end(),
+                         args_.begin() + initial_args_to_skip, args_.end());
+
+    exit_code = RunSubProcess(rewriter_args, stderr_stream, stdout_to_stderr);
+  }
+
   return exit_code;
 }
 
@@ -155,40 +188,49 @@ bool SwiftRunner::ProcessArgument(
 
   if (arg[0] == '@') {
     changed = ProcessPossibleResponseFile(arg, consumer);
-  } else if (arg == "-Xwrapped-swift=-debug-prefix-pwd-is-dot") {
-    // Get the actual current working directory (the workspace root), which we
-    // didn't know at analysis time.
-    consumer("-debug-prefix-map");
-    consumer(GetCurrentDirectory() + "=.");
-    changed = true;
-  } else if (arg == "-Xwrapped-swift=-coverage-prefix-pwd-is-dot") {
-    // Get the actual current working directory (the workspace root), which we
-    // didn't know at analysis time.
-    consumer("-coverage-prefix-map");
-    consumer(GetCurrentDirectory() + "=.");
-    changed = true;
-  } else if (arg == "-Xwrapped-swift=-ephemeral-module-cache") {
-    // Create a temporary directory to hold the module cache, which will be
-    // deleted after compilation is finished.
-    auto module_cache_dir = TempDirectory::Create("swift_module_cache.XXXXXX");
-    consumer("-module-cache-path");
-    consumer(module_cache_dir->GetPath());
-    temp_directories_.push_back(std::move(module_cache_dir));
-    changed = true;
-  } else if (arg.find("-Xwrapped-swift=") == 0) {
-    // TODO(allevato): Report that an unknown wrapper arg was found and give the
-    // caller a way to exit gracefully.
-    changed = true;
   } else {
-    // Apply any other text substitutions needed in the argument (i.e., for
-    // Apple toolchains).
-    auto new_arg = arg;
-    // Bazel doesn't quote arguments in multi-line params files, so we need to
-    // ensure that our defensive quoting kicks in if an argument contains a
-    // space, even if no other changes would have been made.
-    changed = bazel_placeholder_substitutions_.Apply(new_arg) ||
-              new_arg.find_first_of(' ') != std::string::npos;
-    consumer(new_arg);
+    std::string new_arg = arg;
+    if (StripPrefix("-Xwrapped-swift=", new_arg)) {
+      if (new_arg == "-debug-prefix-pwd-is-dot") {
+        // Get the actual current working directory (the workspace root), which
+        // we didn't know at analysis time.
+        consumer("-debug-prefix-map");
+        consumer(GetCurrentDirectory() + "=.");
+        changed = true;
+      } else if (new_arg == "-coverage-prefix-pwd-is-dot") {
+        // Get the actual current working directory (the workspace root), which we
+        // didn't know at analysis time.
+        consumer("-coverage-prefix-map");
+        consumer(GetCurrentDirectory() + "=.");
+        changed = true;
+      } else if (new_arg == "-ephemeral-module-cache") {
+        // Create a temporary directory to hold the module cache, which will be
+        // deleted after compilation is finished.
+        auto module_cache_dir =
+            TempDirectory::Create("swift_module_cache.XXXXXX");
+        consumer("-module-cache-path");
+        consumer(module_cache_dir->GetPath());
+        temp_directories_.push_back(std::move(module_cache_dir));
+        changed = true;
+      } else if (StripPrefix("-generated-header-rewriter=", new_arg)) {
+        generated_header_rewriter_path_ = new_arg;
+        changed = true;
+      } else {
+        // TODO(allevato): Report that an unknown wrapper arg was found and give
+        // the caller a way to exit gracefully.
+        changed = true;
+      }
+    } else {
+      // Apply any other text substitutions needed in the argument (i.e., for
+      // Apple toolchains).
+      //
+      // Bazel doesn't quote arguments in multi-line params files, so we need to
+      // ensure that our defensive quoting kicks in if an argument contains a
+      // space, even if no other changes would have been made.
+      changed = bazel_placeholder_substitutions_.Apply(new_arg) ||
+                new_arg.find_first_of(' ') != std::string::npos;
+      consumer(new_arg);
+    }
   }
 
   return changed;

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -124,6 +124,10 @@ class SwiftRunner {
   // Arguments will be unconditionally written into a response file and passed
   // to the tool that way.
   bool force_response_file_;
+
+  // The path to the generated header rewriter tool, if one is being used for
+  // this compilation.
+  std::string generated_header_rewriter_path_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_


### PR DESCRIPTION
PiperOrigin-RevId: 369323385
(cherry picked from commit e4912a311f32f7c5ae2c5a61f549f03a4b0aab16)