### PR TITLE
Use cpp fragment, instead of objc fragment, to determine whether to generate dsym

### DIFF
--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -105,7 +105,7 @@ def configure_features(
         _enabled_features = requestable_features,
     )
 
-def features_for_build_modes(ctx, cpp_fragment = None):
+def features_for_build_modes(ctx, objc_fragment = None, cpp_fragment = None):
     """Returns a list of Swift toolchain features for current build modes.
 
     This function explicitly breaks the "don't pass `ctx` as an argument"
@@ -114,6 +114,7 @@ def features_for_build_modes(ctx, cpp_fragment = None):
 
     Args:
         ctx: The current rule context.
+        objc_fragment: The Objective-C configuration fragment, if available.
         cpp_fragment: The Cpp configuration fragment, if available.
 
     Returns:
@@ -126,7 +127,13 @@ def features_for_build_modes(ctx, cpp_fragment = None):
         features.append(SWIFT_FEATURE_COVERAGE)
     if compilation_mode in ("dbg", "fastbuild"):
         features.append(SWIFT_FEATURE_ENABLE_TESTING)
-    if cpp_fragment and cpp_fragment.apple_generate_dsym:
+
+    # TODO: Remove getattr once bazel is released with this change
+    if cpp_fragment and getattr(cpp_fragment, "apple_generate_dsym", False):
+        features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
+
+    # TODO: Remove the objc_fragment usage once bazel is released with the C++ change
+    if objc_fragment and getattr(objc_fragment, "generate_dsym", False):
         features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
     return features
 

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -105,7 +105,7 @@ def configure_features(
         _enabled_features = requestable_features,
     )
 
-def features_for_build_modes(ctx, objc_fragment = None):
+def features_for_build_modes(ctx, cpp_fragment = None):
     """Returns a list of Swift toolchain features for current build modes.
 
     This function explicitly breaks the "don't pass `ctx` as an argument"
@@ -114,7 +114,7 @@ def features_for_build_modes(ctx, objc_fragment = None):
 
     Args:
         ctx: The current rule context.
-        objc_fragment: The Objective-C configuration fragment, if available.
+        cpp_fragment: The Cpp configuration fragment, if available.
 
     Returns:
         A list of Swift toolchain features to enable.
@@ -126,7 +126,7 @@ def features_for_build_modes(ctx, objc_fragment = None):
         features.append(SWIFT_FEATURE_COVERAGE)
     if compilation_mode in ("dbg", "fastbuild"):
         features.append(SWIFT_FEATURE_ENABLE_TESTING)
-    if objc_fragment and objc_fragment.generate_dsym:
+    if cpp_fragment and cpp_fragment.apple_generate_dsym:
         features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
     return features
 

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -684,6 +684,7 @@ def _xcode_swift_toolchain_impl(ctx):
     # version.
     requested_features = features_for_build_modes(
         ctx,
+        objc_fragment = ctx.fragments.objc,
         cpp_fragment = ctx.fragments.cpp,
     ) + features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
     requested_features.extend(ctx.features)

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -684,7 +684,7 @@ def _xcode_swift_toolchain_impl(ctx):
     # version.
     requested_features = features_for_build_modes(
         ctx,
-        objc_fragment = ctx.fragments.objc,
+        cpp_fragment = ctx.fragments.cpp,
     ) + features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
     requested_features.extend(ctx.features)
     requested_features.append(SWIFT_FEATURE_BUNDLED_XCTESTS)
@@ -838,6 +838,7 @@ for incremental compilation using a persistent mode.
     doc = "Represents a Swift compiler toolchain provided by Xcode.",
     fragments = [
         "apple",
+        "cpp",
         "objc",
         "swift",
     ],


### PR DESCRIPTION
The information is identical, and we would like to migrate all uses to
cpp fragment so that we can delete the info in objc fragment.

PiperOrigin-RevId: 370899517
(cherry picked from commit 3e53aa28a558b7cb690cae10afd63ca98b221a35)