### PR TITLE
Make the strict include paths from `objc_proto_library` targets available so headers can be found when `swift_clang_module_aspect` compiles a module.

### DIFF
--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -472,6 +472,14 @@ def _handle_module(
                         compilation_context = dep[CcInfo].compilation_context,
                     ),
                 )
+            if apple_common.Objc in dep:
+                target_and_deps_cc_infos.append(
+                    CcInfo(
+                        compilation_context = cc_common.create_compilation_context(
+                            includes = dep[apple_common.Objc].strict_include,
+                        ),
+                    ),
+                )
 
         compilation_context_to_compile = cc_common.merge_cc_infos(
             direct_cc_infos = target_and_deps_cc_infos,


### PR DESCRIPTION
`swift_clang_module_aspect` assumes that CcInfo contains all of the necessary compiler flags to be able to find the headers that are used when compiling an explicit module. This is true for all flags except the header search path in the Objc provider's `strict_include` field. This means that the `strict_include` field needs to be explicitly translated to an equivalent CcInfo when compiling the module.

PiperOrigin-RevId: 370991285
(cherry picked from commit 1aca023d007646d44da3512bac05ebbad64e8135)