### PR TITLE
Rename `swift.strict_modules` to `swift.layering_check` to match the C++ feature name.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -45,6 +45,7 @@ load(
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
+    "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
@@ -52,7 +53,6 @@ load(
     "SWIFT_FEATURE_OPT_USES_OSIZE",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
-    "SWIFT_FEATURE_STRICT_MODULES",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
@@ -538,7 +538,7 @@ def compile_action_configs(
                 ),
             ],
             not_features = [
-                [SWIFT_FEATURE_STRICT_MODULES],
+                [SWIFT_FEATURE_LAYERING_CHECK],
                 [SWIFT_FEATURE_SYSTEM_MODULE],
             ],
         ),
@@ -550,7 +550,7 @@ def compile_action_configs(
                     "-fmodules-strict-decluse",
                 ),
             ],
-            features = [SWIFT_FEATURE_STRICT_MODULES],
+            features = [SWIFT_FEATURE_LAYERING_CHECK],
             not_features = [SWIFT_FEATURE_SYSTEM_MODULE],
         ),
         swift_toolchain_config.action_config(

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -66,7 +66,7 @@ SWIFT_FEATURE_EMIT_C_MODULE = "swift.emit_c_module"
 # If enabled, when compiling an explicit C or Objectve-C module, every header
 # included by the module being compiled must belong to one of the modules listed
 # in its dependencies. This is ignored for system modules.
-SWIFT_FEATURE_STRICT_MODULES = "swift.strict_modules"
+SWIFT_FEATURE_LAYERING_CHECK = "swift.layering_check"
 
 # If enabled, the C or Objective-C target should be compiled as a system module.
 SWIFT_FEATURE_SYSTEM_MODULE = "swift.system_module"


### PR DESCRIPTION
PiperOrigin-RevId: 371693623
(cherry picked from commit 06322f12a2dcbcafb33e598416486c25bef621c8)