### PR TITLE
Add a user settable build setting to specify additional swiftcopts for a swift_libray target.

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,5 +1,9 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+load(
+    "//swift/internal:build_settings.bzl",
+    "per_module_swiftcopt_flag",
+)
 
 package(default_visibility = ["//visibility:public"])
 
@@ -41,6 +45,13 @@ filegroup(
     visibility = [
         "//:__pkg__",
     ],
+)
+
+# User settable flag that specifies additional Swift copts on a per-swiftmodule basis.
+per_module_swiftcopt_flag(
+    name = "per_module_swiftcopt",
+    build_setting_default = "",
+    visibility = ["//visibility:public"],
 )
 
 # Configuration setting for enabling the generation of swiftinterface files.

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -364,6 +364,11 @@ bzl_library(
     visibility = ["//swift:__subpackages__"],
 )
 
+bzl_library(
+    name = "build_settings",
+    srcs = ["build_settings.bzl"],
+)
+
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -152,6 +152,9 @@ def swift_config_attrs():
         "_config_emit_swiftinterface": attr.label(
             default = "@build_bazel_rules_swift//swift:emit_swiftinterface",
         ),
+        "_per_module_swiftcopt": attr.label(
+            default = "@build_bazel_rules_swift//swift:per_module_swiftcopt",
+        ),
     }
 
 def swift_deps_attr(doc, **kwargs):

--- a/swift/internal/build_settings.bzl
+++ b/swift/internal/build_settings.bzl
@@ -1,0 +1,85 @@
+# Copyright 2021 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom build settings rules for Swift rules."""
+
+PerModuleSwiftCoptSettingInfo = provider(
+    doc = "A provider for the parsed per-swiftmodule swift copts.",
+    fields = {
+        "value": "A map of target labels to lists of additional Swift copts to apply to" +
+                 "the target.",
+    },
+)
+
+def additional_per_module_swiftcopts(label, provider):
+    """Returns additional swiftcopts to apply to a target named `label`.
+
+    Args:
+      label: The label of the target.
+      provider: The `PerModuleSwiftCoptsSettingInfo` provider from the calling
+          context.
+    Returns:
+        A list of additional swiftcopts to use when builing the target.
+    """
+    per_module_copts = provider.value
+    if per_module_copts:
+        target_label = str(label)
+        return per_module_copts.get(target_label, [])
+    return []
+
+def _per_module_swiftcopt_flag_impl(ctx):
+    # Each item in this list should of the form
+    # "<target label>=<comma separated copts>".
+    module_and_copts_list = ctx.build_setting_value
+    value = dict()
+    for item in module_and_copts_list:
+        if not item:
+            continue
+        contents = item.split("=", 1)
+        if len(contents) != 2:
+            fail("""\
+--per_module_swiftcopt must be written as a target label, an equal sign \
+("="), and a comma-delimited list of compiler flags. For example, \
+"//package:target=-copt,-copt,...".""")
+
+        # Canonicalize the label using the `Label` constructor.
+        label = str(Label(contents[0]))
+        raw_copts = contents[1]
+
+        # TODO(b/186875113): This breaks if any of the copts actually use
+        # commas. Switch to a more selective approach to splitting,
+        # respecting an escape sequence for commas inside of copts.
+        copts = raw_copts.split(",")
+        if len(copts) > 0:
+            existing_copts = value.get(label)
+            if existing_copts:
+                existing_copts.extend(copts)
+            else:
+                value[label] = copts
+    return PerModuleSwiftCoptSettingInfo(value = value)
+
+per_module_swiftcopt_flag = rule(
+    build_setting = config.string(
+        flag = True,
+        allow_multiple = True,
+    ),
+    # TODO(b/186869451): Support adding swiftcopts by module name in addition
+    # to the target label.
+    doc = """\
+A string list build setting that can be set on the command line. Each item in
+the list is expected to be of the form: <//target-package:name>=<copts> where
+copts is a colon separated list of Swift copts.
+""",
+    implementation = _per_module_swiftcopt_flag_impl,
+)

--- a/swift/internal/build_settings.bzl
+++ b/swift/internal/build_settings.bzl
@@ -41,7 +41,8 @@ def additional_per_module_swiftcopts(label, provider):
 def _per_module_swiftcopt_flag_impl(ctx):
     # Each item in this list should of the form
     # "<target label>=<comma separated copts>".
-    module_and_copts_list = ctx.build_setting_value
+    # TODO: Remove extra list once allow_multiple is enabled
+    module_and_copts_list = [ctx.build_setting_value]
     value = dict()
     for item in module_and_copts_list:
         if not item:
@@ -72,7 +73,7 @@ def _per_module_swiftcopt_flag_impl(ctx):
 per_module_swiftcopt_flag = rule(
     build_setting = config.string(
         flag = True,
-        allow_multiple = True,
+        # allow_multiple = True,  # TODO: Enable once bazel supports it
     ),
     # TODO(b/186869451): Support adding swiftcopts by module name in addition
     # to the target label.

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -16,6 +16,11 @@
 
 load(":attrs.bzl", "swift_deps_attr")
 load(
+    ":build_settings.bzl",
+    "PerModuleSwiftCoptSettingInfo",
+    "additional_per_module_swiftcopts",
+)
+load(
     ":compiling.bzl",
     "new_objc_provider",
     "output_groups_from_compilation_outputs",
@@ -106,6 +111,12 @@ def _swift_library_impl(ctx):
     linkopts = expand_locations(ctx, ctx.attr.linkopts, ctx.attr.swiftc_inputs)
     linkopts = expand_make_variables(ctx, linkopts, "linkopts")
     srcs = ctx.files.srcs
+
+    module_copts = additional_per_module_swiftcopts(
+        ctx.label,
+        ctx.attr._per_module_swiftcopt[PerModuleSwiftCoptSettingInfo],
+    )
+    copts.extend(module_copts)
 
     extra_features = []
     if ctx.attr._config_emit_swiftinterface[BuildSettingInfo].value:


### PR DESCRIPTION
The flag accepts a comma separated list of "target=copts" pairs, where "target" is a fully qualified target label and "copts" is a colon separated list of Swift copts.

PiperOrigin-RevId: 371728552
(cherry picked from commit de9c4e1a00f779af382b2a9b96a2685b54a3f93a)