### PR TITLE
Revert "Add support for older bazel versions for now"

### DIFF
--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -112,7 +112,7 @@ def configure_features(
         _enabled_features = requestable_features,
     )
 
-def features_for_build_modes(ctx, objc_fragment = None, cpp_fragment = None):
+def features_for_build_modes(ctx, cpp_fragment = None):
     """Returns a list of Swift toolchain features for current build modes.
 
     This function explicitly breaks the "don't pass `ctx` as an argument"
@@ -121,7 +121,6 @@ def features_for_build_modes(ctx, objc_fragment = None, cpp_fragment = None):
 
     Args:
         ctx: The current rule context.
-        objc_fragment: The Objective-C configuration fragment, if available.
         cpp_fragment: The Cpp configuration fragment, if available.
 
     Returns:
@@ -134,13 +133,7 @@ def features_for_build_modes(ctx, objc_fragment = None, cpp_fragment = None):
         features.append(SWIFT_FEATURE_COVERAGE)
     if compilation_mode in ("dbg", "fastbuild"):
         features.append(SWIFT_FEATURE_ENABLE_TESTING)
-
-    # TODO: Remove getattr once bazel is released with this change
-    if cpp_fragment and getattr(cpp_fragment, "apple_generate_dsym", False):
-        features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
-
-    # TODO: Remove the objc_fragment usage once bazel is released with the C++ change
-    if objc_fragment and getattr(objc_fragment, "generate_dsym", False):
+    if cpp_fragment and cpp_fragment.apple_generate_dsym:
         features.append(SWIFT_FEATURE_FULL_DEBUG_INFO)
     return features
 

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -681,7 +681,6 @@ def _xcode_swift_toolchain_impl(ctx):
     # version.
     requested_features = features_for_build_modes(
         ctx,
-        objc_fragment = ctx.fragments.objc,
         cpp_fragment = ctx.fragments.cpp,
     ) + features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
     requested_features.extend(ctx.features)


### PR DESCRIPTION
This reverts commit 1b4e4c06ad71e4fc6383d72d64d517ff6674995b.