### PR TITLE
Stop passing `uses_swift` to `new_objc_provider`.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2377,7 +2377,6 @@ def new_objc_provider(
     objc_provider_args = {
         "link_inputs": depset(direct = swiftmodules + link_inputs),
         "providers": all_objc_providers,
-        "uses_swift": True,
     }
 
     # The link action registered by `apple_binary` only looks at `Objc`

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -500,7 +500,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             includes = [aspect_ctx.bin_dir.path]
             objc_info = apple_common.new_objc_provider(
                 providers = objc_infos,
-                uses_swift = True,
                 **objc_info_args
             )
         else:


### PR DESCRIPTION
This flag hasn't been used by Bazel for a very very very very very long time.

PiperOrigin-RevId: 373845026
(cherry picked from commit 05f18b8b495a6b3385b708d2d906b224a8913be6)