### PR TITLE
Add the ability to dump ast to a file

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -41,6 +41,9 @@ swift_action_names = struct(
     # Produces files that are usually fallout of the compilation such as
     # .swiftmodule, -Swift.h and more.
     DERIVE_FILES = "SwiftDeriveFiles",
+
+    # Produces an AST file for each swift source file in a module.
+    DUMP_AST = "SwiftDumpAST",
 )
 
 def _apply_configurator(configurator, prerequisites, args):

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1903,6 +1903,7 @@ def compile(
     )
 
     return struct(
+        ast_files = compile_outputs.ast_files,
         generated_header = compile_outputs.generated_header_file,
         generated_module_map = compile_outputs.generated_module_map_file,
         indexstore = compile_outputs.indexstore_directory,
@@ -1916,7 +1917,6 @@ def compile(
         swiftdoc = compile_outputs.swiftdoc_file,
         swiftinterface = compile_outputs.swiftinterface_file,
         swiftmodule = compile_outputs.swiftmodule_file,
-        ast_files = compile_outputs.ast_files,
     )
 
 def precompile_clang_module(
@@ -2323,6 +2323,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
     # action outputs although they are not processed further.
     other_outputs = []
 
+    # AST files that are available in the swift_ast_file output group
     ast_files = []
 
     for src in srcs:
@@ -2365,8 +2366,8 @@ def _declare_multiple_outputs_and_write_output_file_map(
     )
 
     return struct(
-        object_files = output_objs,
         ast_files = ast_files,
+        object_files = output_objs,
         other_outputs = other_outputs,
         output_file_map = output_map_file,
     )
@@ -2643,6 +2644,11 @@ def output_groups_from_compilation_outputs(compilation_outputs):
     """
     output_groups = {}
 
+    if compilation_outputs.ast_files:
+        output_groups["swift_ast_file"] = depset(
+            compilation_outputs.ast_files,
+        )
+
     if compilation_outputs.indexstore:
         output_groups["swift_index_store"] = depset([
             compilation_outputs.indexstore,
@@ -2662,11 +2668,6 @@ def output_groups_from_compilation_outputs(compilation_outputs):
         output_groups["swiftmodule"] = depset([
             compilation_outputs.swiftmodule,
         ])
-
-    if compilation_outputs.ast_files:
-        output_groups["swift_ast_file"] = depset(
-            compilation_outputs.ast_files,
-        )
 
     return output_groups
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -142,6 +142,19 @@ def compile_action_configs(
             configurators = [_output_swiftmodule_or_file_map_configurator],
         ),
 
+        # Dump ast files
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.DUMP_AST],
+            configurators = [
+                swift_toolchain_config.add_arg("-dump-ast"),
+                swift_toolchain_config.add_arg("-suppress-warnings"),
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.DUMP_AST],
+            configurators = [_output_ast_path_or_file_map_configurator],
+        ),
+
         # Emit precompiled Clang modules, and embed all files that were read
         # during compilation into the PCM.
         swift_toolchain_config.action_config(
@@ -257,6 +270,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg("-DDEBUG"),
@@ -267,6 +281,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg("-DNDEBUG"),
@@ -362,6 +377,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg("-enable-testing"),
@@ -484,6 +500,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg("-Xcc", "-Xclang"),
@@ -501,6 +518,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_global_module_cache_configurator],
             features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
@@ -513,6 +531,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_tmpdir_module_cache_configurator],
             features = [
@@ -525,6 +544,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg(
@@ -544,6 +564,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg(
@@ -635,6 +656,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_dependencies_swiftmodules_configurator],
             not_features = [SWIFT_FEATURE_VFSOVERLAY],
@@ -643,6 +665,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 _dependencies_swiftmodules_vfsoverlay_configurator,
@@ -658,6 +681,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_framework_search_paths_configurator],
         ),
@@ -679,6 +703,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 _clang_search_paths_configurator,
@@ -693,6 +718,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_dependencies_clang_modules_configurator],
             features = [SWIFT_FEATURE_USE_C_MODULES],
@@ -702,6 +728,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_dependencies_clang_modulemaps_configurator],
             not_features = [SWIFT_FEATURE_USE_C_MODULES],
@@ -792,6 +819,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_module_name_configurator],
         ),
@@ -840,6 +868,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_conditional_compilation_flag_configurator],
         ),
@@ -865,6 +894,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_user_compile_flags_configurator],
         ),
@@ -875,6 +905,7 @@ def compile_action_configs(
                 actions = [
                     swift_action_names.COMPILE,
                     swift_action_names.PRECOMPILE_C_MODULE,
+                    swift_action_names.DUMP_AST,
                 ],
                 configurators = [
                     # TODO(#568): Switch to using lambda when the minimum
@@ -910,6 +941,7 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_source_files_configurator],
         ),
@@ -921,6 +953,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [_additional_inputs_configurator],
         ),
@@ -959,6 +992,14 @@ def _output_swiftmodule_or_file_map_configurator(prerequisites, args):
     return _output_or_file_map(
         output_file_map = prerequisites.output_file_map,
         outputs = [prerequisites.swiftmodule_file],
+        args = args,
+    )
+
+def _output_ast_path_or_file_map_configurator(prerequisites, args):
+    """Adds the output file map or single AST file to the command line."""
+    return _output_or_file_map(
+        output_file_map = prerequisites.output_file_map,
+        outputs = prerequisites.ast_files,
         args = args,
     )
 
@@ -1803,6 +1844,22 @@ def compile(
         swift_toolchain = swift_toolchain,
     )
 
+    # Dump AST has to run in its own action because `-dump-ast` is incompatible
+    # with emitting dependency files, which compile/derive files use when
+    # compiling via the worker.
+    # Given usage of AST files is expected to be limited compared to other
+    # compile outputs, moving generation off of the critical path is likely
+    # a reasonable tradeoff for the additional action.
+    run_toolchain_action(
+        actions = actions,
+        action_name = swift_action_names.DUMP_AST,
+        feature_configuration = feature_configuration,
+        outputs = compile_outputs.ast_files,
+        prerequisites = prerequisites,
+        progress_message = "Dumping Swift AST for {}".format(module_name),
+        swift_toolchain = swift_toolchain,
+    )
+
     # If a header and module map were generated for this Swift module, attempt
     # to precompile the explicit module for that header as well.
     if generated_header_name and not is_feature_enabled(
@@ -1859,6 +1916,7 @@ def compile(
         swiftdoc = compile_outputs.swiftdoc_file,
         swiftinterface = compile_outputs.swiftinterface_file,
         swiftmodule = compile_outputs.swiftmodule_file,
+        ast_files = compile_outputs.ast_files,
     )
 
 def precompile_clang_module(
@@ -2168,6 +2226,11 @@ def _declare_compile_outputs(
             actions = actions,
             target_name = target_name,
         )]
+        ast_files = [derived_files.ast(
+            actions = actions,
+            target_name = target_name,
+            src = srcs[0],
+        )]
         other_outputs = []
         output_file_map = None
     else:
@@ -2180,6 +2243,7 @@ def _declare_compile_outputs(
             target_name = target_name,
         )
         object_files = output_info.object_files
+        ast_files = output_info.ast_files
         other_outputs = output_info.other_outputs
         output_file_map = output_info.output_file_map
 
@@ -2202,6 +2266,7 @@ def _declare_compile_outputs(
         indexstore_directory = None
 
     compile_outputs = struct(
+        ast_files = ast_files,
         generated_header_file = generated_header,
         generated_module_map_file = generated_module_map,
         indexstore_directory = indexstore_directory,
@@ -2258,6 +2323,8 @@ def _declare_multiple_outputs_and_write_output_file_map(
     # action outputs although they are not processed further.
     other_outputs = []
 
+    ast_files = []
+
     for src in srcs:
         src_output_map = {}
 
@@ -2269,6 +2336,14 @@ def _declare_multiple_outputs_and_write_output_file_map(
         )
         output_objs.append(obj)
         src_output_map["object"] = obj.path
+
+        ast = derived_files.ast(
+            actions = actions,
+            target_name = target_name,
+            src = src,
+        )
+        ast_files.append(ast)
+        src_output_map["ast-dump"] = ast.path
 
         # Multi-threaded WMO compiles still produce a single .swiftmodule file,
         # despite producing multiple object files, so we have to check
@@ -2291,6 +2366,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
 
     return struct(
         object_files = output_objs,
+        ast_files = ast_files,
         other_outputs = other_outputs,
         output_file_map = output_map_file,
     )
@@ -2586,6 +2662,11 @@ def output_groups_from_compilation_outputs(compilation_outputs):
         output_groups["swiftmodule"] = depset([
             compilation_outputs.swiftmodule,
         ])
+
+    if compilation_outputs.ast_files:
+        output_groups["swift_ast_file"] = depset(
+            compilation_outputs.ast_files,
+        )
 
     return output_groups
 

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -17,6 +17,22 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "owner_relative_path")
 
+def _ast(actions, target_name, src):
+    """Declares a file for an ast file during compilation.
+
+    Args:
+        actions: The context's actions object.
+        target_name: The name of the target being built.
+        src: A `File` representing the source file being compiled.
+
+    Returns:
+        The declared `File` where the given src's AST will be dumped to.
+    """
+    dirname, basename = _intermediate_frontend_file_path(target_name, src)
+    return actions.declare_file(
+        paths.join(dirname, "{}.ast".format(basename)),
+    )
+
 def _autolink_flags(actions, target_name):
     """Declares the response file into which autolink flags will be extracted.
 
@@ -295,6 +311,7 @@ def _xctest_runner_script(actions, target_name):
     return actions.declare_file("{}.test-runner.sh".format(target_name))
 
 derived_files = struct(
+    ast = _ast,
     autolink_flags = _autolink_flags,
     executable = _executable,
     indexstore_directory = _indexstore_directory,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -89,6 +89,7 @@ def _all_tool_configs(
             worker_mode = "wrap",
             additional_tools = additional_tools,
         ),
+        swift_action_names.DUMP_AST: compile_tool_config,
     }
 
 def _all_action_configs(additional_swiftc_copts):

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -364,6 +364,7 @@ def _all_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
             ],
             configurators = [
                 swift_toolchain_config.add_arg("-target", target_triple),
@@ -399,6 +400,7 @@ def _all_action_configs(
                     swift_action_names.COMPILE,
                     swift_action_names.DERIVE_FILES,
                     swift_action_names.PRECOMPILE_C_MODULE,
+                    swift_action_names.DUMP_AST,
                 ],
                 configurators = [
                     swift_toolchain_config.add_arg(
@@ -479,6 +481,7 @@ def _all_action_configs(
                     swift_action_names.COMPILE,
                     swift_action_names.DERIVE_FILES,
                     swift_action_names.PRECOMPILE_C_MODULE,
+                    swift_action_names.DUMP_AST,
                 ],
                 configurators = [
                     partial.make(
@@ -548,6 +551,7 @@ def _all_tool_configs(
     tool_configs = {
         swift_action_names.COMPILE: tool_config,
         swift_action_names.DERIVE_FILES: tool_config,
+        swift_action_names.DUMP_AST: tool_config,
     }
 
     # Xcode 12.0 implies Swift 5.3.

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load(":debug_settings_tests.bzl", "debug_settings_test_suite")
+load(":ast_file_tests.bzl", "ast_file_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
+load(":debug_settings_tests.bzl", "debug_settings_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
 load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
@@ -9,9 +10,11 @@ load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
 
 licenses(["notice"])
 
-debug_settings_test_suite()
+ast_file_test_suite()
 
 coverage_settings_test_suite()
+
+debug_settings_test_suite()
 
 generated_header_test_suite()
 

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -1,0 +1,92 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `ast_file`."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:analysis_failure_test.bzl",
+    "analysis_failure_test",
+)
+load(
+    "@build_bazel_rules_swift//test/rules:provider_test.bzl",
+    "provider_test",
+)
+
+def ast_file_test_suite(name = "ast_file"):
+    """Test suite for `swift_library` dumping ast files.
+
+    Args:
+        name: The name prefix for all the nested tests
+    """
+
+    provider_test(
+        name = "{}_with_no_deps".format(name),
+        expected_files = [
+            "test/fixtures/swift_through_non_swift/lower_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
+    )
+
+    provider_test(
+        name = "{}_with_deps".format(name),
+        expected_files = [
+            "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
+    )
+
+    provider_test(
+        name = "{}_with_private_swift_deps".format(name),
+        expected_files = [
+            "test/fixtures/private_deps/client_swift_deps_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
+    )
+
+    provider_test(
+        name = "{}_with_private_cc_deps".format(name),
+        expected_files = [
+            "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    provider_test(
+        name = "{}_with_multiple_swift_files".format(name),
+        expected_files = [
+            "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
+            "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/multiple_files",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -15,10 +15,6 @@
 """Tests for `ast_file`."""
 
 load(
-    "@build_bazel_rules_swift//test/rules:analysis_failure_test.bzl",
-    "analysis_failure_test",
-)
-load(
     "@build_bazel_rules_swift//test/rules:provider_test.bzl",
     "provider_test",
 )

--- a/test/fixtures/multiple_files/BUILD
+++ b/test/fixtures/multiple_files/BUILD
@@ -1,0 +1,18 @@
+load("//swift:swift.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+swift_library(
+    name = "multiple_files",
+    srcs = [
+        "Empty.swift",
+        "Empty2.swift",
+    ],
+    generates_header = False,
+    tags = FIXTURE_TAGS,
+)

--- a/test/fixtures/multiple_files/Empty.swift
+++ b/test/fixtures/multiple_files/Empty.swift
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/fixtures/multiple_files/Empty2.swift
+++ b/test/fixtures/multiple_files/Empty2.swift
@@ -1,0 +1,1 @@
+// Intentionally empty.

--- a/test/rules/provider_test.bzl
+++ b/test/rules/provider_test.bzl
@@ -150,6 +150,8 @@ def _lookup_provider_by_name(env, target, provider_name):
         provider = CcInfo
     elif provider_name == "DefaultInfo":
         provider = DefaultInfo
+    elif provider_name == "OutputGroupInfo":
+        provider = OutputGroupInfo
     elif provider_name == "SwiftInfo":
         provider = SwiftInfo
     elif provider_name == "apple_common.Objc":
@@ -411,6 +413,7 @@ Currently, only the following providers are recognized:
 
 *   `CcInfo`
 *   `DefaultInfo`
+*   `OutputGroupInfo`
 *   `SwiftInfo`
 *   `apple_common.Objc`
 """,

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -108,6 +108,7 @@ SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
 
 int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
   int exit_code = RunSubProcess(args_, stderr_stream, stdout_to_stderr);
+
   if (exit_code != 0) {
     return exit_code;
   }

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -22,6 +22,11 @@
 #include "tools/common/temp_file.h"
 #include "tools/worker/output_file_map.h"
 
+bool ArgumentEnablesWMO(const std::string &arg) {
+  return arg == "-wmo" || arg == "-whole-module-optimization" ||
+         arg == "-force-single-frontend-invocation";
+}
+
 namespace {
 
 // Creates a temporary file and writes the given arguments to it, one per line.
@@ -319,14 +324,18 @@ bool SwiftRunner::ProcessArgument(
         ++itr;
         new_arg = output_file_map_path_;
         changed = true;
+      } else if (is_dump_ast_ && ArgumentEnablesWMO(arg)) {
+        // WMO is invalid for -dump-ast,
+        // so omit the argument that enables WMO
+        changed = true;
       }
 
       // Apply any other text substitutions needed in the argument (i.e., for
       // Apple toolchains).
       //
-      // Bazel doesn't quote arguments in multi-line params files, so we need to
-      // ensure that our defensive quoting kicks in if an argument contains a
-      // space, even if no other changes would have been made.
+      // Bazel doesn't quote arguments in multi-line params files, so we need
+      // to ensure that our defensive quoting kicks in if an argument contains
+      // a space, even if no other changes would have been made.
       changed = bazel_placeholder_substitutions_.Apply(new_arg) ||
                 new_arg.find_first_of(' ') != std::string::npos;
       consumer(new_arg);
@@ -360,6 +369,8 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
         arg = *it;
         index_store_path_ = arg;
         out_args.push_back(arg);
+      } else if (arg == "-dump-ast") {
+        is_dump_ast_ = true;
       }
     }
   }

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -25,6 +25,10 @@
 #include "tools/common/bazel_substitutions.h"
 #include "tools/common/temp_file.h"
 
+// Returns true if the given command line argument enables whole-module
+// optimization in the compiler.
+extern bool ArgumentEnablesWMO(const std::string &arg);
+
 // Handles spawning the Swift compiler driver, making any required substitutions
 // of the command line arguments (for example, Bazel's magic Xcode placeholder
 // strings).
@@ -130,6 +134,10 @@ class SwiftRunner {
   // Arguments will be unconditionally written into a response file and passed
   // to the tool that way.
   bool force_response_file_;
+
+  // Whether the invocation is being used to dump ast files.
+  // This is used to avoid implicitly adding incompatible flags.
+  bool is_dump_ast_;
 
   // The path to the generated header rewriter tool, if one is being used for
   // this compilation.

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -31,13 +31,6 @@
 
 namespace {
 
-// Returns true if the given command line argument enables whole-module
-// optimization in the compiler.
-static bool ArgumentEnablesWMO(const std::string &arg) {
-  return arg == "-wmo" || arg == "-whole-module-optimization" ||
-         arg == "-force-single-frontend-invocation";
-}
-
 static void FinalizeWorkRequest(const blaze::worker::WorkRequest &request,
                                 blaze::worker::WorkResponse *response,
                                 int exit_code,
@@ -85,12 +78,7 @@ void WorkProcessor::ProcessWorkRequest(
       output_file_map_path = arg;
       arg.clear();
     } else if (ArgumentEnablesWMO(arg)) {
-      if (is_dump_ast) {
-        // WMO compilation doesn't work with -dump-ast
-        arg.clear();
-      } else {
-        is_wmo = true;
-      }
+      is_wmo = true;
     }
 
     if (!arg.empty()) {
@@ -100,8 +88,10 @@ void WorkProcessor::ProcessWorkRequest(
     prev_arg = original_arg;
   }
 
+  bool is_incremental = !is_wmo && !is_dump_ast;
+
   if (!output_file_map_path.empty()) {
-    if (!is_wmo && !is_dump_ast) {
+    if (is_incremental) {
       output_file_map.ReadFromPath(output_file_map_path);
 
       // Rewrite the output file map to use the incremental storage area and
@@ -118,8 +108,8 @@ void WorkProcessor::ProcessWorkRequest(
       // there's no reason to pass it when it's a no-op.
       params_file_stream << "-incremental\n";
     } else {
-      // If WMO is forcing us out of incremental mode, just put the original
-      // output file map back so the outputs end up where they should.
+      // If WMO or -dump-ast is forcing us out of incremental mode, just put the
+      // original output file map back so the outputs end up where they should.
       params_file_stream << "-output-file-map\n";
       params_file_stream << output_file_map_path << '\n';
     }
@@ -130,7 +120,7 @@ void WorkProcessor::ProcessWorkRequest(
 
   std::ostringstream stderr_stream;
 
-  if (!is_wmo) {
+  if (is_incremental) {
     for (const auto &expected_object_pair :
          output_file_map.incremental_outputs()) {
       // Bazel creates the intermediate directories for the files declared at
@@ -166,7 +156,7 @@ void WorkProcessor::ProcessWorkRequest(
   SwiftRunner swift_runner(processed_args, /*force_response_file=*/true);
   int exit_code = swift_runner.Run(&stderr_stream, /*stdout_to_stderr=*/true);
 
-  if (!is_wmo) {
+  if (is_incremental) {
     // Copy the output files from the incremental storage area back to the
     // locations where Bazel declared the files.
     for (const auto &expected_object_pair :

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -70,6 +70,7 @@ void WorkProcessor::ProcessWorkRequest(
   OutputFileMap output_file_map;
   std::string output_file_map_path;
   bool is_wmo = false;
+  bool is_dump_ast = false;
 
   std::string prev_arg;
   for (auto arg : request.arguments()) {
@@ -78,11 +79,18 @@ void WorkProcessor::ProcessWorkRequest(
     // necessary later.
     if (arg == "-output-file-map") {
       arg.clear();
+    } else if (arg == "-dump-ast") {
+      is_dump_ast = true;
     } else if (prev_arg == "-output-file-map") {
       output_file_map_path = arg;
       arg.clear();
     } else if (ArgumentEnablesWMO(arg)) {
-      is_wmo = true;
+      if (is_dump_ast) {
+        // WMO compilation doesn't work with -dump-ast
+        arg.clear();
+      } else {
+        is_wmo = true;
+      }
     }
 
     if (!arg.empty()) {
@@ -93,7 +101,7 @@ void WorkProcessor::ProcessWorkRequest(
   }
 
   if (!output_file_map_path.empty()) {
-    if (!is_wmo) {
+    if (!is_wmo && !is_dump_ast) {
       output_file_map.ReadFromPath(output_file_map_path);
 
       // Rewrite the output file map to use the incremental storage area and


### PR DESCRIPTION
Some tooling (namely https://github.com/square/Cleanse/tree/master/cleansec) operates over dumped swift AST files.
In order to dump AST files, (almost) complete `swiftc` invocations are required, in addition to the `-dump-ast` flag.
Because almost the same set of arguments as module compilation are used for dumping the AST, it is nearly impossible for a bazel user to reconstruct them by hand (or via a standalone rule).

This new output group (and action) serves to dump AST files for each swift source file in a `swift_library` swift module.