### PR TITLE
Include the headers from direct dependencies of a Swift target when compiling the explicit module for its generated header.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -70,6 +70,7 @@ load(
     ":utils.bzl",
     "collect_cc_libraries",
     "compact",
+    "compilation_context_for_explicit_module_compilation",
     "get_providers",
     "struct_fields",
 )
@@ -1776,12 +1777,18 @@ def compile(
         feature_configuration = feature_configuration,
         feature_name = SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
     ):
+        compilation_context_to_compile = (
+            compilation_context_for_explicit_module_compilation(
+                compilation_contexts = [cc_common.create_compilation_context(
+                    headers = depset([compile_outputs.generated_header_file]),
+                )],
+                deps = deps,
+            )
+        )
         precompiled_module = precompile_clang_module(
             actions = actions,
             bin_dir = bin_dir,
-            cc_compilation_context = cc_common.create_compilation_context(
-                headers = depset([compile_outputs.generated_header_file]),
-            ),
+            cc_compilation_context = compilation_context_to_compile,
             feature_configuration = feature_configuration,
             genfiles_dir = genfiles_dir,
             module_map_file = compile_outputs.generated_module_map_file,


### PR DESCRIPTION
PiperOrigin-RevId: 372240650
(cherry picked from commit cc15b6eb5fb7bcd129eaa4960ff60e5c44d9a7eb)