### PR TITLE
Use `-fsystem-module` if the compiler is new enough to support it (Xcode 12.5/Swift 5.4 or higher).

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -55,6 +55,7 @@ load(
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
+    "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
@@ -603,13 +604,14 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [swift_action_names.PRECOMPILE_C_MODULE],
             configurators = [
-                # TODO(b/165649949): ClangImporter doesn't currently handle the
-                # IsSystem bit correctly for the input file, which causes the
-                # module map to be treated as a user input. To work around this
-                # for now, we disable all diagnostics when compiling the
-                # explicit module for system modules, since they're not useful
-                # anyway; this is "close enough" to compiling it as a system
-                # module for the purposes of avoiding noise in the build logs.
+                # Before Swift 5.4, ClangImporter doesn't currently handle the
+                # IsSystem bit correctly for the input file and ignores the
+                # `-fsystem-module` flag, which causes the module map to be
+                # treated as a user input. We can work around this by disabling
+                # diagnostics for system modules. However, this also disables
+                # behavior in ClangImporter that causes system APIs that use
+                # `UInt` to be imported to use `Int` instead. The only solution
+                # here is to use Xcode 12.5 or higher.
                 swift_toolchain_config.add_arg("-Xcc", "-w"),
                 swift_toolchain_config.add_arg(
                     "-Xcc",
@@ -617,6 +619,18 @@ def compile_action_configs(
                 ),
             ],
             features = [SWIFT_FEATURE_SYSTEM_MODULE],
+            not_features = [SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.PRECOMPILE_C_MODULE],
+            configurators = [
+                swift_toolchain_config.add_arg("-Xcc", "-Xclang"),
+                swift_toolchain_config.add_arg("-Xcc", "-fsystem-module"),
+            ],
+            features = [
+                SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG,
+                SWIFT_FEATURE_SYSTEM_MODULE,
+            ],
         ),
     ]
 

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -71,6 +71,14 @@ SWIFT_FEATURE_LAYERING_CHECK = "swift.layering_check"
 # If enabled, the C or Objective-C target should be compiled as a system module.
 SWIFT_FEATURE_SYSTEM_MODULE = "swift.system_module"
 
+# If enabled, the `-Xcc -fsystem-module` flag will be passed when compiling a
+# system C/Objective-C module (with feature `swift.system_module`) because the
+# compiler is new enough to honor it correctly. If disabled, we attempt to mimic
+# this by disabling certain warnings; however, this unfortunately causes `UInt`
+# APIs to be imported by ClangImporter as `UInt` instead of `Int` because
+# ClangImporter doesn't recognize them as true system modules.
+SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG = "swift.supports_system_module_flag"
+
 # If enabled, Swift compilation actions will use batch mode by passing
 # `-enable-batch-mode` to `swiftc`. This is a new compilation mode as of
 # Swift 4.2 that is intended to speed up non-incremental non-WMO builds by

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -41,6 +41,7 @@ load(
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
+    "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
 )
 load(":features.bzl", "features_for_build_modes")
@@ -731,6 +732,10 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 11.4 implies Swift 5.2.
     if _is_xcode_at_least_version(xcode_config, "11.4"):
         requested_features.append(SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES)
+
+    # Xcode 12.5 implies Swift 5.4.
+    if _is_xcode_at_least_version(xcode_config, "12.5"):
+        requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
 
     env = _xcode_env(platform = platform, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()


### PR DESCRIPTION
PiperOrigin-RevId: 373046121
(cherry picked from commit 4cd9b2c01e5e71ba20e78b61e28e396d83de5840)