### PR TITLE
Reuse swiftmodule for incremental builds

### DIFF
--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -43,7 +43,13 @@ bool FileExists(const std::string &path) {
 }
 
 bool RemoveFile(const std::string &path) {
+#ifdef __APPLE__
   return removefile(path.c_str(), nullptr, 0);
+#elif __unix__
+  return remove(path.c_str());
+#else
+#error Only macOS and Unix are supported at this time.
+#endif
 }
 
 bool CopyFile(const std::string &src, const std::string &dest) {

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -22,6 +22,7 @@
 
 #ifdef __APPLE__
 #include <copyfile.h>
+#include <removefile.h>
 #else
 #include <fcntl.h>
 #include <sys/sendfile.h>
@@ -35,6 +36,14 @@ std::string GetCurrentDirectory() {
   std::string cwd(buffer);
   free(buffer);
   return cwd;
+}
+
+bool FileExists(const std::string &path) {
+  return access(path.c_str(), 0) == 0;
+}
+
+bool RemoveFile(const std::string &path) {
+  return removefile(path.c_str(), nullptr, 0);
 }
 
 bool CopyFile(const std::string &src, const std::string &dest) {

--- a/tools/common/file_system.h
+++ b/tools/common/file_system.h
@@ -20,6 +20,12 @@
 // Gets the path to the current working directory.
 std::string GetCurrentDirectory();
 
+// Returns true if something exists at path.
+bool FileExists(const std::string &path);
+
+// Removes the file at path. Returns true if successful.
+bool RemoveFile(const std::string &path);
+
 // Copies the file at src to dest. Returns true if successful.
 bool CopyFile(const std::string &src, const std::string &dest);
 

--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -57,6 +57,7 @@ void OutputFileMap::WriteToPath(const std::string &path) {
 void OutputFileMap::UpdateForIncremental(const std::string &path) {
   nlohmann::json new_output_file_map;
   std::map<std::string, std::string> incremental_outputs;
+  std::map<std::string, std::string> incremental_inputs;
 
   // The empty string key is used to represent outputs that are for the whole
   // module, rather than for a particular source file.
@@ -111,6 +112,15 @@ void OutputFileMap::UpdateForIncremental(const std::string &path) {
     new_output_file_map[src] = src_map;
   }
 
+  auto swiftmodule_path = ReplaceExtension(path, ".swiftmodule", /*all_extensions=*/true);
+  auto copied_swiftmodule_path = MakeIncrementalOutputPath(swiftmodule_path);
+  incremental_inputs[swiftmodule_path] = copied_swiftmodule_path;
+
+  auto swiftdoc_path = ReplaceExtension(path, ".swiftdoc", /*all_extensions=*/true);
+  auto copied_swiftdoc_path = MakeIncrementalOutputPath(swiftdoc_path);
+  incremental_inputs[swiftdoc_path] = copied_swiftdoc_path;
+
   json_ = new_output_file_map;
   incremental_outputs_ = incremental_outputs;
+  incremental_inputs_ = incremental_inputs;
 }

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -39,6 +39,14 @@ class OutputFileMap {
     return incremental_outputs_;
   }
 
+  // A map containing expected output files that will be generated in the
+  // non-incremental storage area, but need to be copied back at the start of
+  // the next compile. The key is the original object path; the corresponding
+  // value is its location in the incremental storage area.
+  const std::map<std::string, std::string> incremental_inputs() const {
+    return incremental_inputs_;
+  }
+
   // Reads the output file map from the JSON file at the given path, and updates
   // it to support incremental builds.
   void ReadFromPath(const std::string &path);
@@ -53,6 +61,7 @@ class OutputFileMap {
 
   nlohmann::json json_;
   std::map<std::string, std::string> incremental_outputs_;
+  std::map<std::string, std::string> incremental_inputs_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_OUTPUT_FILE_MAP_H_


### PR DESCRIPTION
By doing this, for some parts of the build graph, the swiftmodule doesn't have to be recreated. Here is an example with Swift 5.5:

Before:
```console
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Not skipping job: Merging module A; Missing output 'bazel-out/darwin-fastbuild/bin/A.swiftmodule'
remark: Starting Merging module A
remark: Finished Merging module A
remark: Skipped Compiling A.swift
```

After:
```console
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping job: Merging module A; oldest output is current 'bazel-out/darwin-fastbuild/bin/A.swiftmodule'
remark: Skipped Compiling A.swift
```

I'm seeing about a 20% overall speed up on some incremental builds with this change, and around 40% speed up on modules that have no effective change.

Shout out to Cody Vandermyn (@codeman9) for his initial investigation and PoC on this.
