### PR TITLE
Add returns

### DIFF
--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -132,6 +132,7 @@ void WorkProcessor::ProcessWorkRequest(
         stderr_stream << "swift_worker: Could not create directory " << dir_path
                       << " (errno " << errno << ")\n";
         FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
+        return;
       }
     }
 
@@ -147,6 +148,7 @@ void WorkProcessor::ProcessWorkRequest(
                         << expected_object_pair.first << " (errno " << errno
                         << ")\n";
           FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
+          return;
         }
       }
     }
@@ -166,6 +168,7 @@ void WorkProcessor::ProcessWorkRequest(
                       << expected_object_pair.first << " (errno " << errno
                       << ")\n";
         FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
+        return;
       }
     }
 
@@ -185,6 +188,7 @@ void WorkProcessor::ProcessWorkRequest(
                         << expected_object_pair.second << " (errno " << errno
                         << ")\n";
           FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
+          return;
         }
       }
     }

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -129,10 +129,8 @@ void WorkProcessor::ProcessWorkRequest(
       // incremental storage area.
       auto dir_path = Dirname(expected_object_pair.second);
       if (!MakeDirs(dir_path, S_IRWXU)) {
-        stderr_stream << "swift_worker: Could not create directory " << dir_path
-                      << " (errno " << errno << ")\n";
-        FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
-        return;
+        std::cerr << "Could not create directory " << dir_path << " (errno "
+                  << errno << ")\n";
       }
     }
 


### PR DESCRIPTION
Missed with 84286ada38264db60fdfc907bb72863471de6fd7.

Also reverts the hard error on not creating directories. It could try to create the same directory multiple times, and the previous behavior silently errored on those. This can get fixed up in a later change to only try to create each directory once, and to only error if the directory doesn't already exist.
