### PR TITLE
Remove the `-rpath` for the Xcode's developer frameworks directory fr…

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -264,15 +264,10 @@ def _default_linker_opts(
     if use_system_swift_libs:
         linkopts.append("-L/usr/lib/swift")
 
-    # Frameworks in the platform's developer frameworks directory (like XCTest,
-    # but also StoreKitTest on macOS) contain the actual binary for that
-    # framework, not a .tbd file that says where to find it on simulator/device.
-    # So, we need to explicitly add that to test binaries' rpaths. We also need
-    # to add the linker path to the directory containing the dylib with Swift
+    # Add the linker path to the directory containing the dylib with Swift
     # extensions for the XCTest module.
     if is_test and platform_developer_framework_dir:
         linkopts.extend([
-            "-Wl,-rpath,{}".format(platform_developer_framework_dir),
             "-L{}".format(
                 _swift_developer_lib_dir(platform_developer_framework_dir),
             ),


### PR DESCRIPTION
…om the Swift toolchain.

It may have been needed in the past with older versions of Swift, but it doesn't appear to be anymore (and it causes problems if the version targeted during the build is mismatched with the simulator/OS version under which the test is running).

PiperOrigin-RevId: 378400910
(cherry picked from commit 92b727ede6af6a09ec4977c4ea5257c3357a5986)