### PR TITLE
Feature flag to set num-threads to host threads

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -60,6 +60,7 @@ load(
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
+    "SWIFT_FEATURE_USE_HOST_NUM_THREADS",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
@@ -772,6 +773,16 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
             ],
+            configurators = [_wmo_host_thread_count_configurator],
+            features = [
+                [SWIFT_FEATURE_USE_HOST_NUM_THREADS, SWIFT_FEATURE__WMO_IN_SWIFTCOPTS],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
             configurators = [
                 partial.make(
                     _wmo_thread_count_configurator,
@@ -1384,6 +1395,11 @@ def _wmo_thread_count_configurator(should_check_flags, prerequisites, args):
     ):
         # Force threaded mode for WMO builds.
         args.add("-num-threads", str(_DEFAULT_WMO_THREAD_COUNT))
+
+def _wmo_host_thread_count_configurator(prerequisites, args):
+    """Sets num-threads to number of threads on the host.
+    """
+    args.add("-Xwrapped-swift=-use-host-num-threads")
 
 def _is_wmo_manually_requested(user_compile_flags):
     """Returns `True` if a WMO flag is in the given list of compiler flags.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -266,3 +266,6 @@ SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
 # were passed on the command line using `--swiftcopt`. Users should never
 # manually enable, disable, or query this feature.
 SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts"
+
+# If enabled, it passes the number of threads that the host has
+SWIFT_FEATURE_USE_HOST_NUM_THREADS = "swift.use_host_num_threads"

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -146,6 +146,9 @@ class SwiftRunner {
   // `-index-store-path`. After running `swiftc` `index-import` copies relevant
   // index outputs into the `index_store_path` to integrate outputs with Bazel.
   std::string global_index_store_import_path_;
+
+  // If the worker should set num-threads to number of threads on the host.
+  bool use_host_num_threads_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_


### PR DESCRIPTION
Currently, num-threads is hardcoded to 12. This PR sets the value to the
number of cores return by sysctl, or "host threads". This may improve
vertical scaling in some situations for larger core machines.