### PR TITLE
Fix race condition in MakeDirs

### DIFF
--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <string>
+#include <string.h>
 
 #ifdef __APPLE__
 #include <copyfile.h>

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -125,7 +125,7 @@ bool MakeDirs(const std::string &path, int mode) {
 
   // Deal with a race condition when 2 `MakeDirs` are running at the same time:
   // one `mkdir` invocation will fail in each recursive call at different
-  // points. Don't recurse here to avoid an infinite loop in failure cases
+  // points. Don't recurse here to avoid an infinite loop in failure cases.
   if (errno == EEXIST && stat(path.c_str(), &dir_stats) == 0) {
     if (!S_ISDIR(dir_stats.st_mode)) {
       std::cerr << "error: path exists and isn't a directory "

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -121,7 +121,7 @@ bool MakeDirs(const std::string &path, int mode) {
     return true;
   }
 
-  // Save the mkdir errno for better reporting
+  // Save the mkdir errno for better reporting.
   int mkdir_errno = errno;
 
   // Deal with a race condition when 2 `MakeDirs` are running at the same time:


### PR DESCRIPTION
If there are 2 concurrent processes creating the same directories, the existing code fails. I suspect this is "transient" errors we saw in #  567's final CI run, but this is unrelated to the PR. 

I suspect invalidating the worker or other updates triggered big rebuilds. Myself and a co-worker hit this today when we bumped rules_swift. 

This manifests in many ways when using anything that needs a directory e.g.
```
<unknown>:0: error: error opening 'bazel-out/macos-x86_64-applebin_macos-darwin_x86_64-dbg-ST-15eaacdcbb7d/bin/_swift_incremental/tests/macos/xcconfig/array_key_xcconfig_swift_objs/empty.swift.swiftdeps' for output: No such file or directory
```

Note: I don't have a perfect repro - at a 10% rate: invoking Bazel to build 2 swift libraries in the same BUILD file seemed to do the trick.