### PR TITLE
Delete the `swift_common.swift_runtime_linkopts` function.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -502,36 +502,6 @@ A `File` representing the precompiled module (`.pcm`) file, or `None` if
   the toolchain or target does not support precompiled modules.
 
 
-<a id="#swift_common.swift_runtime_linkopts"></a>
-
-## swift_common.swift_runtime_linkopts
-
-<pre>
-swift_common.swift_runtime_linkopts(<a href="#swift_common.swift_runtime_linkopts-is_static">is_static</a>, <a href="#swift_common.swift_runtime_linkopts-toolchain">toolchain</a>, <a href="#swift_common.swift_runtime_linkopts-is_test">is_test</a>)
-</pre>
-
-Returns the flags that should be passed when linking a Swift binary.
-
-This function provides the appropriate linker arguments to callers who need
-to link a binary using something other than `swift_binary` (for example, an
-application bundle containing a universal `apple_binary`).
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="swift_common.swift_runtime_linkopts-is_static"></a>is_static |  A <code>Boolean</code> value indicating whether the binary should be linked against the static (rather than the dynamic) Swift runtime libraries.   |  none |
-| <a id="swift_common.swift_runtime_linkopts-toolchain"></a>toolchain |  The <code>SwiftToolchainInfo</code> provider of the toolchain whose linker options are desired.   |  none |
-| <a id="swift_common.swift_runtime_linkopts-is_test"></a>is_test |  A <code>Boolean</code> value indicating whether the target being linked is a test target.   |  <code>False</code> |
-
-**RETURNS**
-
-A `list` of command line flags that should be passed when linking a
-  binary against the Swift runtime libraries.
-
-
 <a id="#swift_common.toolchain_attrs"></a>
 
 ## swift_common.toolchain_attrs

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -15,7 +15,6 @@
 """Implementation of linking logic for Swift."""
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load(
     "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     "CPP_LINK_STATIC_LIBRARY_ACTION_NAME",
@@ -286,30 +285,4 @@ def register_link_binary_action(
         link_deps_statically = True,
         output_type = output_type,
         stamp = stamp,
-    )
-
-def swift_runtime_linkopts(is_static, toolchain, is_test = False):
-    """Returns the flags that should be passed when linking a Swift binary.
-
-    This function provides the appropriate linker arguments to callers who need
-    to link a binary using something other than `swift_binary` (for example, an
-    application bundle containing a universal `apple_binary`).
-
-    Args:
-        is_static: A `Boolean` value indicating whether the binary should be
-            linked against the static (rather than the dynamic) Swift runtime
-            libraries.
-        toolchain: The `SwiftToolchainInfo` provider of the toolchain whose
-            linker options are desired.
-        is_test: A `Boolean` value indicating whether the target being linked is
-            a test target.
-
-    Returns:
-        A `list` of command line flags that should be passed when linking a
-        binary against the Swift runtime libraries.
-    """
-    return partial.call(
-        toolchain.linker_opts_producer,
-        is_static = is_static,
-        is_test = is_test,
     )

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -41,7 +41,6 @@ load(
     "get_cc_feature_configuration",
     "is_feature_enabled",
 )
-load(":linking.bzl", "swift_runtime_linkopts")
 load(
     ":providers.bzl",
     "create_clang_module",
@@ -67,6 +66,5 @@ swift_common = struct(
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
     precompile_clang_module = precompile_clang_module,
-    swift_runtime_linkopts = swift_runtime_linkopts,
     toolchain_attrs = swift_toolchain_attrs,
 )


### PR DESCRIPTION
This should have been deleted in the previous change that refactored the linker flags. It no longer works because it tries to access a provide field that no longer exists, but nothing broke because nothing calls it anymore. Yay weak typing.

PiperOrigin-RevId: 378673728
(cherry picked from commit 503c9cc8c116599c217ba0c6743998fbfa865f4b)