### PR TITLE
Refer to build_bazel_rules_swift_index_import via a file rather than …

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -114,16 +114,7 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "build_bazel_rules_swift_index_import",
-        build_file_content = """\
-load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
-
-native_binary(
-    name = "index_import",
-    src = "index-import",
-    out = "index-import",
-    visibility = ["//visibility:public"],
-)
-""",
+        build_file = "@build_bazel_rules_swift//third_party/build_bazel_rules_swift_index_import/BUILD.overlay",
         canonical_id = "index-import-5.3.2.6",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.3.2.6/index-import.zip"],
         sha256 = "61a58363f56c5fd84d4ebebe0d9b5dd90c74ae170405a7b9018e8cf698e679de",

--- a/third_party/build_bazel_rules_swift_index_import/BUILD.overlay
+++ b/third_party/build_bazel_rules_swift_index_import/BUILD.overlay
@@ -1,0 +1,9 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+native_binary(
+    name = "index_import",
+    src = "index-import",
+    out = "index-import",
+)


### PR DESCRIPTION
…inline string

For consistency with other repos that do not define their own build files