### PR TITLE
Add files in third_party to :for_bazel_tests

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@ filegroup(
     srcs = [
         "WORKSPACE",
         "//swift:for_bazel_tests",
+        "//third_party:for_bazel_tests",
         "//tools:for_bazel_tests",
     ],
 )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,0 +1,11 @@
+# Consumed by Bazel integration tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]) + [
+        "//third_party/bazel_protos:for_bazel_tests",
+    ],
+    visibility = [
+        "//:__pkg__",
+    ],
+)

--- a/third_party/bazel_protos/BUILD
+++ b/third_party/bazel_protos/BUILD
@@ -13,3 +13,13 @@ cc_proto_library(
     visibility = ["//tools/worker:__pkg__"],
     deps = [":worker_protocol_proto"],
 )
+
+# Consumed by Bazel integration tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = [
+        "//third_party:__pkg__",
+    ],
+)


### PR DESCRIPTION
So they are copied over in integration tests in rules_apple

Though I'm not sure how we've gotten away without this until now?