### PR TITLE
Run clang-format over all cpp files in the repo

### DIFF
--- a/tools/common/bazel_substitutions.cc
+++ b/tools/common/bazel_substitutions.cc
@@ -24,8 +24,7 @@ namespace {
 
 // The placeholder string used by Bazel that should be replaced by
 // `DEVELOPER_DIR` at runtime.
-static const char kBazelXcodeDeveloperDir[] =
-    "__BAZEL_XCODE_DEVELOPER_DIR__";
+static const char kBazelXcodeDeveloperDir[] = "__BAZEL_XCODE_DEVELOPER_DIR__";
 
 // The placeholder string used by Bazel that should be replaced by `SDKROOT`
 // at runtime.
@@ -62,8 +61,7 @@ BazelPlaceholderSubstitutions::BazelPlaceholderSubstitutions(
   placeholder_resolvers_ = {
       {kBazelXcodeDeveloperDir,
        PlaceholderResolver([=]() { return developer_dir; })},
-      {kBazelXcodeSdkRoot,
-       PlaceholderResolver([=]() { return sdk_root; })},
+      {kBazelXcodeSdkRoot, PlaceholderResolver([=]() { return sdk_root; })},
   };
 }
 
@@ -71,7 +69,7 @@ bool BazelPlaceholderSubstitutions::Apply(std::string &arg) {
   bool changed = false;
 
   // Replace placeholders in the string with their actual values.
-  for (auto& pair : placeholder_resolvers_) {
+  for (auto &pair : placeholder_resolvers_) {
     changed |= FindAndReplace(pair.first, pair.second, arg);
   }
 

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -14,13 +14,13 @@
 
 #include "tools/common/file_system.h"
 
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <iostream>
 #include <string>
-#include <string.h>
 
 #ifdef __APPLE__
 #include <copyfile.h>

--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -112,11 +112,13 @@ void OutputFileMap::UpdateForIncremental(const std::string &path) {
     new_output_file_map[src] = src_map;
   }
 
-  auto swiftmodule_path = ReplaceExtension(path, ".swiftmodule", /*all_extensions=*/true);
+  auto swiftmodule_path =
+      ReplaceExtension(path, ".swiftmodule", /*all_extensions=*/true);
   auto copied_swiftmodule_path = MakeIncrementalOutputPath(swiftmodule_path);
   incremental_inputs[swiftmodule_path] = copied_swiftmodule_path;
 
-  auto swiftdoc_path = ReplaceExtension(path, ".swiftdoc", /*all_extensions=*/true);
+  auto swiftdoc_path =
+      ReplaceExtension(path, ".swiftdoc", /*all_extensions=*/true);
   auto copied_swiftdoc_path = MakeIncrementalOutputPath(swiftdoc_path);
   incremental_inputs[swiftdoc_path] = copied_swiftdoc_path;
 

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -101,8 +101,8 @@ class SwiftRunner {
   bool ProcessArgument(Iterator &itr, const std::string &arg,
                        std::function<void(const std::string &)> consumer);
 
-  // Parses arguments to ivars and returns a vector of strings from the iterator.
-  // This method doesn't actually mutate any of the arguments.
+  // Parses arguments to ivars and returns a vector of strings from the
+  // iterator. This method doesn't actually mutate any of the arguments.
   template <typename Iterator>
   std::vector<std::string> ParseArguments(Iterator itr);
 

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "tools/worker/work_processor.h"
+
 #include <google/protobuf/text_format.h>
 #include <sys/stat.h>
 
@@ -26,7 +28,6 @@
 #include "tools/common/temp_file.h"
 #include "tools/worker/output_file_map.h"
 #include "tools/worker/swift_runner.h"
-#include "tools/worker/work_processor.h"
 
 namespace {
 


### PR DESCRIPTION
This way, incidental edits in these files in subsequent PRs won't cause diffs