### PR TITLE
Truly silence warnings about using -wmo with -dump-ast

### DIFF
--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -327,7 +327,7 @@ bool SwiftRunner::ProcessArgument(
       } else if (is_dump_ast_ && ArgumentEnablesWMO(arg)) {
         // WMO is invalid for -dump-ast,
         // so omit the argument that enables WMO
-        changed = true;
+        return true;  // return to avoid consuming the arg
       }
 
       // Apply any other text substitutions needed in the argument (i.e., for


### PR DESCRIPTION
We need an early return to completely avoid consuming the WMO-enabling arg