### PR TITLE
Fix breaking rpaths with swift_test on macOS

### DIFF
--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -255,6 +255,7 @@ def _create_xctest_bundle(name, actions, binary, xctest_bundle_creator):
             basename of the bundle (followed by the .xctest bundle extension).
         actions: The context's actions object.
         binary: The binary that will be copied into the test bundle.
+        xctest_bundle_creator: The script to create the test bundle.
 
     Returns:
         A `File` (tree artifact) representing the `.xctest` bundle.

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -247,7 +247,7 @@ def _swift_linking_rule_impl(
 
     return linking_outputs.executable, providers
 
-def _create_xctest_bundle(name, actions, binary):
+def _create_xctest_bundle(name, actions, binary, xctest_bundle_creator):
     """Creates an `.xctest` bundle that contains the given binary.
 
     Args:
@@ -268,12 +268,10 @@ def _create_xctest_bundle(name, actions, binary):
     args.add(xctest_bundle.path)
     args.add(binary)
 
-    actions.run_shell(
+    actions.run(
         arguments = [args],
-        command = (
-            'mkdir -p "$1/Contents/MacOS" && ' +
-            'cp "$2" "$1/Contents/MacOS"'
-        ),
+        executable = xctest_bundle_creator,
+        tools = [xctest_bundle_creator],
         inputs = [binary],
         mnemonic = "SwiftCreateTestBundle",
         outputs = [xctest_bundle],
@@ -372,6 +370,7 @@ def _swift_test_impl(ctx):
             name = ctx.label.name,
             actions = ctx.actions,
             binary = binary,
+            xctest_bundle_creator = ctx.executable._xctest_bundle_creator,
         )
         xctest_runner = _create_xctest_runner(
             name = ctx.label.name,
@@ -450,6 +449,13 @@ swift_test = rule(
                 default = Label(
                     "@build_bazel_rules_swift//tools/xctest_runner:xctest_runner_template",
                 ),
+            ),
+            "_xctest_bundle_creator": attr.label(
+                cfg = "host",
+                default = Label(
+                    "@build_bazel_rules_swift//tools/xctest_bundle_creator",
+                ),
+                executable = True,
             ),
         },
     ),

--- a/tools/xctest_bundle_creator/BUILD
+++ b/tools/xctest_bundle_creator/BUILD
@@ -1,0 +1,5 @@
+sh_binary(
+    name = "xctest_bundle_creator",
+    srcs = ["xctest_bundle_creator.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/xctest_bundle_creator/xctest_bundle_creator.sh
+++ b/tools/xctest_bundle_creator/xctest_bundle_creator.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly bundle_path="$1/Contents/MacOS"
+readonly binary=$2
+copied_binary="$bundle_path/$(basename "$binary")"
+
+mkdir -p "$bundle_path"
+cp -cL "$binary" "$copied_binary"
+
+rpaths=$(otool -l "$copied_binary" \
+  | grep -A2 LC_RPATH \
+  | grep "^\s*path" | cut -d " " -f 11)
+
+for rpath in $rpaths
+do
+  if [[ $rpath == @* ]]; then
+    prefix="${rpath%%/*}"
+    suffix="${rpath#*/}"
+    xcrun install_name_tool -rpath "$rpath" "$prefix/../../../$suffix" "$copied_binary"
+  fi
+done

--- a/tools/xctest_bundle_creator/xctest_bundle_creator.sh
+++ b/tools/xctest_bundle_creator/xctest_bundle_creator.sh
@@ -15,7 +15,7 @@ rpaths=$(otool -l "$copied_binary" \
 
 for rpath in $rpaths
 do
-  if [[ $rpath == @* ]]; then
+  if [[ $rpath == @loader_path/* || $rpath == @executable_path/* ]]; then
     prefix="${rpath%%/*}"
     suffix="${rpath#*/}"
     xcrun install_name_tool -rpath "$rpath" "$prefix/../../../$suffix" "$copied_binary"


### PR DESCRIPTION
If your binary gets an rpath like `@loader_path/../foo`, when we moved
this into the xctest bundle directory that path would become invalid.
Bazel already does rewrite these paths as needed, but since the link
action doesn't write to the xctest bundle it's still wrong. Ideally we
could output there directly but there is a bazel issue with conflicting
prefix paths when you try to do that because of params file usage.