### PR TITLE
Loosen CC requirement

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -207,7 +207,7 @@ def _create_linux_toolchain(repository_ctx):
     Args:
       repository_ctx: The repository rule context.
     """
-    if repository_ctx.os.environ.get("CC") != "clang":
+    if "clang" not in repository_ctx.os.environ.get("CC"):
         fail("ERROR: rules_swift uses Bazel's CROSSTOOL to link, but Swift " +
              "requires that the driver used is clang. Please set `CC=clang` " +
              "in your environment before invoking Bazel.")


### PR DESCRIPTION
Sometimes on Linux your clang binary name has the version in it, this
enforces the binary at least looks like clang but less strictly.

https://github.com/bazelbuild/rules_swift/issues/43#issuecomment-914527561