### PR TITLE
Add workaround for SR-15123

### DIFF
--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -290,7 +290,7 @@ def _swiftsourceinfo(actions, module_name):
     """
     return actions.declare_file("{}.swiftsourceinfo".format(module_name))
 
-def _vfsoverlay(actions, target_name):
+def _vfsoverlay(actions, target_name, suffix = ""):
     """Declares a file for the VFS overlay for a compilation action.
 
     The VFS overlay is YAML-formatted file that allows us to place the
@@ -300,11 +300,12 @@ def _vfsoverlay(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        suffix: Extra content to add to the generated file's name
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.vfsoverlay.yaml".format(target_name))
+    return actions.declare_file("{}{}.vfsoverlay.yaml".format(target_name, suffix))
 
 def _whole_module_object_file(actions, target_name):
     """Declares a file for object files created with whole module optimization.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -220,6 +220,11 @@ SWIFT_FEATURE_USE_MODULE_WRAP = "swift.use_module_wrap"
 # when access to those paths involves traversing a networked file system.
 SWIFT_FEATURE_VFSOVERLAY = "swift.vfsoverlay"
 
+# If enabled, Swift compilation access will accept source files through a
+# virtual file system. This exists to workaround SR-15123 and will be removed
+# once that is fixed.
+SWIFT_FEATURE_SOURCES_VFSOVERLAY = "swift._sources_vfsoverlay"
+
 # If enabled, builds using the "dbg" compilation mode will explicitly disable
 # swiftc from producing swiftmodules containing embedded file paths, which are
 # inherently non-portable across machines.

--- a/swift/internal/vfsoverlay.bzl
+++ b/swift/internal/vfsoverlay.bzl
@@ -62,3 +62,50 @@ def write_vfsoverlay(
         content = vfsoverlay_yaml,
         output = vfsoverlay_file,
     )
+
+def write_sources_vfsoverlay(
+        actions,
+        srcs,
+        vfsoverlay_file,
+        virtual_swiftmodule_root):
+    """Generates a VFS overlay for the given source files.
+
+    Args:
+        actions: The object used to register actions.
+        srcs: The `list` of `.swift` files to include in the VFS overlay.
+        vfsoverlay_file: A `File` representing the VFS overlay to be written.
+        virtual_swiftmodule_root: The rooted path fragment representing the
+             directory in the VFS where all `.swift` files will be placed.
+    """
+    virtual_swiftmodules = [
+        {
+            "type": "file",
+            "name": src.path,
+            "external-contents": src.path,
+        }
+        for src in srcs
+    ]
+
+    # These explicit settings ensure that the VFS actually improves search
+    # performance.
+    vfsoverlay_object = {
+        "version": 0,
+        "case-sensitive": True,
+        "fallthrough": False,
+        "use-external-names": True,
+        "roots": [
+            {
+                "type": "directory",
+                "name": virtual_swiftmodule_root,
+                "contents": virtual_swiftmodules,
+            },
+        ],
+    }
+
+    # The YAML specification defines it has a superset of JSON, so it is safe to
+    # use the built-in `to_json` function here.
+    vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
+    actions.write(
+        content = vfsoverlay_yaml,
+        output = vfsoverlay_file,
+    )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -38,6 +38,7 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
+    "SWIFT_FEATURE_SOURCES_VFSOVERLAY",
     "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
@@ -605,6 +606,10 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 12.5 implies Swift 5.4.
     if _is_xcode_at_least_version(xcode_config, "12.5"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
+
+    # Xcode 13.0 implies Swift 5.5
+    if _is_xcode_at_least_version(xcode_config, "13.0"):
+        requested_features.append(SWIFT_FEATURE_SOURCES_VFSOVERLAY)
 
     # Xcode 14 implies Swift 5.7.
     if _is_xcode_at_least_version(xcode_config, "14.0"):


### PR DESCRIPTION
This works around an issue in Swift 5.5 / Xcode 13.0 beta 5 where
absolute paths to the sources being compiled are _always_ used and
embedded in the case a vfs overlay is used. This tricks the compiler by
using a vfs overlay for the source files as well.

https://bugs.swift.org/browse/SR-15123