### PR TITLE
Produce `.swiftsourceinfo` file as output of swift_library rule.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -407,7 +407,7 @@ A provider whose type/layout is an implementation detail and should not
 ## swift_common.create_swift_module
 
 <pre>
-swift_common.create_swift_module(<a href="#swift_common.create_swift_module-swiftdoc">swiftdoc</a>, <a href="#swift_common.create_swift_module-swiftmodule">swiftmodule</a>, <a href="#swift_common.create_swift_module-defines">defines</a>, <a href="#swift_common.create_swift_module-swiftinterface">swiftinterface</a>)
+swift_common.create_swift_module(<a href="#swift_common.create_swift_module-swiftdoc">swiftdoc</a>, <a href="#swift_common.create_swift_module-swiftmodule">swiftmodule</a>, <a href="#swift_common.create_swift_module-defines">defines</a>, <a href="#swift_common.create_swift_module-swiftsourceinfo">swiftsourceinfo</a>, <a href="#swift_common.create_swift_module-swiftinterface">swiftinterface</a>)
 </pre>
 
 Creates a value representing a Swift module use as a Swift dependency.
@@ -420,6 +420,7 @@ Creates a value representing a Swift module use as a Swift dependency.
 | <a id="swift_common.create_swift_module-swiftdoc"></a>swiftdoc |  The <code>.swiftdoc</code> file emitted by the compiler for this module.   |  none |
 | <a id="swift_common.create_swift_module-swiftmodule"></a>swiftmodule |  The <code>.swiftmodule</code> file emitted by the compiler for this module.   |  none |
 | <a id="swift_common.create_swift_module-defines"></a>defines |  A list of defines that will be provided as <code>copts</code> to targets that depend on this module. If omitted, the empty list will be used.   |  <code>[]</code> |
+| <a id="swift_common.create_swift_module-swiftsourceinfo"></a>swiftsourceinfo |  The <code>.swiftsourceinfo</code> file emitted by the compiler for this module. May be <code>None</code> if no source info file was emitted.   |  <code>None</code> |
 | <a id="swift_common.create_swift_module-swiftinterface"></a>swiftinterface |  The <code>.swiftinterface</code> file emitted by the compiler for this module. May be <code>None</code> if no module interface file was emitted.   |  <code>None</code> |
 
 **RETURNS**

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1751,6 +1751,7 @@ def compile(
             # for that action). This guarantees some predictability.
             compile_outputs.swiftmodule_file,
             compile_outputs.swiftdoc_file,
+            compile_outputs.swiftsourceinfo_file,
             compile_outputs.generated_header_file,
         ]) + other_outputs
     else:
@@ -1762,6 +1763,7 @@ def compile(
             compile_outputs.swiftmodule_file,
             compile_outputs.swiftdoc_file,
             compile_outputs.swiftinterface_file,
+            compile_outputs.swiftsourceinfo_file,
             compile_outputs.generated_header_file,
             compile_outputs.indexstore_directory,
         ]) + compile_outputs.object_files + other_outputs
@@ -1946,6 +1948,7 @@ def compile(
             swiftdoc = compile_outputs.swiftdoc_file,
             swiftinterface = compile_outputs.swiftinterface_file,
             swiftmodule = compile_outputs.swiftmodule_file,
+            swiftsourceinfo = compile_outputs.swiftsourceinfo_file,
         ),
     )
 
@@ -2192,6 +2195,10 @@ def _declare_compile_outputs(
         actions = actions,
         module_name = module_name,
     )
+    swiftsourceinfo_file = derived_files.swiftsourceinfo(
+        actions = actions,
+        module_name = module_name,
+    )
 
     if are_all_features_enabled(
         feature_configuration = feature_configuration,
@@ -2332,6 +2339,7 @@ def _declare_compile_outputs(
         swiftdoc_file = swiftdoc_file,
         swiftinterface_file = swiftinterface_file,
         swiftmodule_file = swiftmodule_file,
+        swiftsourceinfo_file = swiftsourceinfo_file,
     )
     return compile_outputs, other_outputs
 

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -270,6 +270,18 @@ def _swiftmodule(actions, module_name):
     """
     return actions.declare_file("{}.swiftmodule".format(module_name))
 
+def _swiftsourceinfo(actions, module_name):
+    """Declares a file for the Swift sourceinfo created by a compilation rule.
+
+    Args:
+        actions: The context's actions object.
+        module_name: The name of the module being built.
+
+    Returns:
+        The declared `File`.
+    """
+    return actions.declare_file("{}.swiftsourceinfo".format(module_name))
+
 def _vfsoverlay(actions, target_name):
     """Declares a file for the VFS overlay for a compilation action.
 
@@ -331,6 +343,7 @@ derived_files = struct(
     swiftdoc = _swiftdoc,
     swiftinterface = _swiftinterface,
     swiftmodule = _swiftmodule,
+    swiftsourceinfo = _swiftsourceinfo,
     vfsoverlay = _vfsoverlay,
     whole_module_object_file = _whole_module_object_file,
     xctest_runner_script = _xctest_runner_script,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -353,6 +353,7 @@ def create_swift_module(
         swiftdoc,
         swiftmodule,
         defines = [],
+        swiftsourceinfo = None,
         swiftinterface = None):
     """Creates a value representing a Swift module use as a Swift dependency.
 
@@ -362,6 +363,8 @@ def create_swift_module(
             module.
         defines: A list of defines that will be provided as `copts` to targets
             that depend on this module. If omitted, the empty list will be used.
+        swiftsourceinfo: The `.swiftsourceinfo` file emitted by the compiler for
+            this module. May be `None` if no source info file was emitted.
         swiftinterface: The `.swiftinterface` file emitted by the compiler for
             this module. May be `None` if no module interface file was emitted.
 
@@ -374,6 +377,7 @@ def create_swift_module(
         swiftdoc = swiftdoc,
         swiftinterface = swiftinterface,
         swiftmodule = swiftmodule,
+        swiftsourceinfo = swiftsourceinfo,
     )
 
 def create_swift_info(

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -222,6 +222,7 @@ def _swift_library_impl(ctx):
         module_context.swift.swiftdoc,
         module_context.swift.swiftinterface,
         module_context.swift.swiftmodule,
+        module_context.swift.swiftsourceinfo,
         linking_output.library_to_link.static_library,
         linking_output.library_to_link.pic_static_library,
     ])


### PR DESCRIPTION
Declares `.swiftsourceinfo` as an output file of a compile action and threads the file through to be an output of the swift_library rule.

PiperOrigin-RevId: 398579438
(cherry picked from commit 4e45e790f642d29309e3f6f5fffc706a2593655c)

> Conflicts:
>	swift/internal/compiling.bzl

Fixes #496
Closes #523
