### PR TITLE
swift_autoconfiguration: handle case where `CC` isn't set

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -207,7 +207,8 @@ def _create_linux_toolchain(repository_ctx):
     Args:
       repository_ctx: The repository rule context.
     """
-    if "clang" not in repository_ctx.os.environ.get("CC"):
+    cc = repository_ctx.os.environ.get("CC") or ""
+    if "clang" not in cc:
         fail("ERROR: rules_swift uses Bazel's CROSSTOOL to link, but Swift " +
              "requires that the driver used is clang. Please set `CC=clang` " +
              "in your environment before invoking Bazel.")


### PR DESCRIPTION
This was added in #683. `CC` may not be set in the env, in which case it will be `None`, which will fail with an error like `TypeError: argument of type 'NoneType' is not iterable`

It was going to fail anyway, but now it will fail with the right error.