### PR TITLE
Add swiftsourceinfo file to worker incremental outputs

### DIFF
--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -90,7 +90,7 @@ void OutputFileMap::UpdateForIncremental(const std::string &path) {
         auto swiftdeps_path = ReplaceExtension(new_path, ".swiftdeps");
         src_map["swift-dependencies"] = swiftdeps_path;
       } else if (kind == "swiftdoc" || kind == "swiftinterface" ||
-                 kind == "swiftmodule") {
+                 kind == "swiftmodule" || kind == "swiftsourceinfo") {
         // Module/interface outputs should be moved to the incremental storage
         // area without additional processing.
         auto new_path = MakeIncrementalOutputPath(path);


### PR DESCRIPTION
After bumping our `rules_swift` version to d69bc4080d03bac10339ab3f8c105c3cdc7c3adf, we noticed some failures possibly related to the changes in 9a1073d28b6c3583428f05aaaa2091833320e71d.

About 10-20% of our builds started failing on CI and locally with errors such as:
```
ERROR: /path/to/repo/BUILD.bazel:9:14: output 'container/Wiring/ContainerWiring.swiftsourceinfo' was not created
```

Digging into the execution log, it seems like this file was in `listed_outputs` but not present in `actual_outputs` in some cases. We always build with sandbox on.

Basically in https://github.com/bazelbuild/rules_swift/pull/523/files we wanted to add support for `swiftsourceinfo`. Even though that PR wasn’t merged as far as I can see, the cherry-picked commit from upstream (https://github.com/bazelbuild/rules_swift/pull/692) didn’t even contain the change to `tools/worker/output_file_map.cc`. The following patch fixes it for me on a local machine that previously was failing 100% of the builds with errors like the one above.