### PR TITLE
Improve cross module incremental import

### DIFF
--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -122,6 +122,11 @@ void OutputFileMap::UpdateForIncremental(const std::string &path) {
   auto copied_swiftdoc_path = MakeIncrementalOutputPath(swiftdoc_path);
   incremental_inputs[swiftdoc_path] = copied_swiftdoc_path;
 
+  auto swiftsourceinfo_path =
+      ReplaceExtension(path, ".swiftsourceinfo", /*all_extensions=*/true);
+  auto copied_swiftsourceinfo_path = MakeIncrementalOutputPath(swiftsourceinfo_path);
+  incremental_inputs[swiftsourceinfo_path] = copied_swiftsourceinfo_path;
+
   json_ = new_output_file_map;
   incremental_outputs_ = incremental_outputs;
   incremental_inputs_ = incremental_inputs;


### PR DESCRIPTION
Before:

```
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Not skipping job: Merging module A; Missing output 'bazel-out/darwin_arm64-fastbuild/bin/A.swiftsourceinfo'
remark: Starting Merging module A
remark: Finished Merging module A
remark: Skipped Compiling A.swift
```

After:
```
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping job: Merging module A; oldest output is current 'bazel-out/darwin_arm64-fastbuild/bin/A.swiftmodule'
remark: Skipped Compiling A.swift
```
