### PR TITLE
Change module cache default to be global

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -59,8 +59,8 @@ load(
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
+    "SWIFT_FEATURE_USE_EPHEMERAL_MODULE_CACHE",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
-    "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
@@ -575,10 +575,10 @@ def compile_action_configs(
                 swift_action_names.DUMP_AST,
             ],
             configurators = [_global_module_cache_configurator],
-            features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
             not_features = [
                 [SWIFT_FEATURE_USE_C_MODULES],
                 [SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR],
+                [SWIFT_FEATURE_USE_EPHEMERAL_MODULE_CACHE],
             ],
         ),
         swift_toolchain_config.action_config(
@@ -589,10 +589,12 @@ def compile_action_configs(
             ],
             configurators = [_tmpdir_module_cache_configurator],
             features = [
-                SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
                 SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR,
             ],
-            not_features = [SWIFT_FEATURE_USE_C_MODULES],
+            not_features = [
+                [SWIFT_FEATURE_USE_C_MODULES],
+                [SWIFT_FEATURE_USE_EPHEMERAL_MODULE_CACHE],
+            ],
         ),
         swift_toolchain_config.action_config(
             actions = [
@@ -605,9 +607,11 @@ def compile_action_configs(
                     "-Xwrapped-swift=-ephemeral-module-cache",
                 ),
             ],
+            features = [
+                SWIFT_FEATURE_USE_EPHEMERAL_MODULE_CACHE,
+            ],
             not_features = [
-                [SWIFT_FEATURE_USE_C_MODULES],
-                [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+                SWIFT_FEATURE_USE_C_MODULES,
             ],
         ),
         swift_toolchain_config.action_config(

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -152,14 +152,12 @@ SWIFT_FEATURE_REWRITE_GENERATED_HEADER = "swift.rewrite_generated_header"
 # them.
 SWIFT_FEATURE_USE_C_MODULES = "swift.use_c_modules"
 
-# If enabled, Swift compilation actions will use the same global Clang module
-# cache used by Objective-C compilation actions. This is disabled by default
-# because under some circumstances Clang module cache corruption can cause the
-# Swift compiler to crash (sometimes when switching configurations or syncing a
-# repository), but disabling it also causes a noticeable build time regression
-# so it can be explicitly re-enabled by users who are not affected by those
-# crashes.
-SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
+# If enabled, Swift compilation actions will use the separate Clang module
+# caches used by Objective-C compilation actions. This is disabled by default
+# because the performance improvement is so significant versus using a separate
+# module cache per Swift action. Users can enable this to avoid rare Clang
+# module cache corruption that can cause the Swift compiler to crash.
+SWIFT_FEATURE_USE_EPHEMERAL_MODULE_CACHE = "swift.use_ephemeral_module_cache"
 
 # If enabled, and Swift compilation actions will use the shared Clang module
 # cache path written to


### PR DESCRIPTION
The performance impact of using the global module cache is so
significant for projects with multiple swift_library targets, and the
crashes seem to be so rare, that I think this is the right tradeoff for
the default.

Also discussed on https://github.com/bazelbuild/rules_swift/issues/487