### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -309,6 +309,5 @@ for incremental compilation using a persistent mode.
     doc = "Represents a Swift compiler toolchain.",
     fragments = ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -882,6 +882,5 @@ for incremental compilation using a persistent mode.
         "swift",
     ],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _xcode_swift_toolchain_impl,
 )


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.