### PR TITLE
RFC: Add --@bazel_build_rules_swift//swift:static_stdlib

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -66,6 +66,7 @@ load(
     "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
+    "SWIFT_FEATURE_STATIC_STDLIB",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
@@ -1036,6 +1037,16 @@ def compile_action_configs(
                 swift_action_names.DUMP_AST,
             ],
             configurators = [_conditional_compilation_flag_configurator],
+        ),
+
+        # Enable the built modules to reference static Swift standard libraries.
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [swift_toolchain_config.add_arg("-static-stdlib")],
+            features = [SWIFT_FEATURE_STATIC_STDLIB],
         ),
     ]
 

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -291,6 +291,10 @@ SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES = "swift.skip_function_bodies_for_deri
 # swift.coverage_prefix_map also remap the path in coverage data.
 SWIFT_FEATURE_REMAP_XCODE_PATH = "swift.remap_xcode_path"
 
+# If enabled the built binary will statically link Swift standard libraries.
+# This requires Swift 5.3.1
+SWIFT_FEATURE_STATIC_STDLIB = "swift.static_stdlib"
+
 # A private feature that is set by the toolchain if a flag enabling WMO was
 # passed on the command line using `--swiftcopt`. Users should never manually
 # enable, disable, or query this feature.

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -81,6 +81,7 @@ void WorkProcessor::ProcessWorkRequest(
   std::string output_file_map_path;
   std::string emit_module_path;
   bool is_wmo = false;
+  bool is_static_stdlib = false;
   bool is_dump_ast = false;
 
   std::string prev_arg;
@@ -97,6 +98,8 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (prev_arg == "-emit-module-path") {
       emit_module_path = arg;
+    } else if (arg == "-static-stdlib") {
+      is_static_stdlib = true;
     } else if (ArgumentEnablesWMO(arg)) {
       is_wmo = true;
     }
@@ -108,7 +111,7 @@ void WorkProcessor::ProcessWorkRequest(
     prev_arg = original_arg;
   }
 
-  bool is_incremental = !is_wmo && !is_dump_ast;
+  bool is_incremental = !is_wmo && !is_dump_ast && !is_static_stdlib;
 
   if (!output_file_map_path.empty()) {
     if (is_incremental) {


### PR DESCRIPTION
This PR added the ability to compile Swift binary with stdlib in Linux.

It added `-static-stdlib` to `swiftc` invocation and added
`static-stdlib-args.lnk` to linker flag.

However, there is an issue with Bazel cache:

```
bazel build examples:ddpg --@bazel_build_rules_swift//swift:static_stdlib
```

It compiles.

Then:

```
bazel build examples:ddpg
```

See error:

```
/usr/bin/ld: cannot find -lDispatchStubs
/usr/bin/ld: cannot find -lCoreFoundation
```

It seems reused the previous autolink extract results, because:

```
bazel clean --expunge
bazel build examples:ddpg
```

Worked again.