### PR TITLE
Add a flag to allow tools to be compiled as universal binaries

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_setting")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
 load(
     "//swift/internal:build_settings.bzl",
     "per_module_swiftcopt_flag",
@@ -64,6 +64,18 @@ per_module_swiftcopt_flag(
 bool_setting(
     name = "emit_swiftinterface",
     build_setting_default = False,
+)
+
+bool_flag(
+    name = "universal_tools",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "universal_tools_config",
+    flag_values = {
+        "@build_bazel_rules_swift//swift:universal_tools": "true",
+    },
 )
 
 # Configuration setting for forcing generation of Apple targets.

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -389,14 +389,14 @@ The kind of definitions that should be generated:
             "_protoc": attr.label(
                 cfg = "exec",
                 default = Label(
-                    "@com_google_protobuf//:protoc",
+                    "//tools/protoc_wrapper",
                 ),
                 executable = True,
             ),
             "_protoc_gen_swiftgrpc": attr.label(
                 cfg = "exec",
                 default = Label(
-                    "@com_github_grpc_grpc_swift//:protoc-gen-swiftgrpc",
+                    "@com_github_grpc_grpc_swift//:protoc-gen-swiftgrpc_wrapper",
                 ),
                 executable = True,
             ),

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -587,12 +587,12 @@ swift_protoc_gen_aspect = aspect(
             ),
             "_protoc": attr.label(
                 cfg = "exec",
-                default = Label("@com_google_protobuf//:protoc"),
+                default = Label("//tools/protoc_wrapper"),
                 executable = True,
             ),
             "_protoc_gen_swift": attr.label(
                 cfg = "exec",
-                default = Label("@com_github_apple_swift_protobuf//:ProtoCompilerPlugin"),
+                default = Label("@com_github_apple_swift_protobuf//:ProtoCompilerPlugin_wrapper"),
                 executable = True,
             ),
         },

--- a/third_party/com_github_apple_swift_protobuf/BUILD.overlay
+++ b/third_party/com_github_apple_swift_protobuf/BUILD.overlay
@@ -1,4 +1,8 @@
 load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_binary",
     "swift_library",
@@ -30,4 +34,19 @@ swift_binary(
     ]),
     visibility = ["//visibility:public"],
     deps = [":SwiftProtobufPluginLibrary"],
+)
+
+universal_binary(
+    name = "universal_ProtoCompilerPlugin",
+    binary = ":ProtoCompilerPlugin",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "ProtoCompilerPlugin_wrapper",
+    actual = select({
+        "@build_bazel_rules_swift//swift:universal_tools_config": ":universal_ProtoCompilerPlugin",
+        "//conditions:default": ":ProtoCompilerPlugin",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -1,5 +1,9 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
     "@build_bazel_rules_swift//swift:swift.bzl",
     "swift_binary",
     "swift_library",
@@ -64,4 +68,19 @@ swift_binary(
         "@com_github_apple_swift_protobuf//:SwiftProtobuf",
         "@com_github_apple_swift_protobuf//:SwiftProtobufPluginLibrary",
     ],
+)
+
+universal_binary(
+    name = "universal_protoc-gen-swiftgrpc",
+    binary = ":protoc-gen-swiftgrpc",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "protoc-gen-swiftgrpc_wrapper",
+    actual = select({
+        "@build_bazel_rules_swift//swift:universal_tools_config": ":universal_protoc-gen-swiftgrpc",
+        "//conditions:default": ":protoc-gen-swiftgrpc",
+    }),
+    visibility = ["//visibility:public"],
 )

--- a/tools/protoc_wrapper/BUILD
+++ b/tools/protoc_wrapper/BUILD
@@ -1,0 +1,16 @@
+load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+universal_binary(
+    name = "universal_protoc",
+    binary = "@com_google_protobuf//:protoc",
+)
+
+alias(
+    name = "protoc_wrapper",
+    actual = select({
+        "//swift:universal_tools_config": ":universal_protoc",
+        "//conditions:default": "@com_google_protobuf//:protoc",
+    }),
+)

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary")
 
 licenses(["notice"])
 
@@ -96,6 +97,21 @@ cc_binary(
             ":compile_with_worker",
         ],
     }),
+)
+
+universal_binary(
+    name = "universal_worker",
+    binary = ":worker",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "worker_wrapper",
+    actual = select({
+        "//swift:universal_tools_config": ":universal_worker",
+        "//conditions:default": ":worker",
+    }),
+    visibility = ["//visibility:public"],
 )
 
 # Consumed by Bazel integration tests.


### PR DESCRIPTION
This adds a new boolean flag
`--@build_bazel_rules_swift//swift:universal_tools` that when used will
force all the tools used in this repository to be compiled into
universal binaries. This allows execution running on different macOS
platforms (`arm64` and `x86_64`) to be compatible with each other and
can run natively on both.
