### PR TITLE
Ensure quote_includes are set for swift_library's CcInfo

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -84,7 +84,7 @@ A new attribute dictionary that can be added to the attributes of a
 
 <pre>
 swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>,
-                     <a href="#swift_common.compile-target_name">target_name</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-bin_dir">bin_dir</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-deps">deps</a>,
+                     <a href="#swift_common.compile-target_label">target_label</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-bin_dir">bin_dir</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-deps">deps</a>,
                      <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-genfiles_dir">genfiles_dir</a>, <a href="#swift_common.compile-private_deps">private_deps</a>)
 </pre>
 
@@ -100,7 +100,7 @@ Compiles a Swift module.
 | <a id="swift_common.compile-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use <code>swift_common.derive_module_name</code> to generate a default from the target's label if needed.   |  none |
 | <a id="swift_common.compile-srcs"></a>srcs |  The Swift source files to compile.   |  none |
 | <a id="swift_common.compile-swift_toolchain"></a>swift_toolchain |  The <code>SwiftToolchainInfo</code> provider of the toolchain.   |  none |
-| <a id="swift_common.compile-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
+| <a id="swift_common.compile-target_label"></a>target_label |  The label of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
 | <a id="swift_common.compile-workspace_name"></a>workspace_name |  The name of the workspace for which the code is being compiled, which is used to determine unique file paths for some outputs.   |  none |
 | <a id="swift_common.compile-additional_inputs"></a>additional_inputs |  A list of <code>File</code>s representing additional input files that need to be passed to the Swift compile action because they are referenced by compiler flags.   |  <code>[]</code> |
 | <a id="swift_common.compile-bin_dir"></a>bin_dir |  The Bazel <code>*-bin</code> directory root. If provided, its path is used to store the cache for modules precompiled by Swift's ClangImporter, and it is added to ClangImporter's header search paths for compatibility with Bazel's C++ and Objective-C rules which support includes of generated headers from that location.   |  <code>None</code> |

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -82,6 +82,7 @@ load(
     "compilation_context_for_explicit_module_compilation",
     "get_providers",
     "struct_fields",
+    "quote_includes_from_label",
 )
 load(":vfsoverlay.bzl", "write_vfsoverlay")
 
@@ -1645,7 +1646,7 @@ def compile(
         module_name,
         srcs,
         swift_toolchain,
-        target_name,
+        target_label,
         workspace_name,
         additional_inputs = [],
         bin_dir = None,
@@ -1666,7 +1667,7 @@ def compile(
             a default from the target's label if needed.
         srcs: The Swift source files to compile.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
-        target_name: The name of the target for which the code is being
+        target_label: The label of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
         workspace_name: The name of the workspace for which the code is being
@@ -1758,7 +1759,7 @@ def compile(
         generated_header_name = generated_header_name,
         generated_module_deps_swift_infos = generated_module_deps_swift_infos,
         module_name = module_name,
-        target_name = target_name,
+        target_name = target_label.name,
         user_compile_flags = copts,
     )
 
@@ -1839,7 +1840,7 @@ def compile(
     ):
         vfsoverlay_file = derived_files.vfsoverlay(
             actions = actions,
-            target_name = target_name,
+            target_name = target_label.name,
         )
         write_vfsoverlay(
             actions = actions,
@@ -1922,6 +1923,7 @@ def compile(
             compilation_context_for_explicit_module_compilation(
                 compilation_contexts = [cc_common.create_compilation_context(
                     headers = depset([compile_outputs.generated_header_file]),
+
                 )],
                 deps = deps,
             )
@@ -1937,7 +1939,7 @@ def compile(
             module_name = module_name,
             swift_infos = generated_module_deps_swift_infos,
             swift_toolchain = swift_toolchain,
-            target_name = target_name,
+            target_name = target_label.name,
         )
     else:
         precompiled_module = None
@@ -1952,7 +1954,7 @@ def compile(
             CcInfo(compilation_context = cc_common.create_compilation_context(
                 defines = depset(defines),
                 headers = depset(module_headers),
-                includes = depset([bin_dir.path]),
+                quote_includes = quote_includes_from_label(target_label, bin_dir),
             )),
         ]
     else:

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -198,7 +198,7 @@ def _swift_linking_rule_impl(
             module_name = module_name,
             srcs = srcs,
             swift_toolchain = swift_toolchain,
-            target_name = ctx.label.name,
+            target_label = ctx.label,
             workspace_name = ctx.workspace_name,
         )
         output_groups = output_groups_from_other_compilation_outputs(

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -283,7 +283,7 @@ def _swift_grpc_library_impl(ctx):
         module_name = module_name,
         srcs = generated_files,
         swift_toolchain = swift_toolchain,
-        target_name = ctx.label.name,
+        target_label = ctx.label,
         workspace_name = ctx.workspace_name,
     )
 

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -19,7 +19,7 @@ load(":attrs.bzl", "swift_common_rule_attrs")
 load(":compiling.bzl", "new_objc_provider")
 load(":providers.bzl", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
-load(":utils.bzl", "compact", "get_providers")
+load(":utils.bzl", "compact", "get_providers", "quote_includes_from_label")
 
 def _swift_import_impl(ctx):
     archives = ctx.files.archives
@@ -38,6 +38,9 @@ def _swift_import_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
 
+    compilation_context = cc_common.create_compilation_context(
+        quote_includes = quote_includes_from_label(ctx.label, ctx.bin_dir),
+    )
     libraries_to_link = [
         cc_common.create_library_to_link(
             actions = ctx.actions,
@@ -55,7 +58,12 @@ def _swift_import_impl(ctx):
         linker_inputs = depset([linker_input]),
     )
     cc_info = cc_common.merge_cc_infos(
-        direct_cc_infos = [CcInfo(linking_context = linking_context)],
+        direct_cc_infos = [
+            CcInfo(
+                compilation_context = compilation_context,
+                linking_context = linking_context,
+            ),
+        ],
         cc_infos = [dep[CcInfo] for dep in deps if CcInfo in dep],
     )
 

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -41,6 +41,7 @@ load(
     "expand_locations",
     "expand_make_variables",
     "get_providers",
+    "quote_includes_from_label"
 )
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:sets.bzl", "sets")
@@ -184,7 +185,7 @@ def _swift_library_impl(ctx):
         private_deps = private_deps,
         srcs = srcs,
         swift_toolchain = swift_toolchain,
-        target_name = ctx.label.name,
+        target_label = ctx.label,
         workspace_name = ctx.workspace_name,
     )
 

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -64,7 +64,7 @@ def _swift_module_alias_impl(ctx):
         module_name = module_name,
         srcs = [reexport_src],
         swift_toolchain = swift_toolchain,
-        target_name = ctx.label.name,
+        target_label = ctx.label,
         workspace_name = ctx.workspace_name,
     )
 

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -416,7 +416,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             module_name = module_name,
             srcs = pbswift_files,
             swift_toolchain = swift_toolchain,
-            target_name = target.label.name,
+            target_label = target.label,
             workspace_name = aspect_ctx.workspace_name,
         )
 
@@ -481,7 +481,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
                 libraries_to_link = [linking_output.library_to_link],
             )
         else:
-            includes = None
             objc_info = None
 
         cc_info = CcInfo(

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -70,6 +70,14 @@ def compact(sequence):
     """
     return [item for item in sequence if item != None]
 
+def quote_includes_from_label(label, bin_dir):
+    if not label.workspace_root:
+        return depset([bin_dir.path])
+    return depset([
+        label.workspace_root,
+        paths.join(bin_dir.path, label.workspace_root),
+    ])
+
 def compilation_context_for_explicit_module_compilation(
         compilation_contexts,
         deps):


### PR DESCRIPTION
This mimics the behavior of `cc_library`.

When consuming `CcInfo` from a `swift_library`, if the library is in an external
repo, the `quote_includes` paths are not set.
In the case of a cc_library, both the workspace root and the `bindir` +
`workspace_root` are set.

If the workspace_root isn't set (in case of a non external repo), include the
current sandbox's path `.`.