### PR TITLE
Use `progress_message` placeholders for more performant rules

### DIFF
--- a/swift/internal/autolinking.bzl
+++ b/swift/internal/autolinking.bzl
@@ -83,8 +83,6 @@ def register_autolink_extract_action(
         feature_configuration = feature_configuration,
         outputs = [autolink_file],
         prerequisites = prerequisites,
-        progress_message = (
-            "Extracting autolink data for Swift module {}".format(module_name)
-        ),
+        progress_message = "Extracting autolink data for Swift module %{label}",
         swift_toolchain = swift_toolchain,
     )

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1880,9 +1880,7 @@ def compile(
             feature_configuration = feature_configuration,
             outputs = all_derived_outputs,
             prerequisites = prerequisites,
-            progress_message = (
-                "Generating derived files for Swift module {}".format(module_name)
-            ),
+            progress_message = "Generating derived files for Swift module %{label}",
             swift_toolchain = swift_toolchain,
         )
 
@@ -1892,7 +1890,7 @@ def compile(
         feature_configuration = feature_configuration,
         outputs = all_compile_outputs,
         prerequisites = prerequisites,
-        progress_message = "Compiling Swift module {}".format(module_name),
+        progress_message = "Compiling Swift module %{label}",
         swift_toolchain = swift_toolchain,
     )
 
@@ -1908,7 +1906,7 @@ def compile(
         feature_configuration = feature_configuration,
         outputs = compile_outputs.ast_files,
         prerequisites = prerequisites,
-        progress_message = "Dumping Swift AST for {}".format(module_name),
+        progress_message = "Dumping Swift AST for %{label}",
         swift_toolchain = swift_toolchain,
     )
 
@@ -2168,7 +2166,7 @@ def _precompile_clang_module(
         feature_configuration = feature_configuration,
         outputs = [precompiled_module],
         prerequisites = prerequisites,
-        progress_message = "Precompiling C module {}".format(module_name),
+        progress_message = "Precompiling C module %{label}",
         swift_toolchain = swift_toolchain,
     )
 

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -191,8 +191,6 @@ def _register_modulewrap_action(
         feature_configuration = feature_configuration,
         outputs = [object],
         prerequisites = prerequisites,
-        progress_message = (
-            "Wrapping {} for debugging".format(swiftmodule.short_path)
-        ),
+        progress_message = "Wrapping Swift module %{label} for debugging",
         swift_toolchain = swift_toolchain,
     )

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -182,7 +182,7 @@ def _register_grpcswift_generate_action(
         ],
         mnemonic = "ProtocGenSwiftGRPC",
         outputs = generated_files,
-        progress_message = "Generating Swift sources for {}".format(label),
+        progress_message = "Generating Swift sources for %{label}",
     )
 
     return generated_files

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -214,7 +214,7 @@ def _register_pbswift_generate_action(
         ),
         mnemonic = "ProtocGenSwift",
         outputs = generated_files,
-        progress_message = "Generating Swift sources for {}".format(label),
+        progress_message = "Generating Swift sources for %{label}",
         tools = [
             mkdir_and_run,
             protoc_executable,


### PR DESCRIPTION
From a tip in a BazelCon talk today.