### PR TITLE
Fix a bug that permitted false positive matches in Swift feature allowlists.

### DIFF
--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -269,11 +269,12 @@ def _is_feature_allowed_in_package(
         else:
             is_match = package_spec == package_info.package
 
-        # Package exclusions always take precedence over package inclusions, so
-        # if we have an exclusion match, return false immediately.
-        if package_info.excluded and is_match:
-            return False
-        else:
-            is_allowed = True
+        if is_match:
+            # Package exclusions always take precedence over package inclusions,
+            # so if we have an exclusion match, return false immediately.
+            if package_info.excluded:
+                return False
+            else:
+                is_allowed = True
 
     return is_allowed


### PR DESCRIPTION
PiperOrigin-RevId: 393352196
(cherry picked from commit 5b669040e15627c3ed35ceb2a101991699a50572)