### PR TITLE
Add a feature to switch back to the legacy Swift driver in Swift 5.5 and higher.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -60,6 +60,7 @@ load(
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
+    "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
@@ -129,8 +130,25 @@ def compile_action_configs(
         The list of action configs needed to perform compilation.
     """
 
-    #### Flags that control compilation outputs
+    #### Flags that control the driver
     action_configs = [
+        # Use the legacy driver if requested.
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+                swift_action_names.PRECOMPILE_C_MODULE,
+                swift_action_names.DUMP_AST,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg("-disallow-use-new-driver"),
+            ],
+            features = [SWIFT_FEATURE_USE_OLD_DRIVER],
+        ),
+    ]
+
+    #### Flags that control compilation outputs
+    action_configs += [
         # Emit object file(s).
         swift_toolchain_config.action_config(
             actions = [swift_action_names.COMPILE],

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -177,6 +177,11 @@ SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
 # This feature requires `swift.use_global_module_cache` to be enabled.
 SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR = "swift.global_module_cache_uses_tmpdir"
 
+# If enabled, actions invoking the Swift driver will use the legacy driver
+# instead of the new driver (https://github.com/apple/swift-driver) that
+# launched in Xcode 13/Swift 5.5.
+SWIFT_FEATURE_USE_OLD_DRIVER = "swift.use_old_driver"
+
 # If enabled, actions invoking the Swift driver or frontend may write argument
 # lists into response files (i.e., "@args.txt") to avoid passing command lines
 # that exceed the system limit. Toolchains typically set this automatically if


### PR DESCRIPTION
PiperOrigin-RevId: 398758812
(cherry picked from commit 69bc3ede9176a02207b916a3c87801ce30639fb2)
