### PR TITLE
Test 5.0 rc for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -33,7 +33,8 @@ x_defaults:
 tasks:
   macos_latest:
     name: "Latest Bazel"
-    bazel: latest
+    # TODO(#722): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     <<: *mac_common
 
   macos_last_green:
@@ -43,7 +44,8 @@ tasks:
 
   macos_latest_head_deps:
     name: "Latest Bazel with Head Deps"
-    bazel: latest
+    # TODO(#722): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     shell_commands:
     # Update the WORKSPACE to use head versions of some deps to ensure nothing
     # has landed on them breaking this project.
@@ -52,7 +54,8 @@ tasks:
 
   ubuntu1804_latest:
     name: "Latest Bazel"
-    bazel: latest
+    # TODO(#722): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     shell_commands:
       - "echo --- Downloading and extracting Swift 5.4.2 to $SWIFT_HOME"
       - "mkdir $SWIFT_HOME"
@@ -70,7 +73,8 @@ tasks:
 
   ubuntu1804_latest_head_deps:
     name: "Latest Bazel with Head Deps"
-    bazel: latest
+    # TODO(#722): Change back to `latest` after 5.0 is released
+    bazel: last_rc
     shell_commands:
       - "echo --- Downloading and extracting Swift 5.4.2 to $SWIFT_HOME"
       - "mkdir $SWIFT_HOME"


### PR DESCRIPTION
We are dropping 4.x support in order to land 5.0 required changes. This changes the CI to test against the 5.0 rc instead of 4.2.1.
