### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is enabled by default.

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -511,6 +511,5 @@ The version of XCTest that the toolchain packages.
     doc = "Represents a Swift compiler toolchain.",
     fragments = [] if bazel_features.cc.swift_fragment_removed else ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -843,6 +843,5 @@ for incremental compilation using a persistent mode.
         "objc",
     ] + ([] if bazel_features.cc.swift_fragment_removed else ["swift"]),
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _xcode_swift_toolchain_impl,
 )


### PR DESCRIPTION
This is a step towards removing it entirely.

PiperOrigin-RevId: 406230375
(cherry picked from commit d1ba795ff479881bf14ba70294693dcabace4fd4)
