### PR TITLE
Add name arguments to the test suites.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -12,25 +12,25 @@ load(":pch_output_dir_tests.bzl", "pch_output_dir_test_suite")
 
 licenses(["notice"])
 
-ast_file_test_suite()
+ast_file_test_suite(name = "ast_file")
 
-coverage_settings_test_suite()
+coverage_settings_test_suite(name = "coverage_settings")
 
-debug_settings_test_suite()
+debug_settings_test_suite(name = "debug_settings")
 
-generated_header_test_suite()
+generated_header_test_suite(name = "generated_header")
 
-module_cache_settings_test_suite()
+module_cache_settings_test_suite(name = "module_cache_settings")
 
-output_file_map_test_suite()
+output_file_map_test_suite(name = "output_file_map")
 
-private_deps_test_suite()
+private_deps_test_suite(name = "private_deps")
 
-swift_through_non_swift_test_suite()
+swift_through_non_swift_test_suite(name = "swift_through_non_swift")
 
-split_derived_files_test_suite()
+split_derived_files_test_suite(name = "split_derived_files")
 
-pch_output_dir_test_suite()
+pch_output_dir_test_suite(name = "pch_output_dir_settings")
 
 test_suite(
     name = "all_tests",

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -19,11 +19,11 @@ load(
     "provider_test",
 )
 
-def ast_file_test_suite(name = "ast_file"):
+def ast_file_test_suite(name):
     """Test suite for `swift_library` dumping ast files.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     provider_test(

--- a/test/coverage_settings_tests.bzl
+++ b/test/coverage_settings_tests.bzl
@@ -30,11 +30,11 @@ coverage_xcode_prefix_map_test = make_action_command_line_test_rule(
     },
 )
 
-def coverage_settings_test_suite(name = "coverage_settings"):
+def coverage_settings_test_suite(name):
     """Test suite for coverage options.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
     default_coverage_test(
         name = "{}_default_coverage".format(name),

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -100,11 +100,11 @@ xcode_remap_command_line_test = make_action_command_line_test_rule(
     },
 )
 
-def debug_settings_test_suite(name = "debug_settings"):
+def debug_settings_test_suite(name):
     """Test suite for serializing debugging options.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Verify that `-c dbg` builds serialize debugging options, remap paths, and

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -23,11 +23,11 @@ load(
     "provider_test",
 )
 
-def generated_header_test_suite(name = "generated_header"):
+def generated_header_test_suite(name):
     """Test suite for `swift_library` generated headers.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Verify that the generated header by default gets an automatically

--- a/test/module_cache_settings_tests.bzl
+++ b/test/module_cache_settings_tests.bzl
@@ -44,11 +44,11 @@ incorrect_global_module_cache_uses_tmpdir_action_command_line_test = make_action
     },
 )
 
-def module_cache_settings_test_suite(name = "module_cache_settings"):
+def module_cache_settings_test_suite(name):
     """Test suite for module cache options.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Verify that a global module cache path is passed to swiftc.

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -39,11 +39,11 @@ output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
     },
 )
 
-def output_file_map_test_suite(name = "output_file_map"):
+def output_file_map_test_suite(name):
     """Test suite for `swift_library` generating output file maps.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     output_file_map_test(

--- a/test/pch_output_dir_tests.bzl
+++ b/test/pch_output_dir_tests.bzl
@@ -27,11 +27,11 @@ pch_output_dir_action_command_line_test = make_action_command_line_test_rule(
     },
 )
 
-def pch_output_dir_test_suite(name = "pch_output_dir_settings"):
+def pch_output_dir_test_suite(name):
     """Test suite for pch output dir options.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Verify that a pch dir is passed

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -27,11 +27,11 @@ private_deps_provider_test = make_provider_test_rule(
     },
 )
 
-def private_deps_test_suite(name = "private_deps"):
+def private_deps_test_suite(name):
     """Test suite for propagation behavior of `swift_library.private_deps`.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # Each of the two leaf libraries should propagate their own modules.

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -94,11 +94,11 @@ split_swiftmodule_copts_test = make_action_command_line_test_rule(
     },
 )
 
-def split_derived_files_test_suite(name = "split_derived_files"):
+def split_derived_files_test_suite(name):
     """Test suite for split derived files options.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
     default_no_split_test(
         name = "{}_default_no_split_args".format(name),

--- a/test/swift_through_non_swift_tests.bzl
+++ b/test/swift_through_non_swift_tests.bzl
@@ -19,11 +19,11 @@ load(
     "provider_test",
 )
 
-def swift_through_non_swift_test_suite(name = "swift_through_non_swift"):
+def swift_through_non_swift_test_suite(name):
     """Test suite for propagation of `SwiftInfo` through non-Swift targets.
 
     Args:
-        name: The name prefix for all the nested tests
+      name: the base name to be used in things created by this macro
     """
 
     # The lower swiftmodule should get propagated through the `objc_library` (by


### PR DESCRIPTION
Silences the buildifier warning, but also provides an name so tools like
buildozer that work on the AST can better handle the BUILD files where they are
called.

RELNOTES: None
PiperOrigin-RevId: 420123866
(cherry picked from commit 14b8cfcc4956e2c38f66f855783cbeccec2bd6f3)