### PR TITLE
Add empty `fields` to providers that don't have fields.

### DIFF
--- a/test/rules/provider_test.bzl
+++ b/test/rules/provider_test.bzl
@@ -23,18 +23,17 @@ load(
     "unittest",
 )
 
+# A sentinel value returned by `_evaluate_field` when a `None` value is
+# encountered during the evaluation of a dotted path on any component other than
+# the last component. This allows the caller to distinguish between a legitimate
+# `None` value being returned by the entire path vs. an unexpected `None` in an
+# earlier component.
+#
+# A `provider` is used here because it is a simple way of getting a known unique
+# object from Bazel that cannot be equal to any other object.
 _EVALUATE_FIELD_FAILED = provider(
-    doc = """
-A sentinel value returned by `_evaluate_field` when a `None` value is
-encountered during the evaluation of a dotted path on any component other than
-the last component. This allows the caller to distinguish between a legitimate
-`None` value being returned by the entire path vs. an unexpected `None` in an
-earlier component.
-
-A `provider` is used here because it is a simple way of getting a known unique
-object from Bazel that cannot be equal to any other object.
-""",
-    fields = [],
+    doc = "Sentinel value, not otherwise used.",
+    fields = {},
 )
 
 def _evaluate_field(env, source, field):


### PR DESCRIPTION
The providers are used as markers themselves, and it isn't that the fields are
undeclared, they have no fields.

RELNOTES: None
PiperOrigin-RevId: 420275818
(cherry picked from commit a4a91acf440f89deadace4aee5a6cebf59a43fa3)