### PR TITLE
Fix exit code for swiftc crashes

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -173,11 +173,16 @@ int RunSubProcess(const std::vector<std::string> &args,
       return wait_status;
     }
 
-    int exit_status = WEXITSTATUS(status);
-    if (exit_status != 0) {
-      return exit_status;
+    if (WIFEXITED(status)) {
+      return WEXITSTATUS(status);
     }
-    return 0;
+
+    if (WIFSIGNALED(status)) {
+      return WTERMSIG(status);
+    }
+
+    // Unhandled case, if we hit this we should handle it above.
+    return 42;
   } else {
     std::cerr << "Error forking process '" << args[0] << "'. "
               << strerror(status) << "\n";


### PR DESCRIPTION
In the case that swiftc crashed, the worker would return that it exited
0. This was because calling WEXITSTATUS when WIFEXITED is not true is
invalid and happened to return 0 in that case. We now handle the case
where swiftc exits from a signal, and return the signal it exited with
instead. There might be some other cases here that we have to handle in
the future, so for now those are failures so we don't return an invalid
value.

Also see https://github.com/bazelbuild/bazel/issues/14543