### PR TITLE
Stop adding headers to ObjcProvider

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2671,9 +2671,6 @@ def new_objc_provider(
             force_load_libraries,
             order = "topological",
         ),
-        header = depset(
-            module_context.clang.compilation_context.direct_headers,
-        ),
         library = depset(
             direct_libraries,
             transitive = transitive_cc_libs,


### PR DESCRIPTION
This is no longer needed.  It was leftover from the compile info
migration because (primarily) IDE still relied on it to get direct
header information.  We just migrated those use cases to CcInfo as
well.

PiperOrigin-RevId: 421187175
(cherry picked from commit 5804b272c07f0749d9356ae52baf4c4d2e21acd5)