### PR TITLE
Add a feature that allows the ASAN version compatibility check to be disabled, for folks who _know what they're doing._

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -48,6 +48,7 @@ load(
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
+    "SWIFT_FEATURE_NO_ASAN_VERSION_CHECK",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_OSIZE",
@@ -515,6 +516,19 @@ def compile_action_configs(
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
             ],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-Xllvm",
+                    "-asan-guard-against-version-mismatch=0",
+                ),
+            ],
+            features = [
+                "asan",
+                SWIFT_FEATURE_NO_ASAN_VERSION_CHECK,
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE],
             configurators = [
                 swift_toolchain_config.add_arg("-sanitize=thread"),
             ],

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -122,6 +122,13 @@ SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS = (
     "swift.module_map_no_private_headers"
 )
 
+# When code is compiled with ASAN enabled, a reference to a versioned symbol is
+# emitted that ensures that the object files are linked to a version of the ASAN
+# runtime library that is known to be compatible. If this feature is enabled,
+# the versioned symbol reference will be omitted, allowing the object files to
+# link to any version of the ASAN runtime library.
+SWIFT_FEATURE_NO_ASAN_VERSION_CHECK = "swift.no_asan_version_check"
+
 # If enabled, the compilation action for a library target will not generate a
 # module map for the Objective-C generated header. This feature is ignored if
 # the target is not generating a header.


### PR DESCRIPTION
Taking this just to reduce the chance of merge conflicts with upstream