### PR TITLE
Add SWIFT_AVOID_WARNING_USING_OLD_DRIVER to environment

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -534,6 +534,8 @@ def _all_tool_configs(
         env = dict(env)
         env["TOOLCHAINS"] = custom_toolchain
 
+    env["SWIFT_AVOID_WARNING_USING_OLD_DRIVER"] = "1"
+
     tool_config = swift_toolchain_config.driver_tool_config(
         driver_mode = "swiftc",
         env = env,


### PR DESCRIPTION
Since
https://github.com/apple/swift/commit/e24eef4b35290135634c11a9a83e652de1e4919d
Swift now emits a warning about the old driver being deprecated. If you
enable the old driver flag we can assume you are doing that
intentionally for now and know that isn't a forever solution.