### PR TITLE
Move to lambdas since the helper is so simple.

### DIFF
--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -451,10 +451,11 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         # `SwiftProtoCcInfo`. Finally, the `swift_proto_library` rule will
         # extract the `CcInfo` from the `SwiftProtoCcInfo` of its single
         # dependency and propagate that safely up the tree.
-        transitive_cc_infos = (
-            get_providers(proto_deps, SwiftProtoCcInfo, _extract_cc_info) +
-            get_providers(support_deps, CcInfo)
-        )
+        transitive_cc_infos = get_providers(
+            proto_deps,
+            SwiftProtoCcInfo,
+            lambda proto_cc_info: proto_cc_info.cc_info,
+        ) + get_providers(support_deps, CcInfo)
 
         # Propagate an `apple_common.Objc` provider with linking info about the
         # library so that linking with Apple Starlark APIs/rules works
@@ -464,7 +465,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         objc_infos = get_providers(
             proto_deps,
             SwiftProtoCcInfo,
-            _extract_objc_info,
+            lambda proto_cc_info: proto_cc_info.objc_info,
         ) + get_providers(support_deps, apple_common.Objc)
 
         objc_info = new_objc_provider(
@@ -516,7 +517,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
             providers = get_providers(
                 proto_deps,
                 SwiftProtoCcInfo,
-                _extract_objc_info,
+                lambda proto_cc_info: proto_cc_info.objc_info,
             ),
         )
 
@@ -526,7 +527,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
                     cc_infos = get_providers(
                         proto_deps,
                         SwiftProtoCcInfo,
-                        _extract_cc_info,
+                        lambda proto_cc_info: proto_cc_info.cc_info,
                     ),
                 ),
                 objc_info = objc_info,
@@ -543,28 +544,6 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
     ))
 
     return providers
-
-def _extract_cc_info(proto_cc_info):
-    """A map function to extract the `CcInfo` from a `SwiftProtoCcInfo`.
-
-    Args:
-        proto_cc_info: A `SwiftProtoCcInfo` provider.
-
-    Returns:
-        The `CcInfo` nested inside the `SwiftProtoCcInfo`.
-    """
-    return proto_cc_info.cc_info
-
-def _extract_objc_info(proto_cc_info):
-    """A map function to extract the `Objc` provider from a `SwiftProtoCcInfo`.
-
-    Args:
-        proto_cc_info: A `SwiftProtoCcInfo` provider.
-
-    Returns:
-        The `ObjcInfo` nested inside the `SwiftProtoCcInfo`.
-    """
-    return proto_cc_info.objc_info
 
 swift_protoc_gen_aspect = aspect(
     attr_aspects = ["deps"],


### PR DESCRIPTION
Avoids having to go look up what the function is doing since it is just fetching
a field.

RELNOTES: None
PiperOrigin-RevId: 422556605
(cherry picked from commit c410bdb263b95261a9f0015e4d3594ba10a804fa)