### PR TITLE
Ensure debug paths embedded in DWARF segments of PCM files built for Swift are workspace-relative.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -454,6 +454,7 @@ def compile_action_configs(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,
+                swift_action_names.PRECOMPILE_C_MODULE,
             ],
             configurators = [
                 swift_toolchain_config.add_arg(


### PR DESCRIPTION
PiperOrigin-RevId: 423448286
(cherry picked from commit 34e7ea5b113ac8a1af5f9397e57a24196d21ce77)