### PR TITLE
Reland: Retrieve single arch cpu from `cc_toolchain` instead of from `ctx.fragments.apple`

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -633,44 +633,19 @@ def _xcode_env(xcode_config, platform):
         apple_common.target_apple_env(xcode_config, platform),
     )
 
-# TODO(https://github.com/bazelbuild/bazel/issues/14291): Use the value from
-# ctx.fragments.apple.single_arch_cpu
-def _single_arch_cpu(cc_toolchain):
-    """Returns the single effective architecture for the current configuration.
-
-    Args:
-        cc_toolchain: The C++ toolchain from which linking flags and other
-            tools needed by the Swift toolchain (such as `clang`) will be
-            retrieved.
-
-    Returns:
-        A single architecture without the platform name (e.g. `x86_64`).
-    """
-    cpu = cc_toolchain.cpu
-    if cpu.startswith("ios_sim_"):
-        return cpu[len("ios_sim_"):]
-    if cpu.startswith("ios_"):
-        return cpu[len("ios_"):]
-    if cpu.startswith("watchos_"):
-        return cpu[len("watchos_"):]
-    if cpu.startswith("tvos_"):
-        return cpu[len("tvos_"):]
-    if cpu.startswith("darwin_"):
-        return cpu[len("darwin_"):]
-
-    # Legacy cpu name
-    if cpu == "darwin":
-        return "x86_64"
-
-    fail("ERROR: Unhandled cpu type {}".format(cpu))
-
 def _xcode_swift_toolchain_impl(ctx):
     apple_fragment = ctx.fragments.apple
     cpp_fragment = ctx.fragments.cpp
     apple_toolchain = apple_common.apple_toolchain()
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    cpu = _single_arch_cpu(cc_toolchain)
+    # TODO(https://github.com/bazelbuild/bazel/issues/14291): Always use the
+    # value from ctx.fragments.apple.single_arch_cpu
+    if cc_toolchain.cpu.startswith("darwin_"):
+        cpu = cc_toolchain.cpu[len("darwin_"):]
+    else:
+        cpu = apple_fragment.single_arch_cpu
+
     platform = apple_fragment.single_arch_platform
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 


### PR DESCRIPTION
`ctx.fragments.apple.single_arch_cpu` is returning the default macos
cpu for the host platform for tools while it should return the cpu of
the execution platform.

~The original patch relied on `ctx.fragments.apple.single_arch_platform`
which can also be wrong in some cases. Now we only look at the platform
prefix in the cpu string instead.~

~There is a caveat with this workaround: When building a `swift_library`
directly without a `--cpu` flag, the `cpu` value would be the cpu value
of the exec platform, regardless of the `--apple_platform_type` value.~
