### PR TITLE
Fix worker target

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -848,7 +848,7 @@ toolchain (such as `clang`) will be retrieved.
                 cfg = "exec",
                 allow_files = True,
                 default = Label(
-                    "@build_bazel_rules_swift//tools/worker",
+                    "@build_bazel_rules_swift//tools/worker:worker_wrapper",
                 ),
                 doc = """\
 An executable that wraps Swift compiler invocations and also provides support


### PR DESCRIPTION
This should be the wrapper target so that it can be configured to be
built as a universal binary.

Missing change from 2f9d3ac2afdea672f280eb0b88e0e0d76e39febb.
