### PR TITLE
Fix swift_binary depending on apple_static_framework_import

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -247,7 +247,7 @@ def register_link_binary_action(
                         cc_common.create_linker_input(
                             owner = owner,
                             user_link_flags = depset(dep_link_flags),
-                            additional_inputs = depset(static_framework_files),
+                            additional_inputs = objc.static_framework_file,
                         ),
                     ]),
                 ),

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -236,7 +236,10 @@ def register_link_binary_action(
                 "-framework",
                 objc.dynamic_framework_names.to_list(),
             ))
-            dep_link_flags.extend(static_framework_files)
+            dep_link_flags.extend([
+                file.path
+                for file in static_framework_files
+            ])
 
             linking_contexts.append(
                 cc_common.create_linking_context(
@@ -244,6 +247,7 @@ def register_link_binary_action(
                         cc_common.create_linker_input(
                             owner = owner,
                             user_link_flags = depset(dep_link_flags),
+                            additional_inputs = depset(static_framework_files),
                         ),
                     ]),
                 ),


### PR DESCRIPTION
Previously this caused this issue:

```
ERROR: path/to/BUILD:14:13: in swift_binary rule //tools/deadcode:deadcode:
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_ksmiley/751b7cfc481e6eb168e92ffcfb919baa/external/build_bazel_rules_swift/swift/internal/swift_binary_test.bzl", line 305, column 61, in _swift_binary_impl
                _, linking_outputs, providers = _swift_linking_rule_impl(
        File "/private/var/tmp/_bazel_ksmiley/751b7cfc481e6eb168e92ffcfb919baa/external/build_bazel_rules_swift/swift/internal/swift_binary_test.bzl", line 245, column 50, in _swift_linking_rule_impl
                linking_outputs = register_link_binary_action(
        File "/private/var/tmp/_bazel_ksmiley/751b7cfc481e6eb168e92ffcfb919baa/external/build_bazel_rules_swift/swift/internal/linking.bzl", line 251, column 54, in register_link_binary_action
                cc_common.create_linker_input(
Error in create_linker_input: for 'user_link_flags', got a depset of 'File', expected a depset of 'string'
```

These files also have to be passed as inputs to the action.