### PR TITLE
Remove `rules_cc` as a dependency

### DIFF
--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -2,7 +2,6 @@
 # vice versa when it is linked into the existing native linking rules for Apple
 # platforms.
 
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load(
     "//swift:swift.bzl",
     "swift_binary",

--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_binary", "swift_library")
 
 licenses(["notice"])

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -59,15 +59,6 @@ def swift_rules_dependencies():
 
     _maybe(
         http_archive,
-        name = "rules_cc",
-        # Latest 08-10-20
-        urls = ["https://github.com/bazelbuild/rules_cc/archive/1477dbab59b401daa94acedbeaefe79bf9112167.tar.gz"],
-        sha256 = "b87996d308549fc3933f57a786004ef65b44b83fd63f1b0303a4bbc3fd26bbaf",
-        strip_prefix = "rules_cc-1477dbab59b401daa94acedbeaefe79bf9112167/",
-    )
-
-    _maybe(
-        http_archive,
         name = "com_github_apple_swift_protobuf",
         urls = ["https://github.com/apple/swift-protobuf/archive/1.12.0.tar.gz"],
         sha256 = "f50dae44d998b49c271bf9288f2e1ff564bb950d8f276b43dce2a82079b22e25",

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 

--- a/test/fixtures/swift_through_non_swift/BUILD
+++ b/test/fixtures/swift_through_non_swift/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//swift:swift.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
+
 load(
     "@build_bazel_apple_support//rules:universal_binary.bzl",
     "universal_binary",

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -1,4 +1,3 @@
-
 load(
     "@build_bazel_apple_support//rules:universal_binary.bzl",
     "universal_binary",

--- a/third_party/com_github_nlohmann_json/BUILD.overlay
+++ b/third_party/com_github_nlohmann_json/BUILD.overlay
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-
 package(
     default_visibility = ["//tools/worker:__pkg__"],
 )


### PR DESCRIPTION
This repo has been abandoned in favor of the `@_builtins` repo
(Starlark rules implemented in Bazel's core).
