### PR TITLE
Fix dependency linker flags being de-duped

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -247,7 +247,7 @@ def register_link_binary_action(
                     linker_inputs = depset([
                         cc_common.create_linker_input(
                             owner = owner,
-                            user_link_flags = depset(dep_link_flags),
+                            user_link_flags = dep_link_flags,
                             additional_inputs = objc.static_framework_file,
                         ),
                     ]),

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,6 +3,7 @@ load(":ast_file_tests.bzl", "ast_file_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
 load(":debug_settings_tests.bzl", "debug_settings_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
+load(":linking_tests.bzl", "linking_test_suite")
 load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":output_file_map_tests.bzl", "output_file_map_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
@@ -19,6 +20,8 @@ coverage_settings_test_suite(name = "coverage_settings")
 debug_settings_test_suite(name = "debug_settings")
 
 generated_header_test_suite(name = "generated_header")
+
+linking_test_suite(name = "linking")
 
 module_cache_settings_test_suite(name = "module_cache_settings")
 

--- a/test/fixtures/linking/BUILD
+++ b/test/fixtures/linking/BUILD
@@ -1,0 +1,16 @@
+load("//swift:swift.bzl", "swift_binary")
+load(":fake_framework.bzl", "fake_framework")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+fake_framework(
+    name = "framework",
+)
+
+swift_binary(
+    name = "bin",
+    srcs = ["main.swift"],
+    deps = [":framework"],
+)

--- a/test/fixtures/linking/fake_framework.bzl
+++ b/test/fixtures/linking/fake_framework.bzl
@@ -1,0 +1,14 @@
+"""Simple rule to emulate apple_static_framework_import"""
+
+def _impl(ctx):
+    binary1 = ctx.actions.declare_file("framework1.framework/framework")
+    ctx.actions.write(binary1, "empty")
+    binary2 = ctx.actions.declare_file("framework2.framework/framework")
+    ctx.actions.write(binary2, "empty")
+    return apple_common.new_objc_provider(
+        static_framework_file = depset([binary1, binary2]),
+    )
+
+fake_framework = rule(
+    implementation = _impl,
+)

--- a/test/fixtures/linking/main.swift
+++ b/test/fixtures/linking/main.swift
@@ -1,0 +1,1 @@
+print("hello")

--- a/test/linking_tests.bzl
+++ b/test/linking_tests.bzl
@@ -1,0 +1,25 @@
+"""Tests for validating linking behavior"""
+
+load(
+    "@build_bazel_rules_swift//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+
+linking_test = make_action_command_line_test_rule()
+
+def linking_test_suite(name):
+    linking_test(
+        name = "{}_duplicate_linking_args".format(name),
+        expected_argv = [
+            "-framework framework1",
+            "-framework framework2",
+        ],
+        mnemonic = "CppLink",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/rules/action_command_line_test.bzl
+++ b/test/rules/action_command_line_test.bzl
@@ -44,15 +44,27 @@ def _action_command_line_test_impl(ctx):
         )
         return analysistest.end(env)
     if len(matching_actions) != 1:
-        unittest.fail(
-            env,
-            ("Expected exactly one action with the mnemonic '{}', " +
-             "but found {}.").format(
-                mnemonic,
-                len(matching_actions),
-            ),
-        )
-        return analysistest.end(env)
+        # This is a hack to avoid CppLink meaning binary linking and static
+        # library archiving https://github.com/bazelbuild/bazel/pull/15060
+        if mnemonic == "CppLink" and len(matching_actions) == 2:
+            matching_actions = [
+                action
+                for action in matching_actions
+                if action.argv[0] not in [
+                    "/usr/bin/ar",
+                    "external/local_config_cc/libtool",
+                ]
+            ]
+        if len(matching_actions) != 1:
+            unittest.fail(
+                env,
+                ("Expected exactly one action with the mnemonic '{}', " +
+                 "but found {}.").format(
+                    mnemonic,
+                    len(matching_actions),
+                ),
+            )
+            return analysistest.end(env)
 
     action = matching_actions[0]
     message_prefix = "In {} action for target '{}', ".format(


### PR DESCRIPTION
Wrapping these in a depset caused these flags to be de-duplicated, which
meant if a single dependency added `-framework foo -framework bar` it
would turn into the invalid `-framework foo bar`. This mode is also
discouraged by the documentation:

https://docs.bazel.build/versions/main/skylark/lib/cc_common.html#create_linker_input

We now use a list instead.