### PR TITLE
Drop partial swiftmodule from other_outputs

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2346,7 +2346,6 @@ def _declare_compile_outputs(
             actions = actions,
             embeds_bc = embeds_bc,
             emits_bc = emits_bc,
-            emits_partial_modules = output_nature.emits_partial_modules,
             split_derived_file_generation = split_derived_file_generation,
             srcs = srcs,
             target_name = target_name,
@@ -2394,7 +2393,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
         actions,
         embeds_bc,
         emits_bc,
-        emits_partial_modules,
         split_derived_file_generation,
         srcs,
         target_name):
@@ -2406,9 +2404,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
             files.
         emits_bc: If `True` the compiler will generate LLVM BC files instead of
             object files.
-        emits_partial_modules: `True` if the compilation action is expected to
-            emit partial `.swiftmodule` files (i.e., one `.swiftmodule` file per
-            source file, as in a non-WMO compilation).
         split_derived_file_generation: Whether objects and modules are produced
             by separate actions.
         srcs: The list of source files that will be compiled.
@@ -2490,22 +2485,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
         )
         ast_files.append(ast)
         src_output_map["ast-dump"] = ast.path
-
-        # Multi-threaded WMO compiles still produce a single .swiftmodule file,
-        # despite producing multiple object files, so we have to check
-        # explicitly for that case.
-        if emits_partial_modules:
-            partial_module = derived_files.partial_swiftmodule(
-                actions = actions,
-                target_name = target_name,
-                src = src,
-            )
-
-            if split_derived_file_generation:
-                derived_files_output_map[src.path] = {"swiftmodule": partial_module.path}
-            else:
-                src_output_map["swiftmodule"] = partial_module.path
-
         output_map[src.path] = struct(**src_output_map)
 
     actions.write(
@@ -2818,9 +2797,6 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
         *   `emits_multiple_objects`: `True` if the Swift frontend emits an
             object file per source file, instead of a single object file for the
             whole module, in a compilation action with the given flags.
-        *   `emits_partial_modules`: `True` if the Swift frontend emits partial
-            `.swiftmodule` files for the individual source files in a
-            compilation action with the given flags.
     """
     is_wmo = (
         is_feature_enabled(
@@ -2845,7 +2821,6 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
 
     return struct(
         emits_multiple_objects = not (is_wmo and is_single_threaded),
-        emits_partial_modules = not is_wmo,
     )
 
 def _exclude_swift_incompatible_define(define):

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2500,7 +2500,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
                 target_name = target_name,
                 src = src,
             )
-            other_outputs.append(partial_module)
 
             if split_derived_file_generation:
                 derived_files_output_map[src.path] = {"swiftmodule": partial_module.path}

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -155,28 +155,6 @@ def _modulewrap_object(actions, target_name):
     """
     return actions.declare_file("{}.modulewrap.o".format(target_name))
 
-def _partial_swiftmodule(actions, target_name, src):
-    """Declares a file for a partial Swift module created during compilation.
-
-    These files are produced when the compiler is invoked with multiple frontend
-    invocations (i.e., whole module optimization disabled); in that case, there
-    is a partial `.swiftmodule` file produced for each source file, which are
-    then merged by another frontend invocation to produce the single
-    `.swiftmodule` file for the entire module.
-
-    Args:
-        actions: The context's actions object.
-        target_name: The name of the target being built.
-        src: A `File` representing the source file being compiled.
-
-    Returns:
-        The declared `File`.
-    """
-    dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
-        paths.join(dirname, "{}.partial_swiftmodule".format(basename)),
-    )
-
 def _precompiled_module(actions, target_name):
     """Declares the precompiled module for a C/Objective-C target.
 
@@ -353,7 +331,6 @@ derived_files = struct(
     intermediate_object_file = _intermediate_object_file,
     module_map = _module_map,
     modulewrap_object = _modulewrap_object,
-    partial_swiftmodule = _partial_swiftmodule,
     precompiled_module = _precompiled_module,
     reexport_modules_src = _reexport_modules_src,
     static_archive = _static_archive,


### PR DESCRIPTION
Previously we required this file to be produced by adding it to the
outputs of compile actions. Starting with Swift 5.6 in incremental mode
the driver no longer produces these files, and instead separates
compilation from a single module creation step, instead of producing
partial modules and merging them. This leads to this file never being
created, and a build failure. This file is never consumed elsewhere, so
we don't need to ensure it's created.

https://github.com/apple/swift-driver/commit/e0c3e5c740e68202e0a7777d3f6af795d9150296

Fixes https://github.com/bazelbuild/rules_swift/issues/775