### PR TITLE
Add private feature noting emit-module-separately behavior

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -64,6 +64,7 @@ load(
     "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
+    "SWIFT_FEATURE__EMIT_MODULE_SEPARATELY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
@@ -2835,6 +2836,11 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
         _is_wmo_manually_requested(user_compile_flags)
     )
 
+    emit_module_separately = is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE__EMIT_MODULE_SEPARATELY,
+    )
+
     # We check the feature first because that implies that `-num-threads 0` was
     # present in `--swiftcopt`, which overrides all other flags (like the user
     # compile flags, which come from the target's `copts`). Only fallback to
@@ -2846,7 +2852,7 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
 
     return struct(
         emits_multiple_objects = not (is_wmo and is_single_threaded),
-        emits_partial_modules = not is_wmo,
+        emits_partial_modules = not is_wmo and not emit_module_separately,
     )
 
 def _exclude_swift_incompatible_define(define):

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -283,6 +283,10 @@ SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
 # manually enable, disable, or query this feature.
 SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts"
 
+# A private feature that is set by the toolchain if the version of Swift
+# defaults to skipping emitting partial modules.
+SWIFT_FEATURE__EMIT_MODULE_SEPARATELY = "swift._emit_module_separately"
+
 # A feature to enable setting pch-output-dir
 # This is a directory to persist automatically created precompiled bridging headers
 SWIFT_FEATURE_USE_PCH_OUTPUT_DIR = "swift.use_pch_output_dir"

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -32,6 +32,7 @@ load(
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
+    "SWIFT_FEATURE__EMIT_MODULE_SEPARATELY",
 )
 
 def _scratch_file(repository_ctx, temp_dir, name, content = ""):
@@ -92,6 +93,20 @@ def _check_debug_prefix_map(repository_ctx, swiftc_path, _temp_dir):
         "-version",
         "-debug-prefix-map",
         "foo=bar",
+    )
+
+def _check_emit_module_separately(repository_ctx, swiftc_path, _temp_dir):
+    """Returns True if `swiftc` supports emitting module separately.
+
+    Note: this uses the presence of the WMO related flag to determine this,
+    since it was added in 5.6 which is the same version that switched the
+    default.
+    """
+    return _swift_succeeds(
+        repository_ctx,
+        swiftc_path,
+        "-version",
+        "-emit-module-separately-wmo",
     )
 
 def _check_supports_private_deps(repository_ctx, swiftc_path, temp_dir):
@@ -199,6 +214,7 @@ _FEATURE_CHECKS = {
     SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES: _check_skip_function_bodies,
     SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS: _check_supports_private_deps,
     SWIFT_FEATURE_USE_RESPONSE_FILES: _check_use_response_files,
+    SWIFT_FEATURE__EMIT_MODULE_SEPARATELY: _check_emit_module_separately,
 }
 
 def _create_linux_toolchain(repository_ctx):

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -43,6 +43,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
+    "SWIFT_FEATURE__EMIT_MODULE_SEPARATELY",
 )
 load(":features.bzl", "features_for_build_modes")
 load(":toolchain_config.bzl", "swift_toolchain_config")
@@ -716,6 +717,10 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 12.5 implies Swift 5.4.
     if _is_xcode_at_least_version(xcode_config, "12.5"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
+
+    # Xcode 13.3 implies Swift 5.6.
+    if _is_xcode_at_least_version(xcode_config, "13.3"):
+        requested_features.append(SWIFT_FEATURE__EMIT_MODULE_SEPARATELY)
 
     env = _xcode_env(platform = platform, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()


### PR DESCRIPTION
With Swift 5.6 the swift driver now emits modules in a separate step,
which skips the partial module merging step that happened before. This
means partial swiftmodule files are not emitted. This reflects that in
our logic for determining this. It's also enabled by default for WMO
builds, but that shouldn't matter for now either since we already
assumed that.

Technically this isn't a perfect solution, this ignores the fact that
users could pass -no-emit-modules-separately, or the WMO version of
these flags but this doesn't seem to be an issue.

https://github.com/apple/swift-driver/commit/e0c3e5c740e68202e0a7777d3f6af795d9150296

Fixes https://github.com/bazelbuild/rules_swift/issues/775