### PR TITLE
Revert "Pass -no-emit-module-separately by default"

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -49,7 +49,6 @@ load(
     "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_NO_ASAN_VERSION_CHECK",
-    "SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_OSIZE",
@@ -934,18 +933,6 @@ def compile_action_configs(
                 SWIFT_FEATURE_INDEX_WHILE_BUILDING,
                 SWIFT_FEATURE_DISABLE_SYSTEM_INDEX,
             ],
-        ),
-        swift_toolchain_config.action_config(
-            actions = [
-                swift_action_names.COMPILE,
-                swift_action_names.DERIVE_FILES,
-            ],
-            configurators = [
-                swift_toolchain_config.add_arg(
-                    "-no-emit-module-separately",
-                ),
-            ],
-            features = [SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY],
         ),
 
         # User-defined conditional compilation flags (defined for Swift; those

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -283,10 +283,6 @@ SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
 # manually enable, disable, or query this feature.
 SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts"
 
-# A private feature that is set by the toolchain to disable the driver using
-# a separate job for emitting the swiftmodule.
-SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY = "swift.no_emit_module_separately"
-
 # A feature to enable setting pch-output-dir
 # This is a directory to persist automatically created precompiled bridging headers
 SWIFT_FEATURE_USE_PCH_OUTPUT_DIR = "swift.use_pch_output_dir"

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -30,7 +30,6 @@ load(
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
-    "SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
 )
@@ -93,20 +92,6 @@ def _check_debug_prefix_map(repository_ctx, swiftc_path, _temp_dir):
         "-version",
         "-debug-prefix-map",
         "foo=bar",
-    )
-
-def _check_emit_module_separately(repository_ctx, swiftc_path, _temp_dir):
-    """Returns True if `swiftc` supports emitting module separately.
-
-    Note: this uses the presence of the WMO related flag to determine this,
-    since it was added in 5.6 which is the same version that switched the
-    default.
-    """
-    return _swift_succeeds(
-        repository_ctx,
-        swiftc_path,
-        "-version",
-        "-emit-module-separately-wmo",
     )
 
 def _check_supports_private_deps(repository_ctx, swiftc_path, temp_dir):
@@ -212,7 +197,6 @@ _FEATURE_CHECKS = {
     SWIFT_FEATURE_DEBUG_PREFIX_MAP: _check_debug_prefix_map,
     SWIFT_FEATURE_ENABLE_BATCH_MODE: _check_enable_batch_mode,
     SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES: _check_skip_function_bodies,
-    SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY: _check_emit_module_separately,
     SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS: _check_supports_private_deps,
     SWIFT_FEATURE_USE_RESPONSE_FILES: _check_use_response_files,
 }

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -38,7 +38,6 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
-    "SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
@@ -717,10 +716,6 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 12.5 implies Swift 5.4.
     if _is_xcode_at_least_version(xcode_config, "12.5"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
-
-    # Xcode 13.3 implies Swift 5.6.
-    if _is_xcode_at_least_version(xcode_config, "13.3"):
-        requested_features.append(SWIFT_FEATURE_NO_EMIT_MODULE_SEPARATELY)
 
     env = _xcode_env(platform = platform, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()


### PR DESCRIPTION
Reverts bazelbuild/rules_swift#785

This is the right fix instead https://github.com/bazelbuild/rules_swift/pull/786