### PR TITLE
Bump Linux and Swift version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,12 +24,14 @@ x_defaults:
     build_targets:
       - "//examples/..."
       - "-//examples/apple/..."
+      - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
     test_flags: *linux_flags
     test_targets:
       - "//doc/..."
       - "//examples/..."
       - "//test/..."
       - "-//examples/apple/..."
+      - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
 
 tasks:
   macos_latest:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,10 +10,11 @@ x_defaults:
       - "//examples/..."
       - "//test/..."
   linux_common: &linux_common
-    platform: ubuntu1804
+    platform: ubuntu2004
     environment:
       CC: clang
-      SWIFT_HOME: "$HOME/swift-5.4.2"
+      SWIFT_VERSION: "5.5.3"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     build_flags: &linux_flags
       # On Linux, we look for Swift toolchain binaries on the path. We may be
@@ -50,31 +51,31 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *mac_common
 
-  ubuntu1804_latest:
+  ubuntu2004_latest:
     name: "Latest Bazel"
     bazel: latest
     shell_commands:
-      - "echo --- Downloading and extracting Swift 5.4.2 to $SWIFT_HOME"
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
       - "mkdir $SWIFT_HOME"
-      - "curl https://mirror.bazel.build/swift.org/builds/swift-5.4.2-release/ubuntu1804/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-ubuntu18.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     <<: *linux_common
 
-  ubuntu1804_last_green:
+  ubuntu2004_last_green:
     name: "Last Green Bazel"
     bazel: last_green
     shell_commands:
-      - "echo --- Downloading and extracting Swift 5.4.2 to $SWIFT_HOME"
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
       - "mkdir $SWIFT_HOME"
-      - "curl https://mirror.bazel.build/swift.org/builds/swift-5.4.2-release/ubuntu1804/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-ubuntu18.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     <<: *linux_common
 
-  ubuntu1804_latest_head_deps:
+  ubuntu2004_latest_head_deps:
     name: "Latest Bazel with Head Deps"
     bazel: latest
     shell_commands:
-      - "echo --- Downloading and extracting Swift 5.4.2 to $SWIFT_HOME"
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
       - "mkdir $SWIFT_HOME"
-      - "curl https://mirror.bazel.build/swift.org/builds/swift-5.4.2-release/ubuntu1804/swift-5.4.2-RELEASE/swift-5.4.2-RELEASE-ubuntu18.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
       # Update the WORKSPACE to use head versions of some deps to ensure nothing
       # has landed on them breaking this project.
       - .bazelci/update_workspace_to_deps_heads.sh

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -69,9 +69,9 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc_swift",
-        urls = ["https://github.com/grpc/grpc-swift/archive/0.9.0.tar.gz"],
-        sha256 = "bcaaa8c44c0d29902bf4a5c6df593286338659ffa0110cc11a0fd8fcb890feb7",
-        strip_prefix = "grpc-swift-0.9.0/",
+        urls = ["https://github.com/grpc/grpc-swift/archive/0.9.1.tar.gz"],
+        sha256 = "6b3a2ed13c805c6b8f339f558f2a1372bdcf84c079c104a6d0b54fd7650b8fbf",
+        strip_prefix = "grpc-swift-0.9.1/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
     )
 

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -69,9 +69,9 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc_swift",
-        urls = ["https://github.com/grpc/grpc-swift/archive/0.9.1.tar.gz"],
-        sha256 = "6b3a2ed13c805c6b8f339f558f2a1372bdcf84c079c104a6d0b54fd7650b8fbf",
-        strip_prefix = "grpc-swift-0.9.1/",
+        urls = ["https://github.com/grpc/grpc-swift/archive/0.9.0.tar.gz"],
+        sha256 = "bcaaa8c44c0d29902bf4a5c6df593286338659ffa0110cc11a0fd8fcb890feb7",
+        strip_prefix = "grpc-swift-0.9.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
     )
 


### PR DESCRIPTION
I had to disable grpc tests on linux here because the version of grpc-swift we're on is very old and no longer compiles on Linux. Updating it is quite difficult since it has changed to a large dependency tree on nio