### PR TITLE
common: remove dead code (NFCI)

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -134,14 +134,6 @@ std::vector<const char *> ConvertToCArgs(const std::vector<std::string> &args) {
 
 }  // namespace
 
-void ExecProcess(const std::vector<std::string> &args) {
-  std::vector<const char *> exec_argv = ConvertToCArgs(args);
-  execv(args[0].c_str(), const_cast<char **>(exec_argv.data()));
-  std::cerr << "Error executing child process.'" << args[0] << "'. "
-            << strerror(errno) << "\n";
-  abort();
-}
-
 int RunSubProcess(const std::vector<std::string> &args,
                   std::ostream *stderr_stream, bool stdout_to_stderr) {
   std::vector<const char *> exec_argv = ConvertToCArgs(args);

--- a/tools/common/process.h
+++ b/tools/common/process.h
@@ -18,10 +18,6 @@
 #include <string>
 #include <vector>
 
-// Turn our current process into a new process. Avoids fork overhead.
-// Never returns.
-void ExecProcess(const std::vector<std::string> &args);
-
 // Spawns a subprocess for given arguments args and waits for it to terminate.
 // The first argument is used for the executable path. If stdout_to_stderr is
 // set, then stdout is redirected to the stderr stream as well. Returns the exit


### PR DESCRIPTION
This removes the definition of `ExecProcess` which is unused currently.