### PR TITLE
common: trivial cleanup of `BUILD`

### DIFF
--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -1,10 +1,6 @@
 load("@bazel_skylib//lib:selects.bzl", "selects")
 
-package(
-    default_visibility = [
-        "//tools/worker:__pkg__",
-    ],
-)
+package(default_visibility = ["//tools/worker:__pkg__"])
 
 licenses(["notice"])
 


### PR DESCRIPTION
Avoid unnecessary vertical whitespace in `project` call.  This has a
single parameter and can be compressed to a single line instead of 5.