### PR TITLE
Migrate the Swift worker to use the JSON protocol instead of binary protos.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -230,6 +230,7 @@ def run_toolchain_action(
             tool_config.use_param_file
         ):
             execution_requirements["supports-workers"] = "1"
+            execution_requirements["requires-worker-protocol"] = "json"
 
         executable = swift_toolchain.swift_worker
         tool_executable_args.add(tool_config.executable)

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -46,9 +46,8 @@ cc_library(
     }),
     deps = [
         ":swift_runner",
-        "//third_party/bazel_protos:worker_protocol_cc_proto",
+        ":worker_protocol",
         "//tools/common:temp_file",
-        "@com_google_protobuf//:protobuf",
     ],
 )
 
@@ -92,6 +91,23 @@ cc_library(
         "//tools/common:bazel_substitutions",
         "//tools/common:process",
         "//tools/common:temp_file",
+        "@com_github_nlohmann_json//:json",
+    ],
+)
+
+cc_library(
+    name = "worker_protocol",
+    srcs = ["worker_protocol.cc"],
+    hdrs = ["worker_protocol.h"],
+    copts = selects.with_or({
+        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+            "/std:c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    }),
+    deps = [
         "@com_github_nlohmann_json//:json",
     ],
 )

--- a/tools/worker/compile_with_worker.cc
+++ b/tools/worker/compile_with_worker.cc
@@ -14,14 +14,13 @@
 
 #include "tools/worker/compile_with_worker.h"
 
-#include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <google/protobuf/util/delimited_message_util.h>
 #include <unistd.h>
 
 #include <iostream>
+#include <optional>
 
-#include "third_party/bazel_protos/worker_protocol.pb.h"
 #include "tools/worker/work_processor.h"
+#include "tools/worker/worker_protocol.h"
 
 // How Swift Incremental Compilation Works
 // =======================================
@@ -76,13 +75,6 @@
 // it can find them as well.
 
 int CompileWithWorker(const std::vector<std::string> &args) {
-  // Set up the input and output streams used to communicate with Bazel over
-  // stdin and stdout.
-  google::protobuf::io::FileInputStream file_input_stream(STDIN_FILENO);
-  file_input_stream.SetCloseOnDelete(false);
-  google::protobuf::io::FileOutputStream file_output_stream(STDOUT_FILENO);
-  file_output_stream.SetCloseOnDelete(false);
-
   // Pass the "universal arguments" to the Swift work processor. They will be
   // rewritten to replace any placeholders if necessary, and then passed at the
   // beginning of any process invocation. Note that these arguments include the
@@ -90,26 +82,18 @@ int CompileWithWorker(const std::vector<std::string> &args) {
   WorkProcessor swift_worker(args);
 
   while (true) {
-    blaze::worker::WorkRequest request;
-    if (!google::protobuf::util::ParseDelimitedFromZeroCopyStream(
-            &request, &file_input_stream, nullptr)) {
+    std::optional<bazel_rules_swift::worker_protocol::WorkRequest> request =
+        bazel_rules_swift::worker_protocol::ReadWorkRequest(std::cin);
+    if (!request) {
       std::cerr << "Could not read WorkRequest from stdin. Killing worker "
                 << "process.\n";
       return 254;
     }
 
-    blaze::worker::WorkResponse response;
-    swift_worker.ProcessWorkRequest(request, &response);
+    bazel_rules_swift::worker_protocol::WorkResponse response;
+    swift_worker.ProcessWorkRequest(*request, response);
 
-    if (!google::protobuf::util::SerializeDelimitedToZeroCopyStream(
-            response, &file_output_stream)) {
-      std::cerr << "Could not write WorkResponse to stdout. Killing worker "
-                << "process.\n";
-      return 254;
-    }
-    // Flush stdout after writing to ensure that Bazel doesn't hang waiting for
-    // the response due to buffering.
-    file_output_stream.Flush();
+    bazel_rules_swift::worker_protocol::WriteWorkResponse(response, std::cout);
   }
 
   return 0;

--- a/tools/worker/work_processor.h
+++ b/tools/worker/work_processor.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "third_party/bazel_protos/worker_protocol.pb.h"
+#include "tools/worker/worker_protocol.h"
 
 // Manages persistent global state for the Swift worker and processes individual
 // work requests.
@@ -31,8 +31,9 @@ class WorkProcessor {
 
   // Processes the given work request and writes its exit code and stderr output
   // (if any) into the given response.
-  void ProcessWorkRequest(const blaze::worker::WorkRequest &request,
-                          blaze::worker::WorkResponse *response);
+  void ProcessWorkRequest(
+      const bazel_rules_swift::worker_protocol::WorkRequest &request,
+      bazel_rules_swift::worker_protocol::WorkResponse &response);
 
  private:
   std::vector<std::string> universal_args_;

--- a/tools/worker/worker_protocol.cc
+++ b/tools/worker/worker_protocol.cc
@@ -1,0 +1,76 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/worker/worker_protocol.h"
+
+#include <nlohmann/json.hpp>
+
+namespace bazel_rules_swift::worker_protocol {
+
+// Populates an `Input` parsed from JSON. This function satisfies an API
+// requirement of the JSON library, allowing it to automatically parse `Input`
+// values from nested JSON objects.
+void from_json(const ::nlohmann::json &j, Input &input) {
+  // As with the protobuf messages from which these types originate, we supply
+  // default values if any keys are not present.
+  input.path = j.value("path", "");
+  input.digest = j.value("digest", "");
+}
+
+// Populates an `WorkRequest` parsed from JSON. This function satisfies an API
+// requirement of the JSON library (although `WorkRequest` is a top-level object
+// in our schema so we only call it directly).
+void from_json(const ::nlohmann::json &j, WorkRequest &work_request) {
+  // As with the protobuf messages from which these types originate, we supply
+  // default values if any keys are not present.
+  work_request.arguments = j.value("arguments", std::vector<std::string>());
+  work_request.inputs = j.value("inputs", std::vector<Input>());
+  work_request.request_id = j.value("requestId", 0);
+  work_request.cancel = j.value("cancel", false);
+  work_request.verbosity = j.value("verbosity", 0);
+  work_request.sandbox_dir = j.value("sandboxDir", "");
+}
+
+// Populates a JSON object with values from an `WorkResponse`. This function
+// satisfies an API requirement of the JSON library (although `WorkResponse` is
+// a top-level object in our schema so we only call it directly).
+void to_json(::nlohmann::json &j, const WorkResponse &work_response) {
+  j = ::nlohmann::json{{"exitCode", work_response.exit_code},
+                       {"output", work_response.output},
+                       {"requestId", work_response.request_id},
+                       {"wasCancelled", work_response.was_cancelled}};
+}
+
+std::optional<WorkRequest> ReadWorkRequest(std::istream &stream) {
+  std::string line;
+  if (!std::getline(stream, line)) {
+    return std::nullopt;
+  }
+
+  WorkRequest request;
+  from_json(::nlohmann::json::parse(line), request);
+  return request;
+}
+
+void WriteWorkResponse(const WorkResponse &response, std::ostream &stream) {
+  ::nlohmann::json response_json;
+  to_json(response_json, response);
+
+  // Use `dump` with default arguments to get the most compact representation
+  // of the response, and flush stdout after writing to ensure that Bazel
+  // doesn't hang waiting for the response due to buffering.
+  stream << response_json.dump() << std::flush;
+}
+
+}  // namespace bazel_rules_swift::worker_protocol

--- a/tools/worker/worker_protocol.h
+++ b/tools/worker/worker_protocol.h
@@ -1,0 +1,101 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORKER_PROTOCOL_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORKER_PROTOCOL_H_
+
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace bazel_rules_swift::worker_protocol {
+
+// An input file passed into a work request.
+//
+// This struct corresponds to the `blaze.worker.Input` message defined in
+// https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto.
+struct Input {
+  // The path in the file system from which the file should be read.
+  std::string path;
+
+  // An opaque token representing a hash of the file's contents.
+  std::string digest;
+};
+
+// A single work unit that Bazel sent to the worker.
+//
+// This struct corresponds to the `blaze.worker.WorkRequest` message defined in
+// https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto.
+struct WorkRequest {
+  // The command line arguments of the action.
+  std::vector<std::string> arguments;
+
+  // The inputs that the worker is allowed to read during execution of this
+  // request.
+  std::vector<Input> inputs;
+
+  // If 0, this request must be processed alone; otherwise, it is the unique
+  // identifier of a request that can be processed in parallel with other
+  // requests.
+  int request_id;
+
+  // If true, a previously sent `WorkRequest` with the same request ID should be
+  // cancelled.
+  bool cancel;
+
+  // If greater than zero, the worker may output extra debug information to the
+  // worker log via stderr.
+  int verbosity;
+
+  // For multiplex workers, this is the relative path inside the worker's
+  // current working directory where the worker can place inputs and outputs.
+  // This is empty for singleplex workers, which use their current working
+  // directory directly.
+  std::string sandbox_dir;
+};
+
+// A message sent from the worker back to Bazel when it has finished its work on
+// a request.
+//
+// This struct corresponds to the `blaze.worker.WorkResponse` message defined in
+// https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto.
+struct WorkResponse {
+  // The exit status to report for the action.
+  int exit_code;
+
+  // Text printed to the user after the response has been received (for example,
+  // compiler warnings/errors).
+  std::string output;
+
+  // The ID of the `WorkRequest` that this response is associated with.
+  int request_id;
+
+  // Indicates that the corresponding request was cancelled.
+  bool was_cancelled;
+};
+
+// Parses and returns the next `WorkRequest` from the given stream. The format
+// of the stream must be newline-delimited JSON (i.e., each line of the input is
+// a complete JSON object). This function returns `nullopt` if the request could
+// not be read (for example, because the JSON was malformed, or the stream was
+// closed).
+std::optional<WorkRequest> ReadWorkRequest(std::istream &stream);
+
+// Writes the given `WorkResponse` as compact JSON to the given stream.
+void WriteWorkResponse(const WorkResponse &response, std::ostream &stream);
+
+}  // namespace bazel_rules_swift::worker_protocol
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORKER_PROTOCOL_H_


### PR DESCRIPTION
This avoids having the proto compiler—a large dependency—be in the critical path of every Swift compilation.

Upstream version of https://github.com/bazelbuild/rules_swift/pull/657

Fixes https://github.com/bazelbuild/rules_swift/issues/516

PiperOrigin-RevId: 441799750
(cherry picked from commit af37ae712fdea608a9678c289785ce458fdeb5fc)