### PR TITLE
common: port `temp_file` to C++17 and Windows

### DIFF
--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -27,6 +27,14 @@ cc_library(
 cc_library(
     name = "temp_file",
     hdrs = ["temp_file.h"],
+    copts = selects.with_or({
+        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+            "/std:c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    }),
 )
 
 # Consumed by Bazel integration tests.

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -55,6 +55,14 @@ cc_library(
     name = "compile_without_worker",
     srcs = ["compile_without_worker.cc"],
     hdrs = ["compile_without_worker.h"],
+    copts = selects.with_or({
+        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+            "/std:c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    }),
     deps = [
         ":swift_runner",
     ],


### PR DESCRIPTION
Use C++17 more heavily here to avoid the use of `fts.h` making the code
easier to port.  Reduce the string manipulation by using
`std::filesystem::path` and use that to additionally locate the
temporary file location.  Emulate the POSIX semantics for `mkdtemp` and
`mkstemp` as much as possible to provide equivalent behaviour on
Windows.