### PR TITLE
worker: alter includes for Windows friendliness

### DIFF
--- a/tools/worker/compile_with_worker.cc
+++ b/tools/worker/compile_with_worker.cc
@@ -14,8 +14,6 @@
 
 #include "tools/worker/compile_with_worker.h"
 
-#include <unistd.h>
-
 #include <iostream>
 #include <optional>
 

--- a/tools/worker/worker_protocol.h
+++ b/tools/worker/worker_protocol.h
@@ -15,8 +15,10 @@
 #ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORKER_PROTOCOL_H_
 #define BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_WORKER_PROTOCOL_H_
 
-#include <iostream>
 #include <nlohmann/json.hpp>
+
+#include <iostream>
+#include <optional>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Remove an unnecessary inclusion of the Unix standard header
(`unistd.h`).  Add a missing C++ include for `std::optional`.