### PR TITLE
build: make the build constraints for MSVC work

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -15,3 +15,23 @@ filegroup(
         "//:__pkg__",
     ],
 )
+
+config_setting(
+    name = "msvc",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "msvc-cl",
+    },
+    visibility = [
+        "//:__subpackages__",
+    ],
+)
+
+config_setting(
+    name = "clang-cl",
+    flag_values = {
+        "@bazel_tools//tools/cpp:compiler": "clang-cl",
+    },
+    visibility = [
+        "//:__subpackages__",
+    ],
+)

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -15,7 +15,7 @@ cc_library(
     srcs = ["process.cc"],
     hdrs = ["process.h"],
     copts = selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [
@@ -28,7 +28,7 @@ cc_library(
     name = "temp_file",
     hdrs = ["temp_file.h"],
     copts = selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -37,7 +37,7 @@ cc_library(
     ],
     hdrs = ["compile_with_worker.h"],
     copts = selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [
@@ -56,7 +56,7 @@ cc_library(
     srcs = ["compile_without_worker.cc"],
     hdrs = ["compile_without_worker.h"],
     copts = selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [
@@ -82,7 +82,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }) + selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [
@@ -108,7 +108,7 @@ cc_library(
     srcs = ["worker_protocol.cc"],
     hdrs = ["worker_protocol.h"],
     copts = selects.with_or({
-        ("@bazel_tools//tools/cpp:clang-cl", "@bazel_tools//tools/cpp:msvc"): [
+        ("//tools:clang-cl", "//tools:msvc"): [
             "/std:c++17",
         ],
         "//conditions:default": [


### PR DESCRIPTION
This adds a working form of the constraints to get the correct flags by
default when building with cl (MSVC or clang) for Windows.