### PR TITLE
ci: add an initial configuration for Windows builds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -32,6 +32,10 @@ x_defaults:
       - "//test/..."
       - "-//examples/apple/..."
       - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
+  windows_common: &windows_common
+    platform: windows
+    build_targets:
+      - "//tools/..."
 
 tasks:
   macos_latest:
@@ -82,5 +86,10 @@ tasks:
       # has landed on them breaking this project.
       - .bazelci/update_workspace_to_deps_heads.sh
     <<: *linux_common
+
+  windows_last_green:
+    name: "Last Green Bazel"
+    bazel: last_green
+    <<: *windows_common
 
 buildifier: latest

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,5 +7,4 @@ common --incompatible_allow_tags_propagation
 build --macos_minimum_os=10.15
 
 # Make sure no warnings slip into the C++ tools we vendor
-build --copt=-Werror
-build --host_copt=-Werror
+build --features treat_warnings_as_errors


### PR DESCRIPTION
Add a build-only partial CI coverage for Windows.  This should ensure
that we do not regress on the C++ portions of the Windows support.
Having this coverage should enable us to begin focusing on the Starlark
rules support for Windows.

Bump the C++ dependency when building for Windows to C++20 to use
designated initializers.