### PR TITLE
common: fix off-by-one error in `_mktemp_s` call

### DIFF
--- a/tools/common/temp_file.h
+++ b/tools/common/temp_file.h
@@ -54,7 +54,7 @@ class TempFile {
     std::string path = temporary.string();
 
 #if defined(_WIN32)
-    if (errno_t error = _mktemp_s(path.data(), path.size())) {
+    if (errno_t error = _mktemp_s(path.data(), path.size() + 1)) {
       std::cerr << "Failed to create temporary file '" << temporary
                 << "': " << strerror(error) << "\n";
       return nullptr;


### PR DESCRIPTION
`path.size()` would give the size of the string without the trailing
null terminator, which would then assert (on debug) or abort on opt.
This would prevent the worker from ever executing the child.