### PR TITLE
swift: use executable suffixes for tool invocation

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -322,6 +322,7 @@ swift_toolchain(
   os = "windows",
   root = "{root}",
   version_file = "{version_file}",
+  tool_executable_suffix = ".exe",
 )
 """.format(
             feature_list = ", ".join(['"{}"'.format(feature) for feature in feature_values]),

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -50,7 +50,8 @@ def _all_tool_configs(
         swift_executable,
         toolchain_root,
         use_param_file,
-        additional_tools):
+        additional_tools,
+        tool_executable_suffix):
     """Returns the tool configurations for the Swift toolchain.
 
     Args:
@@ -60,6 +61,8 @@ def _all_tool_configs(
         use_param_file: If True, the compile action should use a param file for
             its arguments.
         additional_tools: Any extra tool inputs to pass to each driver config
+        tool_executable_suffix: The suffix for executable tools to use (e.g.
+            `.exe` on Windows).
 
     Returns:
         A dictionary mapping action name to tool configurations.
@@ -73,6 +76,7 @@ def _all_tool_configs(
         swift_executable = swift_executable,
         tool_inputs = tool_inputs,
         toolchain_root = toolchain_root,
+        tool_executable_suffix = tool_executable_suffix,
         use_param_file = use_param_file,
         worker_mode = "persistent",
     )
@@ -83,6 +87,7 @@ def _all_tool_configs(
             swift_executable = swift_executable,
             tool_inputs = tool_inputs,
             toolchain_root = toolchain_root,
+            tool_executable_suffix = tool_executable_suffix,
             worker_mode = "wrap",
         ),
         swift_action_names.COMPILE: compile_tool_config,
@@ -94,6 +99,7 @@ def _all_tool_configs(
             swift_executable = swift_executable,
             tool_inputs = tool_inputs,
             toolchain_root = toolchain_root,
+            tool_executable_suffix = tool_executable_suffix,
             worker_mode = "wrap",
         ),
         swift_action_names.DUMP_AST: compile_tool_config,
@@ -205,6 +211,7 @@ def _swift_toolchain_impl(ctx):
         toolchain_root = toolchain_root,
         use_param_file = SWIFT_FEATURE_USE_RESPONSE_FILES in ctx.features,
         additional_tools = [ctx.file.version_file],
+        tool_executable_suffix = ctx.attr.tool_executable_suffix,
     )
     all_action_configs = _all_action_configs(
         additional_swiftc_copts = ctx.fragments.swift.copts(),
@@ -309,6 +316,13 @@ An executable that wraps Swift compiler invocations and also provides support
 for incremental compilation using a persistent mode.
 """,
                 executable = True,
+            ),
+            "tool_executable_suffix": attr.string(
+                doc = """\
+The suffix to apply to the tools when invoking them.  This is a platform
+dependent value (e.g. `.exe` on Window).
+                  """,
+                mandatory = False,
             ),
         },
     ),

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -226,6 +226,7 @@ def _driver_tool_config(
         args = [],
         swift_executable = None,
         toolchain_root = None,
+        tool_executable_suffix = "",
         **kwargs):
     """Returns a new Swift toolchain tool configuration for the Swift driver.
 
@@ -254,6 +255,7 @@ def _driver_tool_config(
             toolchain.
         toolchain_root: The root directory of the Swift toolchain, if the
             toolchain provides it.
+        tool_executable_suffix: The suffix for executable tools.
         **kwargs: Additional arguments that will be passed unmodified to
             `swift_toolchain_config.tool_config`.
 
@@ -261,13 +263,15 @@ def _driver_tool_config(
         A new tool configuration.
     """
     if swift_executable:
-        executable = swift_executable
+        executable = swift_executable.path
         args = ["--driver-mode={}".format(driver_mode)] + args
     elif toolchain_root:
         executable = paths.join(toolchain_root, "bin", driver_mode)
     else:
         executable = driver_mode
 
+    if not executable.endswith(tool_executable_suffix):
+        executable = "{}{}".format(executable, tool_executable_suffix)
     return _tool_config(args = args, executable = executable, **kwargs)
 
 def _validate_worker_mode(worker_mode):


### PR DESCRIPTION
When building on Windows, we should suffix the executable tool with the
executable suffix.  This ensures that the worker can actually launch the
process.  If the user specified the swift_executable, ensure that we do
not double suffix the tool.