### PR TITLE
examples: support Windows in dispatch example

### DIFF
--- a/examples/xplatform/dispatch/main.swift
+++ b/examples/xplatform/dispatch/main.swift
@@ -23,6 +23,8 @@
 import Dispatch
 #if os(Linux)
 import Glibc
+#elseif os(Windows)
+import ucrt
 #else
 import Darwin
 #endif


### PR DESCRIPTION
The example code assumed Linux or Darwin are the only platforms.  Teach
it about Windows as well.