### PR TITLE
Add `compilation_context` to `SwiftInfo` modules

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -208,6 +208,39 @@ A `struct` containing the `compilation_context`, `module_map`, and
   `precompiled_module` fields provided as arguments.
 
 
+<a id="#swift_common.create_compilation_context"></a>
+
+## swift_common.create_compilation_context
+
+<pre>
+swift_common.create_compilation_context(<a href="#swift_common.create_compilation_context-defines">defines</a>, <a href="#swift_common.create_compilation_context-srcs">srcs</a>, <a href="#swift_common.create_compilation_context-transitive_modules">transitive_modules</a>)
+</pre>
+
+Cretes a compilation context for a Swift target.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.create_compilation_context-defines"></a>defines |  A list of defines   |  none |
+| <a id="swift_common.create_compilation_context-srcs"></a>srcs |  A list of Swift source files used to compile the target.   |  none |
+| <a id="swift_common.create_compilation_context-transitive_modules"></a>transitive_modules |  A list of modules (as returned by <code>swift_common.create_module</code>) from the transitive dependencies of the target.   |  none |
+
+**RETURNS**
+
+A `struct` containing four fields:
+
+  *   `defines`: A sequence of defines used when compiling the target.
+      Includes the defines for the target and its transitive dependencies.
+  *   `direct_sources`: A sequence of Swift source files used to compile
+      the target.
+  *   `module_maps`: A sequence of module maps used to compile the clang
+      module for this target.
+  *   `swiftmodules`: A sequence of swiftmodules depended on by the
+      target.
+
+
 <a id="#swift_common.create_linking_context_from_compilation_outputs"></a>
 
 ## swift_common.create_linking_context_from_compilation_outputs
@@ -259,7 +292,7 @@ A tuple of `(CcLinkingContext, CcLinkingOutputs)` containing the linking
 ## swift_common.create_module
 
 <pre>
-swift_common.create_module(<a href="#swift_common.create_module-name">name</a>, <a href="#swift_common.create_module-clang">clang</a>, <a href="#swift_common.create_module-is_system">is_system</a>, <a href="#swift_common.create_module-swift">swift</a>)
+swift_common.create_module(<a href="#swift_common.create_module-name">name</a>, <a href="#swift_common.create_module-clang">clang</a>, <a href="#swift_common.create_module-compilation_context">compilation_context</a>, <a href="#swift_common.create_module-is_system">is_system</a>, <a href="#swift_common.create_module-swift">swift</a>)
 </pre>
 
 Creates a value containing Clang/Swift module artifacts of a dependency.
@@ -288,6 +321,7 @@ the set of transitive module names that are propagated by dependencies
 | :------------- | :------------- | :------------- |
 | <a id="swift_common.create_module-name"></a>name |  The name of the module.   |  none |
 | <a id="swift_common.create_module-clang"></a>clang |  A value returned by <code>swift_common.create_clang_module</code> that contains artifacts related to Clang modules, such as a module map or precompiled module. This may be <code>None</code> if the module is a pure Swift module with no generated Objective-C interface.   |  <code>None</code> |
+| <a id="swift_common.create_module-compilation_context"></a>compilation_context |  A value returned from <code>swift_common.create_compilation_context</code> that contains the context needed to compile the module being built. This may be <code>None</code> if the module wasn't compiled from sources.   |  <code>None</code> |
 | <a id="swift_common.create_module-is_system"></a>is_system |  Indicates whether the module is a system module. The default value is <code>False</code>. System modules differ slightly from non-system modules in the way that they are passed to the compiler. For example, non-system modules have their Clang module maps passed to the compiler in both implicit and explicit module builds. System modules, on the other hand, do not have their module maps passed to the compiler in implicit module builds because there is currently no way to indicate that modules declared in a file passed via <code>-fmodule-map-file</code> should be treated as system modules even if they aren't declared with the <code>[system]</code> attribute, and some system modules may not build cleanly with respect to warnings otherwise. Therefore, it is assumed that any module with <code>is_system == True</code> must be able to be found using import search paths in order for implicit module builds to succeed.   |  <code>False</code> |
 | <a id="swift_common.create_module-swift"></a>swift |  A value returned by <code>swift_common.create_swift_module</code> that contains artifacts related to Swift modules, such as the <code>.swiftmodule</code>, <code>.swiftdoc</code>, and/or <code>.swiftinterface</code> files emitted by the compiler. This may be <code>None</code> if the module is a pure C/Objective-C module.   |  <code>None</code> |
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1631,6 +1631,54 @@ def derive_module_name(*args):
         module_name = "_" + module_name
     return module_name
 
+def create_compilation_context(defines, srcs, transitive_modules):
+    """Cretes a compilation context for a Swift target.
+
+    Args:
+        defines: A list of defines
+        srcs: A list of Swift source files used to compile the target.
+        transitive_modules: A list of modules (as returned by
+            `swift_common.create_module`) from the transitive dependencies of
+            the target.
+
+    Returns:
+        A `struct` containing four fields:
+
+        *   `defines`: A sequence of defines used when compiling the target.
+            Includes the defines for the target and its transitive dependencies.
+        *   `direct_sources`: A sequence of Swift source files used to compile
+            the target.
+        *   `module_maps`: A sequence of module maps used to compile the clang
+            module for this target.
+        *   `swiftmodules`: A sequence of swiftmodules depended on by the
+            target.
+    """
+    defines_set = sets.make(defines)
+    module_maps = []
+    swiftmodules = []
+    for module in transitive_modules:
+        if (module.clang and module.clang.module_map and
+            (module.clang.precompiled_module or not module.is_system)):
+            module_maps.append(module.clang.module_map)
+
+        swift_module = module.swift
+        if not swift_module:
+            continue
+        swiftmodules.append(swift_module.swiftmodule)
+        if swift_module.defines:
+            defines_set = sets.union(
+                defines_set,
+                sets.make(swift_module.defines),
+            )
+
+    # Tuples are used instead of lists since they need to be frozen
+    return struct(
+        defines = tuple(sets.to_list(defines_set)),
+        direct_sources = tuple(srcs),
+        module_maps = tuple(module_maps),
+        swiftmodules = tuple(swiftmodules),
+    )
+
 def compile(
         *,
         actions,
@@ -1782,18 +1830,11 @@ def compile(
         merged_providers.swift_info.transitive_modules.to_list()
     )
 
-    transitive_swiftmodules = []
-    defines_set = sets.make(defines)
-    for module in transitive_modules:
-        swift_module = module.swift
-        if not swift_module:
-            continue
-        transitive_swiftmodules.append(swift_module.swiftmodule)
-        if swift_module.defines:
-            defines_set = sets.union(
-                defines_set,
-                sets.make(swift_module.defines),
-            )
+    compilation_context = create_compilation_context(
+        defines = defines,
+        srcs = srcs,
+        transitive_modules = transitive_modules,
+    )
 
     # We need this when generating the VFS overlay file and also when
     # configuring inputs for the compile action, so it's best to precompute it
@@ -1808,7 +1849,7 @@ def compile(
         )
         write_vfsoverlay(
             actions = actions,
-            swiftmodules = transitive_swiftmodules,
+            swiftmodules = compilation_context.swiftmodules,
             vfsoverlay_file = vfsoverlay_file,
             virtual_swiftmodule_root = _SWIFTMODULES_VFS_ROOT,
         )
@@ -1819,7 +1860,7 @@ def compile(
         additional_inputs = additional_inputs,
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_providers.cc_info.compilation_context,
-        defines = sets.to_list(defines_set),
+        defines = compilation_context.defines,
         genfiles_dir = feature_configuration._genfiles_dir,
         is_swift = True,
         module_name = module_name,
@@ -1829,7 +1870,7 @@ def compile(
         objc_info = merged_providers.objc_info,
         source_files = srcs,
         transitive_modules = transitive_modules,
-        transitive_swiftmodules = transitive_swiftmodules,
+        transitive_swiftmodules = compilation_context.swiftmodules,
         user_compile_flags = copts,
         vfsoverlay_file = vfsoverlay_file,
         vfsoverlay_search_path = _SWIFTMODULES_VFS_ROOT,
@@ -1918,6 +1959,7 @@ def compile(
             module_map = compile_outputs.generated_module_map_file,
             precompiled_module = precompiled_module,
         ),
+        compilation_context = compilation_context,
         is_system = False,
         swift = create_swift_module(
             defines = defines,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -235,7 +235,13 @@ provider.
     },
 )
 
-def create_module(*, name, clang = None, is_system = False, swift = None):
+def create_module(
+        *,
+        name,
+        clang = None,
+        compilation_context = None,
+        is_system = False,
+        swift = None):
     """Creates a value containing Clang/Swift module artifacts of a dependency.
 
     It is possible for both `clang` and `swift` to be present; this is the case
@@ -260,6 +266,10 @@ def create_module(*, name, clang = None, is_system = False, swift = None):
             contains artifacts related to Clang modules, such as a module map or
             precompiled module. This may be `None` if the module is a pure Swift
             module with no generated Objective-C interface.
+        compilation_context: A value returned from
+            `swift_common.create_compilation_context` that contains the
+            context needed to compile the module being built. This may be `None`
+            if the module wasn't compiled from sources.
         is_system: Indicates whether the module is a system module. The default
             value is `False`. System modules differ slightly from non-system
             modules in the way that they are passed to the compiler. For
@@ -286,6 +296,7 @@ def create_module(*, name, clang = None, is_system = False, swift = None):
     """
     return struct(
         clang = clang,
+        compilation_context = compilation_context,
         is_system = is_system,
         name = name,
         swift = swift,

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -32,6 +32,7 @@ load(
 load(
     ":compiling.bzl",
     "compile",
+    "create_compilation_context",
     "derive_module_name",
     "precompile_clang_module",
 )
@@ -59,6 +60,7 @@ swift_common = struct(
     compile = compile,
     configure_features = configure_features,
     create_clang_module = create_clang_module,
+    create_compilation_context = create_compilation_context,
     create_linking_context_from_compilation_outputs = create_linking_context_from_compilation_outputs,
     create_module = create_module,
     create_swift_info = create_swift_info,


### PR DESCRIPTION
This adds a new struct to `SwiftInfo` modules that exposes the information used during compilation of a Swift target. The main use case is aspects, in particular ones for IDE integration. The attributes exposed mirror some of those found in `CcInfo.compliation_context` and `ObjcProvider`.

The initial attributes are ones that I personally need right now, but we can add more later as they are identified.