### PR TITLE
Fix test ... for linking

### DIFF
--- a/test/fixtures/linking/BUILD
+++ b/test/fixtures/linking/BUILD
@@ -1,4 +1,5 @@
 load("//swift:swift.bzl", "swift_binary")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 load(":fake_framework.bzl", "fake_framework")
 
 package(
@@ -7,10 +8,12 @@ package(
 
 fake_framework(
     name = "framework",
+    tags = FIXTURE_TAGS,
 )
 
 swift_binary(
     name = "bin",
     srcs = ["main.swift"],
+    tags = FIXTURE_TAGS,
     deps = [":framework"],
 )


### PR DESCRIPTION
This test adds invalid frameworks just to build a command line for
testing, this marks them as manual so they aren't built when testing
everything.