### PR TITLE
Revert "Add `compilation_context` to `SwiftInfo` (#815)"

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -208,39 +208,6 @@ A `struct` containing the `compilation_context`, `module_map`, and
   `precompiled_module` fields provided as arguments.
 
 
-<a id="#swift_common.create_compilation_context"></a>
-
-## swift_common.create_compilation_context
-
-<pre>
-swift_common.create_compilation_context(<a href="#swift_common.create_compilation_context-defines">defines</a>, <a href="#swift_common.create_compilation_context-srcs">srcs</a>, <a href="#swift_common.create_compilation_context-transitive_modules">transitive_modules</a>)
-</pre>
-
-Cretes a compilation context for a Swift target.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="swift_common.create_compilation_context-defines"></a>defines |  A list of defines   |  none |
-| <a id="swift_common.create_compilation_context-srcs"></a>srcs |  A list of Swift source files used to compile the target.   |  none |
-| <a id="swift_common.create_compilation_context-transitive_modules"></a>transitive_modules |  A list of modules (as returned by <code>swift_common.create_module</code>) from the transitive dependencies of the target.   |  none |
-
-**RETURNS**
-
-A `struct` containing four fields:
-
-  *   `defines`: A sequence of defines used when compiling the target.
-      Includes the defines for the target and its transitive dependencies.
-  *   `direct_sources`: A sequence of Swift source files used to compile
-      the target.
-  *   `module_maps`: A sequence of module maps used to compile the clang
-      module for this target.
-  *   `swiftmodules`: A sequence of swiftmodules depended on by the
-      target.
-
-
 <a id="#swift_common.create_linking_context_from_compilation_outputs"></a>
 
 ## swift_common.create_linking_context_from_compilation_outputs
@@ -292,7 +259,7 @@ A tuple of `(CcLinkingContext, CcLinkingOutputs)` containing the linking
 ## swift_common.create_module
 
 <pre>
-swift_common.create_module(<a href="#swift_common.create_module-name">name</a>, <a href="#swift_common.create_module-clang">clang</a>, <a href="#swift_common.create_module-compilation_context">compilation_context</a>, <a href="#swift_common.create_module-is_system">is_system</a>, <a href="#swift_common.create_module-swift">swift</a>)
+swift_common.create_module(<a href="#swift_common.create_module-name">name</a>, <a href="#swift_common.create_module-clang">clang</a>, <a href="#swift_common.create_module-is_system">is_system</a>, <a href="#swift_common.create_module-swift">swift</a>)
 </pre>
 
 Creates a value containing Clang/Swift module artifacts of a dependency.
@@ -321,7 +288,6 @@ the set of transitive module names that are propagated by dependencies
 | :------------- | :------------- | :------------- |
 | <a id="swift_common.create_module-name"></a>name |  The name of the module.   |  none |
 | <a id="swift_common.create_module-clang"></a>clang |  A value returned by <code>swift_common.create_clang_module</code> that contains artifacts related to Clang modules, such as a module map or precompiled module. This may be <code>None</code> if the module is a pure Swift module with no generated Objective-C interface.   |  <code>None</code> |
-| <a id="swift_common.create_module-compilation_context"></a>compilation_context |  A value returned from <code>swift_common.create_compilation_context</code> that contains the context needed to compile the module being built. This may be <code>None</code> if the module wasn't compiled from sources.   |  <code>None</code> |
 | <a id="swift_common.create_module-is_system"></a>is_system |  Indicates whether the module is a system module. The default value is <code>False</code>. System modules differ slightly from non-system modules in the way that they are passed to the compiler. For example, non-system modules have their Clang module maps passed to the compiler in both implicit and explicit module builds. System modules, on the other hand, do not have their module maps passed to the compiler in implicit module builds because there is currently no way to indicate that modules declared in a file passed via <code>-fmodule-map-file</code> should be treated as system modules even if they aren't declared with the <code>[system]</code> attribute, and some system modules may not build cleanly with respect to warnings otherwise. Therefore, it is assumed that any module with <code>is_system == True</code> must be able to be found using import search paths in order for implicit module builds to succeed.   |  <code>False</code> |
 | <a id="swift_common.create_module-swift"></a>swift |  A value returned by <code>swift_common.create_swift_module</code> that contains artifacts related to Swift modules, such as the <code>.swiftmodule</code>, <code>.swiftdoc</code>, and/or <code>.swiftinterface</code> files emitted by the compiler. This may be <code>None</code> if the module is a pure C/Objective-C module.   |  <code>None</code> |
 

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -235,13 +235,7 @@ provider.
     },
 )
 
-def create_module(
-        *,
-        name,
-        clang = None,
-        compilation_context = None,
-        is_system = False,
-        swift = None):
+def create_module(*, name, clang = None, is_system = False, swift = None):
     """Creates a value containing Clang/Swift module artifacts of a dependency.
 
     It is possible for both `clang` and `swift` to be present; this is the case
@@ -266,10 +260,6 @@ def create_module(
             contains artifacts related to Clang modules, such as a module map or
             precompiled module. This may be `None` if the module is a pure Swift
             module with no generated Objective-C interface.
-        compilation_context: A value returned from
-            `swift_common.create_compilation_context` that contains the
-            context needed to compile the module being built. This may be `None`
-            if the module wasn't compiled from sources.
         is_system: Indicates whether the module is a system module. The default
             value is `False`. System modules differ slightly from non-system
             modules in the way that they are passed to the compiler. For
@@ -296,7 +286,6 @@ def create_module(
     """
     return struct(
         clang = clang,
-        compilation_context = compilation_context,
         is_system = is_system,
         name = name,
         swift = swift,

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -32,7 +32,6 @@ load(
 load(
     ":compiling.bzl",
     "compile",
-    "create_compilation_context",
     "derive_module_name",
     "precompile_clang_module",
 )
@@ -60,7 +59,6 @@ swift_common = struct(
     compile = compile,
     configure_features = configure_features,
     create_clang_module = create_clang_module,
-    create_compilation_context = create_compilation_context,
     create_linking_context_from_compilation_outputs = create_linking_context_from_compilation_outputs,
     create_module = create_module,
     create_swift_info = create_swift_info,


### PR DESCRIPTION
This reverts commit 42036b5212fedcd0e1377100d34d7a83e79e7ed6.

```
Traceback (most recent call last):
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/swift_library.bzl", line 173, column 93, in _swift_library_impl
         module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/compiling.bzl", line 1883, column 29, in compile
         run_toolchain_action(
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/actions.bzl", line 249, column 42, in run_toolchain_action
         action_inputs = _apply_action_configs(
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/actions.bzl", line 136, column 52, in _apply_action_configs
         action_inputs = _apply_configurator(
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/actions.bzl", line 67, column 28, in _apply_configurator
         return configurator(prerequisites, args)
File "/private/var/tmp/_bazel_ksmiley/c8513c989333be3c89713e16206869b2/external/build_bazel_rules_swift/swift/internal/compiling.bzl", line 1425, column 31, in _dependencies_swiftmodules_vfsoverlay_configurator
         inputs = swiftmodules + [prerequisites.vfsoverlay_file],
Error: unsupported binary operation: tuple + list
```