### PR TITLE
swift: introduce a feature to control debug info on Windows

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -30,6 +30,7 @@ load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_BITCODE_EMBEDDED",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
+    "SWIFT_FEATURE_CODEVIEW_DEBUG_INFO",
     "SWIFT_FEATURE_COVERAGE",
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DBG",
@@ -506,10 +507,28 @@ def compile_action_configs(
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
+                swift_toolchain_config.add_arg("-g"),
+                swift_toolchain_config.add_arg("-debug-info-format=codeview"),
+            ],
+            features = [
+                [SWIFT_FEATURE_DBG, SWIFT_FEATURE_CODEVIEW_DEBUG_INFO],
+                [SWIFT_FEATURE_FASTBUILD, SWIFT_FEATURE_CODEVIEW_DEBUG_INFO],
+                [SWIFT_FEATURE_FULL_DEBUG_INFO, SWIFT_FEATURE_CODEVIEW_DEBUG_INFO],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
                 swift_toolchain_config.add_arg("-gline-tables-only"),
             ],
             features = [SWIFT_FEATURE_FASTBUILD],
-            not_features = [SWIFT_FEATURE_FULL_DEBUG_INFO],
+            not_features = [
+                [SWIFT_FEATURE_FULL_DEBUG_INFO],
+                [SWIFT_FEATURE_CODEVIEW_DEBUG_INFO],
+            ],
         ),
 
         # Make paths written into debug info workspace-relative.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -98,6 +98,9 @@ SWIFT_FEATURE_ENABLE_TESTING = "swift.enable_testing"
 # warnings otherwise.
 SWIFT_FEATURE_FULL_DEBUG_INFO = "swift.full_debug_info"
 
+# Use CodeView debug information, which enables generation of PDBs for debugging.
+SWIFT_FEATURE_CODEVIEW_DEBUG_INFO = "swift.codeview_debug_info"
+
 # If enabled, the compilation action for a target will produce an index store.
 # https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -26,6 +26,7 @@ Skylib.
 
 load(
     "@build_bazel_rules_swift//swift/internal:feature_names.bzl",
+    "SWIFT_FEATURE_CODEVIEW_DEBUG_INFO",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
@@ -313,6 +314,7 @@ def _create_windows_toolchain(repository_ctx):
 
     root = path_to_swiftc.dirname.dirname
     enabled_features = [
+        SWIFT_FEATURE_CODEVIEW_DEBUG_INFO,
         SWIFT_FEATURE_DEBUG_PREFIX_MAP,
         SWIFT_FEATURE_ENABLE_BATCH_MODE,
         SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES,


### PR DESCRIPTION
Windows poorly supports DWARF (or rather DWARF poorly supports Windows)
and the swift driver poorly supports CodeView.  However, both are useful
in different scenarios.  Add a feature to use codeview, and enable it by
default.  The default is important as DWARF cannot supported by link
which is picked up as the default linker.