### PR TITLE
tools: port mkdir_and_run to work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cmd text eol=crlf

--- a/tools/mkdir_and_run/BUILD
+++ b/tools/mkdir_and_run/BUILD
@@ -1,8 +1,17 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
 licenses(["notice"])
 
-sh_binary(
+native_binary(
     name = "mkdir_and_run",
-    srcs = ["mkdir_and_run.sh"],
+    src = select({
+        "@bazel_tools//src/conditions:host_windows": "mkdir_and_run.cmd",
+        "//conditions:default": "mkdir_and_run.sh",
+    }),
+    out = select({
+        "@bazel_tools//src/conditions:host_windows": "mkdir_and_run.cmd",
+        "//conditions:default": "mkdir_and_run.sh",
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/tools/mkdir_and_run/mkdir_and_run.cmd
+++ b/tools/mkdir_and_run/mkdir_and_run.cmd
@@ -1,0 +1,23 @@
+
+@echo off
+
+setlocal
+
+set argc=0
+FOR %%a IN (%*) DO SET /A argc+=1
+
+IF %argc% LSS 2 (
+  echo ERROR: Need at least two arguments. 1>&2
+  exit /b 1
+)
+
+set location=%1
+shift
+
+set executable=%1
+shift
+
+md %location:/=\%
+"%executable:/=\%" %*
+
+endlocal


### PR DESCRIPTION
Prefer a cmd script over bash on Windows.  This allows this command to
be used across platforms.