### PR TITLE
Fix empty glob in toolchains

### DIFF
--- a/tools/dump_toolchains/dump_toolchains.sh
+++ b/tools/dump_toolchains/dump_toolchains.sh
@@ -26,6 +26,7 @@ readonly toolchain_directories=(
   ~/Library/Developer/Toolchains
 )
 
+shopt -s nullglob
 for toolchain_directory in "${toolchain_directories[@]}"
 do
   for toolchain in "$toolchain_directory"/*.xctoolchain


### PR DESCRIPTION
Otherwise the glob returns 1 entry with the literal *