### PR TITLE
CI: complete the Windows CI coverage

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,12 +40,24 @@ x_defaults:
       - "-//test:output_file_map_default"
   windows_common: &windows_common
     platform: windows
+    environment:
+      SWIFT_VERSION: 6.1.0
+      PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%Path%"
+      SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows
       - "--strategy=SwiftCompile="
+      - "--repo_env=SDKROOT=%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
+      - "--repo_env=Path=%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%Path%"
     build_targets:
       - "//tools/..."
+    test_flags:
+     - "--compiler=clang-cl"
+    test_targets:
+      - "//examples/..."
+      - "-//examples/apple/..."
+      - "-//examples/xplatform/grpc/..." # TODO: Fix gRPC on Windows
 
 tasks:
   macos_7:
@@ -117,11 +129,14 @@ tasks:
       - .bazelci/update_workspace_to_deps_heads.sh
     <<: *linux_common
 
-  # TODO: re-enable when Windows in Bazel CI is properly configured for Swift.
-  # windows_last_green:
-  #   name: "Last Green Bazel"
-  #   bazel: last_green
-  #   <<: *windows_common
+  windows_last_green:
+    name: "Last Green Bazel"
+    bazel: last_green
+    batch_commands:
+      - echo --- Downloading and installing Swift %SWIFT_VERSION%
+      - curl.exe -L https://download.swift.org/swift-6.1-release/windows10/swift-6.1-RELEASE/swift-6.1-RELEASE-windows10.exe -o %TEMP%\installer.exe
+      - PowerShell Start-Process -FilePath ${env:TEMP}\installer.exe -ArgumentList(\"/install\", \"/passive\", \"/norestart\", \"/log log.txt\") -Wait -PassThru -Verb RunAs
+    <<: *windows_common
 
   doc_tests:
     name: "Doc tests"


### PR DESCRIPTION
Extend the Windows CI to include the tests as well.  This will mostly
complete the Windows support (the remaining pieces remain in supporting
the Windows ARM64 build host).