### PR TITLE
Upgrade gRPC to 1.7.3

### DIFF
--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -58,7 +58,10 @@ swift_grpc_library(
 swift_binary(
     name = "echo_server",
     srcs = ["server_main.swift"],
-    deps = [":echo_server_services_swift"],
+    deps = [
+        ":echo_proto_swift",
+        ":echo_server_services_swift",
+    ],
 )
 
 swift_test(

--- a/examples/xplatform/grpc/client_main.swift
+++ b/examples/xplatform/grpc/client_main.swift
@@ -14,19 +14,45 @@
 
 import Foundation
 import SwiftProtobuf
+import GRPC
+import NIOCore
+import NIOPosix
 import examples_xplatform_grpc_echo_proto
 import examples_xplatform_grpc_echo_client_services_swift
 
+// Setup an `EventLoopGroup` for the connection to run on.
+//
+// See: https://github.com/apple/swift-nio#eventloops-and-eventloopgroups
+let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+// Make sure the group is shutdown when we're done with it.
+defer {
+  try! group.syncShutdownGracefully()
+}
+
+// Configure the channel, we're not using TLS so the connection is `insecure`.
+let channel = try GRPCChannelPool.with(
+  target: .host("localhost", port: 9000),
+  transportSecurity: .plaintext,
+  eventLoopGroup: group
+)
+
 // Initialize the client using the same address the server is started on.
-let client = RulesSwift_Examples_Grpc_EchoServiceServiceClient(address: "0.0.0.0:9000",
-                                                               secure: false)
+let client = RulesSwift_Examples_Grpc_EchoServiceClient(channel: channel)
 
 // Construct a request to the echo service.
-var request = RulesSwift_Examples_Grpc_EchoRequest()
-request.contents = "Hello, world!"
-let timestamp = Google_Protobuf_Timestamp(date: Date())
-request.extra = try! Google_Protobuf_Any(message: timestamp)
+var request = RulesSwift_Examples_Grpc_EchoRequest.with {
+  $0.contents = "Hello, world!"
+  let timestamp = Google_Protobuf_Timestamp(date: Date())
+  request.extra = try! Google_Protobuf_Any(message: timestamp)
+}
+
+let call = client.echo(request)
 
 // Make the remote method call and print the response we receive.
-let response = try client.echo(request)
-print(response.contents)
+do {
+  let response = try call.response.wait()
+  print(response.contents)
+} catch {
+  print("Echo failed: \(error)")
+}

--- a/examples/xplatform/grpc/client_unit_test.swift
+++ b/examples/xplatform/grpc/client_unit_test.swift
@@ -21,14 +21,15 @@ import examples_xplatform_grpc_echo_proto
 class ClientUnitTest {
 
   func testSynchronousCall() throws {
-    let client: RulesSwift_Examples_Grpc_EchoServiceService = {
-      let stub = RulesSwift_Examples_Grpc_EchoServiceServiceTestStub()
-      stub.echoResponses.append(RulesSwift_Examples_Grpc_EchoResponse.with { response in
+    let client: RulesSwift_Examples_Grpc_EchoServiceClientProtocol = {
+      let stub = RulesSwift_Examples_Grpc_EchoServiceTestClient()
+      stub.enqueueEchoResponse(RulesSwift_Examples_Grpc_EchoResponse.with { response in
         response.contents = "Hello"
       })
       return stub
    }()
-   let response = try client.echo(RulesSwift_Examples_Grpc_EchoRequest())
+   let call = client.echo(RulesSwift_Examples_Grpc_EchoRequest())
+   let response = try! call.response.wait()
    XCTAssertEqual(response.contents, "Hello")
   }
 }

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -60,19 +60,64 @@ def swift_rules_dependencies():
     _maybe(
         http_archive,
         name = "com_github_apple_swift_protobuf",
-        urls = ["https://github.com/apple/swift-protobuf/archive/1.12.0.tar.gz"],
-        sha256 = "f50dae44d998b49c271bf9288f2e1ff564bb950d8f276b43dce2a82079b22e25",
-        strip_prefix = "swift-protobuf-1.12.0/",
+        urls = ["https://github.com/apple/swift-protobuf/archive/1.19.0.tar.gz"],
+        sha256 = "f057930b9dbd17abeaaceaa45e9f8b3e87188c05211710563d2311b9edf490aa",
+        strip_prefix = "swift-protobuf-1.19.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc_swift",
-        urls = ["https://github.com/grpc/grpc-swift/archive/0.9.0.tar.gz"],
-        sha256 = "bcaaa8c44c0d29902bf4a5c6df593286338659ffa0110cc11a0fd8fcb890feb7",
-        strip_prefix = "grpc-swift-0.9.0/",
+        urls = ["https://github.com/grpc/grpc-swift/archive/1.7.3.tar.gz"],
+        sha256 = "833a150bdebb8ec0282fd91761aec0705a9b05645de42619b60fb6b9ec04b786",
+        strip_prefix = "grpc-swift-1.7.3/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_nio",
+        urls = ["https://github.com/apple/swift-nio/archive/2.40.0.tar.gz"],
+        sha256 = "fd0418e9cc64d5c05012b37147c819978ac162c5ec7aa874a488846f6b3a90e6",
+        strip_prefix = "swift-nio-2.40.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_nio_http2",
+        urls = ["https://github.com/apple/swift-nio-http2/archive/1.21.0.tar.gz"],
+        sha256 = "f034bd793d2170e1b85b6feb8cb796154d96ae43ff3a912ac6b992367faef09c",
+        strip_prefix = "swift-nio-http2-1.21.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_nio_transport_services",
+        urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.12.0.tar.gz"],
+        sha256 = "bf0fa49564263048b988b9767a05ca2c43c167d27172886c5f070720c3adbe8d",
+        strip_prefix = "swift-nio-transport-services-1.12.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_nio_extras",
+        urls = ["https://github.com/apple/swift-nio-extras/archive/1.11.0.tar.gz"],
+        sha256 = "57ef8b0a19bd3d4233ee18d4b96c0d2fc95d66ae53c5d6d2105e1428f672bd0d",
+        strip_prefix = "swift-nio-extras-1.11.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_log",
+        urls = ["https://github.com/apple/swift-log/archive/1.4.2.tar.gz"],
+        sha256 = "de51662b35f47764b6e12e9f1d43e7de28f6dd64f05bc30a318cf978cf3bc473",
+        strip_prefix = "swift-log-1.4.2/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_log/BUILD.overlay",
     )
 
     _maybe(

--- a/third_party/com_github_apple_swift_log/BUILD.overlay
+++ b/third_party/com_github_apple_swift_log/BUILD.overlay
@@ -1,0 +1,18 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "Logging",
+    srcs = glob([
+        "Sources/Logging/**/*.swift",
+    ]),
+    module_name = "Logging",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_apple_swift_nio/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio/BUILD.overlay
@@ -1,0 +1,223 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "NIOCore",
+    srcs = glob([
+        "Sources/NIOCore/*.swift",
+    ]),
+    deps = [
+        ":NIOConcurrencyHelpers",
+        ":CNIOLinux",
+    ],
+    module_name = "NIOCore",
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "NIOEmbedded",
+    srcs = glob([
+        "Sources/NIOEmbedded/*.swift",
+    ]),
+    module_name = "NIOEmbedded",
+    visibility = ["//visibility:public"],
+    deps = [
+        "NIOCore",
+        "NIOConcurrencyHelpers",
+        "_NIODataStructures",
+    ],
+)
+
+swift_library(
+    name = "NIOPosix",
+    srcs = glob([
+        "Sources/NIOPosix/*.swift",
+    ]),
+    module_name = "NIOPosix",
+    visibility = ["//visibility:public"],
+    deps = [
+        "CNIOLinux",
+        "CNIODarwin",
+        "CNIOWindows",
+        "NIOConcurrencyHelpers",
+        "NIOCore",
+        "_NIODataStructures",
+    ],
+)
+
+swift_library(
+    name = "NIO",
+    srcs = glob([
+        "Sources/NIO/*.swift",
+    ]),
+    module_name = "NIO",
+    visibility = ["//visibility:public"],
+    deps = [
+        "NIOCore",
+        "NIOEmbedded",
+        "NIOPosix",
+    ],
+)
+
+swift_library(
+    name = "_NIOConcurrency",
+    srcs = glob([
+        "Sources/_NIOConcurrency/*.swift",
+    ]),
+    module_name = "_NIOConcurrency",
+    visibility = ["//visibility:public"],
+    deps = ["NIO", "NIOCore"],
+)
+
+swift_library(
+    name = "NIOFoundationCompat",
+    srcs = glob([
+        "Sources/NIOFoundationCompat/*.swift",
+    ]),
+    module_name = "NIOFoundationCompat",
+    visibility = ["//visibility:public"],
+    deps = [
+        "NIO",
+        "NIOCore",
+    ],
+)
+
+cc_library(
+    name = "CNIOAtomics",
+    srcs = glob([
+        "Sources/CNIOAtomics/**/*.c",
+        "Sources/CNIOAtomics/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CNIOAtomics/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/CNIOAtomics/include"],
+    tags = ["swift_module=CNIOAtomics"],
+)
+
+cc_library(
+    name = "CNIOSHA1",
+    srcs = glob([
+        "Sources/CNIOSHA1/**/*.c",
+        "Sources/CNIOSHA1/**/*.cc",
+    ]),
+    hdrs = [
+        "Sources/CNIOSHA1/**/*.h",
+    ],
+    copts = [],
+    includes = ["Sources/CNIOSHA1/include"],
+    tags = ["swift_module=CNIOSHA1"],
+)
+
+cc_library(
+    name = "CNIOLinux",
+    srcs = glob([
+        "Sources/CNIOLinux/**/*.c",
+        "Sources/CNIOLinux/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CNIOLinux/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/CNIOLinux/include"],
+    tags = ["swift_module=CNIOLinux"],
+)
+
+cc_library(
+    name = "CNIODarwin",
+    srcs = glob([
+        "Sources/CNIODarwin/**/*.c",
+        "Sources/CNIODarwin/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CNIODarwin/**/*.h",
+    ]),
+    copts = ["-D__APPLE_USE_RFC_3542"],
+    includes = ["Sources/CNIODarwin/include"],
+    tags = ["swift_module=CNIODarwin"],
+)
+
+cc_library(
+    name = "CNIOWindows",
+    srcs = glob([
+        "Sources/CNIOWindows/**/*.c",
+        "Sources/CNIOWindows/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CNIOWindows/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/CNIOWindows/include"],
+    tags = ["swift_module=CNIOWindows"],
+)
+
+swift_library(
+    name = "NIOTLS",
+    srcs = glob([
+        "Sources/NIOTLS/*.swift",
+    ]),
+    module_name = "NIOTLS",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NIOCore",
+    ],
+)
+
+swift_library(
+    name = "NIOHTTP1",
+    srcs = glob([
+        "Sources/NIOHTTP1/*.swift",
+    ]),
+    module_name = "NIOHTTP1",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NIOCore",
+        ":CNIOHTTPParser",
+    ],
+)
+
+swift_library(
+    name = "NIOConcurrencyHelpers",
+    srcs = glob([
+        "Sources/NIOConcurrencyHelpers/*.swift",
+    ]),
+    module_name = "NIOConcurrencyHelpers",
+    visibility = ["//visibility:public"],
+    deps = ["CNIOAtomics"],
+)
+
+swift_library(
+    name = "_NIODataStructures",
+    srcs = glob([
+        "Sources/_NIODataStructures/*.swift",
+    ]),
+    module_name = "_NIODataStructures",
+    visibility = ["//visibility:public"],
+    deps = [
+        "NIOCore",
+        "NIOConcurrencyHelpers",
+        "CNIOHTTPParser",
+    ],
+)
+
+cc_library(
+    name = "CNIOHTTPParser",
+    srcs = glob([
+        "Sources/CNIOHTTPParser/**/*.c",
+        "Sources/CNIOHTTPParser/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CNIOHTTPParser/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/CNIOHTTPParser/include"],
+    tags = ["swift_module=CNIOHTTPParser"],
+)

--- a/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
@@ -1,0 +1,21 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "NIOExtras",
+    srcs = glob([
+        "Sources/NIOExtras/**/*.swift",
+    ]),
+    deps = [
+        "@com_github_apple_swift_nio//:NIOCore",
+    ],
+    module_name = "NIOExtras",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
@@ -1,0 +1,35 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "NIOHPACK",
+    srcs = glob([
+        "Sources/NIOHPACK/**/*.swift",
+    ]),
+    deps = [
+        "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOHTTP1",
+        "@com_github_apple_swift_nio//:NIOTLS",
+    ],
+    module_name = "NIOHPACK",
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "NIOHTTP2",
+    srcs = glob([
+        "Sources/NIOHTTP2/**/*.swift",
+    ]),
+    deps = [
+        ":NIOHPACK",
+    ],
+    module_name = "NIOHTTP2",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
@@ -1,0 +1,22 @@
+load(
+    "@build_bazel_apple_support//rules:universal_binary.bzl",
+    "universal_binary",
+)
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+swift_library(
+    name = "NIOTransportServices",
+    srcs = glob([
+        "Sources/NIOTransportServices/**/*.swift",
+    ]),
+    deps = [
+        "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOFoundationCompat",
+    ],
+    module_name = "NIOTransportServices",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -8,59 +8,44 @@ load(
     "swift_library",
 )
 
-swift_library(
-    name = "SwiftGRPC",
+cc_library(
+    name = "CGRPCZlib",
     srcs = glob([
-        "Sources/SwiftGRPC/**/*.swift",
+        "Sources/CGRPCZlib/**/*.c",
+        "Sources/CGRPCZlib/**/*.cc",
+    ]),
+    hdrs = glob([
+        "Sources/CGRPCZlib/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/CGRPCZlib/include"],
+    tags = ["swift_module=CGRPCZlib"],
+)
+
+swift_library(
+    name = "GRPC",
+    srcs = glob([
+        "Sources/GRPC/**/*.swift",
     ]),
     copts = ["-DSWIFT_PACKAGE"],  # activates CgRPC imports
-    module_name = "SwiftGRPC",
+    module_name = "GRPC",
     visibility = ["//visibility:public"],
     deps = [
-        ":CgRPC",
+        ":CGRPCZlib",
+        "@com_github_apple_swift_log//:Logging",
+        "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio_extras//:NIOExtras",
+        "@com_github_apple_swift_nio_http2//:NIOHPACK",
+        "@com_github_apple_swift_nio_http2//:NIOHTTP2",
+        "@com_github_apple_swift_nio_transport_services//:NIOTransportServices",
         "@com_github_apple_swift_protobuf//:SwiftProtobuf",
     ],
 )
 
-cc_library(
-    name = "BoringSSL",
-    srcs = glob([
-        "Sources/BoringSSL/crypto/**/*.c",
-        "Sources/BoringSSL/crypto/**/*.h",
-        "Sources/BoringSSL/ssl/**/*.cc",
-        "Sources/BoringSSL/ssl/**/*.h",
-        "Sources/BoringSSL/third_party/**/*.c",
-        "Sources/BoringSSL/third_party/**/*.h",
-    ]),
-    hdrs = glob(["Sources/BoringSSL/include/**/*.h"]),
-    copts = ["-Wno-unused-function"],
-    includes = ["Sources/BoringSSL/include"],
-)
-
-cc_library(
-    name = "CgRPC",
-    srcs = glob([
-        "Sources/CgRPC/include/**/*.h",
-        "Sources/CgRPC/shim/*.c",
-        "Sources/CgRPC/src/**/*.c",
-        "Sources/CgRPC/src/**/*.cc",
-        "Sources/CgRPC/src/**/*.h",
-        "Sources/CgRPC/third_party/nanopb/**/*.c",
-    ]) + ["Sources/CgRPC/shim/internal.h"],
-    hdrs = ["Sources/CgRPC/shim/cgrpc.h"],
-    copts = ["-DPB_NO_PACKED_STRUCTS=1"],
-    includes = ["Sources/CgRPC/include"],
-    tags = ["swift_module=CgRPC"],
-    deps = [
-        ":BoringSSL",
-        "@zlib",
-    ],
-)
-
 swift_binary(
-    name = "protoc-gen-swiftgrpc",
+    name = "protoc-gen-grpc-swift",
     srcs = glob([
-        "Sources/protoc-gen-swiftgrpc/*.swift",
+        "Sources/protoc-gen-grpc-swift/*.swift",
     ]),
     visibility = ["//visibility:public"],
     deps = [
@@ -70,16 +55,16 @@ swift_binary(
 )
 
 universal_binary(
-    name = "universal_protoc-gen-swiftgrpc",
-    binary = ":protoc-gen-swiftgrpc",
+    name = "universal_protoc-gen-grpc-swift",
+    binary = ":protoc-gen-grpc-swift",
     visibility = ["//visibility:public"],
 )
 
 alias(
-    name = "protoc-gen-swiftgrpc_wrapper",
+    name = "protoc-gen-grpc-swift_wrapper",
     actual = select({
-        "@build_bazel_rules_swift//swift:universal_tools_config": ":universal_protoc-gen-swiftgrpc",
-        "//conditions:default": ":protoc-gen-swiftgrpc",
+        "@build_bazel_rules_swift//swift:universal_tools_config": ":universal_protoc-gen-grpc-swift",
+        "//conditions:default": ":protoc-gen-grpc-swift",
     }),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This upgrades past the 0.X series into the 1.X series which changes the
import from `SwiftGRPC` to simply `GRPC` (it's cleaner).

Fixed: #827