### PR TITLE
Exit early in worker on failures

### DIFF
--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -188,6 +188,10 @@ void WorkProcessor::ProcessWorkRequest(
 
   SwiftRunner swift_runner(processed_args, /*force_response_file=*/true);
   int exit_code = swift_runner.Run(&stderr_stream, /*stdout_to_stderr=*/true);
+  if (exit_code != 0) {
+    FinalizeWorkRequest(request, response, exit_code, stderr_stream);
+    return;
+  }
 
   if (is_incremental) {
     // Copy the output files from the incremental storage area back to the


### PR DESCRIPTION
Previously we would copy back incremental outputs even if compilations
failed. This meant if swift ever produced a partial set of outputs, or
partial output, the next compilation might fail because of these
invalid inputs.

Another attempt at helping with https://github.com/bazelbuild/rules_swift/issues/819