### PR TITLE
Cleanup swiftdeps on corrupt incremental module

### DIFF
--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -73,6 +73,7 @@ void OutputFileMap::UpdateForIncremental(const std::string &path,
   nlohmann::json new_output_file_map;
   std::map<std::string, std::string> incremental_outputs;
   std::map<std::string, std::string> incremental_inputs;
+  std::vector<std::string> incremental_cleanup_outputs;
 
   // The empty string key is used to represent outputs that are for the whole
   // module, rather than for a particular source file.
@@ -109,6 +110,8 @@ void OutputFileMap::UpdateForIncremental(const std::string &path,
                                .replace_extension(".swiftdeps")
                                .string();
         }
+
+        incremental_cleanup_outputs.push_back(swiftdeps_path);
       } else if (kind == "swiftdoc" || kind == "swiftinterface" ||
                  kind == "swiftmodule" || kind == "swiftsourceinfo") {
         // Module/interface outputs should be moved to the incremental storage
@@ -122,6 +125,8 @@ void OutputFileMap::UpdateForIncremental(const std::string &path,
                                .replace_extension(".swiftdeps")
                                .string();
         }
+
+        incremental_cleanup_outputs.push_back(swiftdeps_path);
       } else if (kind == "swift-dependencies") {
         // If there was already a "swift-dependencies" entry present, ignore it.
         // (This shouldn't happen because the build rules won't do this, but
@@ -169,4 +174,5 @@ void OutputFileMap::UpdateForIncremental(const std::string &path,
   json_ = new_output_file_map;
   incremental_outputs_ = incremental_outputs;
   incremental_inputs_ = incremental_inputs;
+  incremental_cleanup_outputs_ = incremental_cleanup_outputs;
 }

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -47,6 +47,12 @@ class OutputFileMap {
     return incremental_inputs_;
   }
 
+  // A list of output files that will be generated in the incremental storage
+  // area, and need to be cleaned up if a corrupt module is detected.
+  const std::vector<std::string> incremental_cleanup_outputs() const {
+    return incremental_cleanup_outputs_;
+  }
+
   // Reads the output file map from the JSON file at the given path, and updates
   // it to support incremental builds.
   void ReadFromPath(const std::string &path,
@@ -64,6 +70,7 @@ class OutputFileMap {
   nlohmann::json json_;
   std::map<std::string, std::string> incremental_outputs_;
   std::map<std::string, std::string> incremental_inputs_;
+  std::vector<std::string> incremental_cleanup_outputs_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_OUTPUT_FILE_MAP_H_


### PR DESCRIPTION
Fixes #819.

When a SwiftCompile action is cancelled, it can leave the incremental storage area in a corrupt state, in which all later compiles return exit code 0, but don't actually produce an output (#819).

34ce7835bda5e787b633f2ce0cc9687e90f7f952 identified a good way to tell that the storage area was in a corrupt state, but it didn't fully fix the problem. We also need to delete the existing `swiftdeps` files, which this change does.