### PR TITLE
Add `swift.emit_symbol_graph` feature

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -707,8 +707,6 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
-                swift_action_names.DERIVE_FILES,
-                swift_action_names.DUMP_AST,
             ],
             configurators = [_emit_symbol_graph_configurator],
             features = [
@@ -1625,11 +1623,6 @@ def _emit_symbol_graph_configurator(prerequisites, args):
 
       This is a directory to persist symbol graph files that can be used by
       tools such as DocC or jazzy to generate documentation.
-
-      Note: that like the global index store and module cache, we expect clang
-      to namespace these correctly per arch / os version / etc by the hash in
-      the path. However, it is also put into the bin_dir for an added layer of
-      safety.
     """
     args.add(
         "-Xfrontend",
@@ -2882,6 +2875,11 @@ def output_groups_from_other_compilation_outputs(*, other_compilation_outputs):
     if other_compilation_outputs.indexstore:
         output_groups["swift_index_store"] = depset([
             other_compilation_outputs.indexstore,
+        ])
+
+    if other_compilation_outputs.symbol_graph:
+        output_groups["swift_symbol_graph"] = depset([
+            other_compilation_outputs.symbol_graph,
         ])
 
     return output_groups

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -69,6 +69,18 @@ def _indexstore_directory(actions, target_name):
     """
     return actions.declare_directory("{}.indexstore".format(target_name))
 
+def _symbol_graph_directory(actions, target_name):
+    """Declares a directory in which the compiler's symbol graph will be written.
+
+    Args:
+        actions: The context's actions object.
+        target_name: The name of the target being built.
+
+    Returns:
+        The declared `File`.
+    """
+    return actions.declare_directory("{}.symbolgraph".format(target_name))
+
 def _intermediate_bc_file(actions, target_name, src):
     """Declares a file for an intermediate llvm bc file during compilation.
 
@@ -340,6 +352,7 @@ derived_files = struct(
     swiftinterface = _swiftinterface,
     swiftmodule = _swiftmodule,
     swiftsourceinfo = _swiftsourceinfo,
+    symbol_graph_directory = _symbol_graph_directory,
     vfsoverlay = _vfsoverlay,
     whole_module_object_file = _whole_module_object_file,
     xctest_runner_script = _xctest_runner_script,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -105,6 +105,9 @@ SWIFT_FEATURE_CODEVIEW_DEBUG_INFO = "swift.codeview_debug_info"
 # https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"
 
+# If enabled, the compilation action for a target will produce a symbol graph.
+SWIFT_FEATURE_EMIT_SYMBOL_GRAPH = "swift.emit_symbol_graph"
+
 # If enabled the compilation action will not produce indexes for system modules.
 SWIFT_FEATURE_DISABLE_SYSTEM_INDEX = "swift.disable_system_index"
 


### PR DESCRIPTION
That emits the symbol graph for the Swift target to `bazel-bin`.

Symbol graphs can then be fed to tools such as [DocC](https://github.com/apple/swift-docc) or [jazzy](https://github.com/realm/jazzy) to generate documentation for a target.

For example, for [Envoy Mobile](https://github.com/envoyproxy/envoy-mobile):

```
$ ./bazelw build //library/swift:ios_lib --config=ios
$ "$(xcrun --find docc)" convert \
  --index \
  --fallback-display-name Envoy \
  --fallback-bundle-identifier io.envoyproxy.EnvoyMobile \
  --fallback-bundle-version 0.4.6 \
  --output-dir Envoy.doccarchive \
  --transform-for-static-hosting \
  --additional-symbol-graph-dir bazel-bin/library/swift/ios_lib.symbolgraph
```