### PR TITLE
Fix compile() for swift_module_alias

### DIFF
--- a/examples/xplatform/module_alias/BUILD
+++ b/examples/xplatform/module_alias/BUILD
@@ -1,0 +1,19 @@
+load("//swift:swift.bzl", "swift_binary", "swift_library", "swift_module_alias")
+
+licenses(["notice"])
+
+swift_binary(
+    name = "hello_world",
+    deps = [":main_alias"],
+)
+
+swift_library(
+    name = "main",
+    srcs = ["main.swift"],
+)
+
+swift_module_alias(
+    name = "main_alias",
+    deps = [":main"],
+    module_name = "Main_Alias",
+)

--- a/examples/xplatform/module_alias/main.swift
+++ b/examples/xplatform/module_alias/main.swift
@@ -1,0 +1,15 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print("Hello, world!")

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -56,21 +56,26 @@ def _swift_module_alias_impl(ctx):
 
     module_context, compilation_outputs, other_compilation_outputs = swift_common.compile(
         actions = ctx.actions,
+        apple_fragment = ctx.fragments.apple,
         copts = ["-parse-as-library"],
         deps = deps,
         feature_configuration = feature_configuration,
+        is_test = ctx.attr.testonly,
         module_name = module_name,
         srcs = [reexport_src],
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
         workspace_name = ctx.workspace_name,
+        xcode_config = ctx.attr._xcode_config
     )
 
     linking_context, linking_output = (
         swift_common.create_linking_context_from_compilation_outputs(
             actions = ctx.actions,
+            apple_fragment = ctx.fragments.apple,
             compilation_outputs = compilation_outputs,
             feature_configuration = feature_configuration,
+            is_test = ctx.attr.testonly,
             label = ctx.label,
             linking_contexts = [
                 dep[CcInfo].linking_context
@@ -79,6 +84,7 @@ def _swift_module_alias_impl(ctx):
             ],
             module_context = module_context,
             swift_toolchain = swift_toolchain,
+            xcode_config = ctx.attr._xcode_config
         )
     )
 
@@ -146,6 +152,12 @@ linked into that target. Allowed kinds are `swift_import` and `swift_library`
 """,
                 providers = [[SwiftInfo]],
             ),
+            "_xcode_config": attr.label(
+                default = configuration_field(
+                    name = "xcode_config_label",
+                    fragment = "apple",
+                ),
+            ),
         },
     ),
     doc = """\
@@ -167,6 +179,6 @@ symbol is defined; it is not repeated by the alias module.)
 > `deps` in the new module. You depend on undocumented features at your own
 > risk, as they may change in a future version of Swift.
 """,
-    fragments = ["cpp"],
+    fragments = ["apple", "cpp"],
     implementation = _swift_module_alias_impl,
 )


### PR DESCRIPTION
Adds a missing argument to allow this code to run

Fixes compile() missing 3 required keyword-only arguments: apple_fragment, is_test, xcode_config #848