### PR TITLE
Adding a new `-gmodules` flag to swift compilations to for a new lldb regression in Xcode 13.3.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -518,6 +518,11 @@ def compile_action_configs(
             ],
         ),
         swift_toolchain_config.action_config(
+            actions = [swift_action_names.PRECOMPILE_C_MODULE],
+            configurators = [swift_toolchain_config.add_arg("-Xcc", "-gmodules")],
+            features = [[SWIFT_FEATURE_DBG], [SWIFT_FEATURE_FULL_DEBUG_INFO]],
+        ),
+        swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
                 swift_action_names.DERIVE_FILES,


### PR DESCRIPTION
lldb is failing to properly parse the dwarf data in pre-compiled modules. Adding this flag fixes the issue with Xcode 13.3 and also works with Xcode 13.2.1.

PiperOrigin-RevId: 443118640
(cherry picked from commit 02234a9b9ebd80574d748febbb894263a6ab2767)