### PR TITLE
Migrate ObjcConfiguration usage to equivalent info in CppConfiguration

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -78,11 +78,12 @@ def _swift_developer_lib_dir(platform_framework_dir):
         "lib",
     )
 
-def _command_line_objc_copts(compilation_mode, objc_fragment):
+def _command_line_objc_copts(compilation_mode, cpp_fragment, objc_fragment):
     """Returns copts that should be passed to `clang` from the `objc` fragment.
 
     Args:
         compilation_mode: The current compilation mode.
+        cpp_fragment: The `cpp` configuration fragment.
         objc_fragment: The `objc` configuration fragment.
 
     Returns:
@@ -120,7 +121,7 @@ def _command_line_objc_copts(compilation_mode, objc_fragment):
                 "-Wno-extra",
             ]
 
-    clang_copts = objc_fragment.copts + legacy_copts
+    clang_copts = cpp_fragment.objccopts + legacy_copts
     return [copt for copt in clang_copts if copt != "-g"]
 
 def _platform_developer_framework_dir(
@@ -736,6 +737,7 @@ def _xcode_swift_toolchain_impl(ctx):
     all_action_configs = _all_action_configs(
         additional_objc_copts = _command_line_objc_copts(
             ctx.var["COMPILATION_MODE"],
+            ctx.fragments.cpp,
             ctx.fragments.objc,
         ),
         additional_swiftc_copts = ctx.fragments.swift.copts(),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -121,7 +121,10 @@ def _command_line_objc_copts(compilation_mode, cpp_fragment, objc_fragment):
                 "-Wno-extra",
             ]
 
-    clang_copts = cpp_fragment.objccopts + legacy_copts
+    if getattr(cpp_fragment, "objccopts", None) != None:
+        clang_copts = getattr(cpp_fragment, "objccopts") + legacy_copts
+    else:
+        clang_copts = getattr(objc_fragment, "copts", []) + legacy_copts
     return [copt for copt in clang_copts if copt != "-g"]
 
 def _platform_developer_framework_dir(


### PR DESCRIPTION
We would like to migrate all such usage to CppConfiguration so that we
can delete the info in ObjcConfiguration.

PiperOrigin-RevId: 457500060
(cherry picked from commit 912d40dade63be23c325ac79a1854868ded16601)