### PR TITLE
Remove the `toolchain` field from `SwiftUsageInfo`.

### DIFF
--- a/doc/aspects.md
+++ b/doc/aspects.md
@@ -25,14 +25,6 @@ or deeper in its dependency tree. Conversely, if neither a target nor its
 transitive dependencies use Swift, the `SwiftUsageInfo` provider will not be
 propagated.
 
-Specifically, the aspect propagates which toolchain was used to build those
-dependencies. This information is typically always the same for any Swift
-targets built in the same configuration, but this allows upstream targets that
-may not be *strictly* Swift-related and thus don't want to depend directly on
-the Swift toolchain (such as Apple universal binary linking rules) to avoid
-doing so but still get access to information derived from the toolchain (like
-which linker flags to pass to link to the runtime).
-
 We use an aspect (as opposed to propagating this information through normal
 providers returned by `swift_library`) because the information is needed if
 Swift is used _anywhere_ in a dependency graph, even as dependencies of other

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -99,18 +99,14 @@ that use the toolchain.
 ## SwiftUsageInfo
 
 <pre>
-SwiftUsageInfo(<a href="#SwiftUsageInfo-toolchain">toolchain</a>)
+SwiftUsageInfo()
 </pre>
 
 A provider that indicates that Swift was used by a target or any target that it
-depends on, and specifically which toolchain was used.
+depends on.
 
 
 **FIELDS**
 
-
-| Name  | Description |
-| :------------- | :------------- |
-| <a id="SwiftUsageInfo-toolchain"></a>toolchain |  The Swift toolchain that was used to build the targets propagating this provider.    |
 
 

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -225,14 +225,9 @@ Swift build rules, and they are also passed to the C++ APIs used when linking
 SwiftUsageInfo = provider(
     doc = """\
 A provider that indicates that Swift was used by a target or any target that it
-depends on, and specifically which toolchain was used.
+depends on.
 """,
-    fields = {
-        "toolchain": """\
-The Swift toolchain that was used to build the targets propagating this
-provider.
-""",
-    },
+    fields = {},
 )
 
 def create_module(


### PR DESCRIPTION
It's no longer used anywhere and may interfere with toolchainification. It was previously used to retrieve the toolchain from which linker flags should be retrieved, but those are now passed via an implicit dependency.

PiperOrigin-RevId: 439394121
(cherry picked from commit 2e7227d72e0f70b68a30fe57729a4fa7882fb4a1)