### PR TITLE
Fix missing dependency

### DIFF
--- a/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
@@ -16,6 +16,7 @@ swift_library(
     deps = [
         "@com_github_apple_swift_nio//:NIOCore",
         "@com_github_apple_swift_nio//:NIOFoundationCompat",
+        "@com_github_apple_swift_nio//:NIOTLS",
     ],
     module_name = "NIOTransportServices",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Fixes the following compilation error:
```
external/com_github_apple_swift_nio_transport_services/Sources/NIOTransportServices/NIOTSConnectionChannel.swift:20:8: error: no such module 'NIOTLS'
```