### PR TITLE
Enable sandboxing for swift builds

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -33,6 +33,10 @@ x_defaults:
       - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
   windows_common: &windows_common
     platform: windows
+    build_flags:
+      # Override 'sandboxed' strategy set in .bazelrc because it's not
+      # available on Windows
+      - "--strategy=SwiftCompile="
     build_targets:
       - "//tools/..."
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -8,3 +8,7 @@ build --macos_minimum_os=10.15
 
 # Make sure no warnings slip into the C++ tools we vendor
 build --features treat_warnings_as_errors
+
+# The default strategy is worker, which has sandboxing disabled by default,
+# which can hide issues with non-hermetic bugs.
+build --strategy=SwiftCompile=sandboxed

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,4 +11,4 @@ build --features treat_warnings_as_errors
 
 # The default strategy is worker, which has sandboxing disabled by default,
 # which can hide issues with non-hermetic bugs.
-build --strategy=SwiftCompile=sandboxed
+build --strategy=SwiftCompile=sandboxed,worker,local

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,4 +11,4 @@ build --features treat_warnings_as_errors
 
 # The default strategy is worker, which has sandboxing disabled by default,
 # which can hide issues with non-hermetic bugs.
-build --strategy=SwiftCompile=sandboxed,worker,local
+build --strategy=SwiftCompile=sandboxed


### PR DESCRIPTION
Prevents issues with non-hermetic bugs like
https://github.com/bazelbuild/rules_swift/pull/865.
