### PR TITLE
Use host arch for linux autoconfiguration

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -206,8 +206,7 @@ _FEATURE_CHECKS = {
     SWIFT_FEATURE_USE_RESPONSE_FILES: _check_use_response_files,
 }
 
-def _normalized_linux_cpu(repository_ctx):
-    cpu = repository_ctx.os.arch
+def _normalized_linux_cpu(cpu):
     if cpu in ("amd64"):
         return "x86_64"
     return cpu
@@ -258,7 +257,7 @@ swift_toolchain(
     version_file = "{version_file}",
 )
 """.format(
-            cpu = _normalized_linux_cpu(repository_ctx),
+            cpu = _normalized_linux_cpu(repository_ctx.os.arch),
             feature_list = ", ".join([
                 '"{}"'.format(feature)
                 for feature in feature_values

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -206,6 +206,12 @@ _FEATURE_CHECKS = {
     SWIFT_FEATURE_USE_RESPONSE_FILES: _check_use_response_files,
 }
 
+def _normalized_linux_cpu(repository_ctx):
+    cpu = repository_ctx.os.arch
+    if cpu in ("amd64"):
+        return "x86_64"
+    return cpu
+
 def _create_linux_toolchain(repository_ctx):
     """Creates BUILD targets for the Swift toolchain on Linux.
 
@@ -252,7 +258,7 @@ swift_toolchain(
     version_file = "{version_file}",
 )
 """.format(
-            cpu = repository_ctx.os.arch,
+            cpu = _normalized_linux_cpu(repository_ctx),
             feature_list = ", ".join([
                 '"{}"'.format(feature)
                 for feature in feature_values

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -245,13 +245,14 @@ package(default_visibility = ["//visibility:public"])
 
 swift_toolchain(
     name = "toolchain",
-    arch = "x86_64",
+    arch = "{cpu}",
     features = [{feature_list}],
     os = "linux",
     root = "{root}",
     version_file = "{version_file}",
 )
 """.format(
+            cpu = repository_ctx.os.arch,
             feature_list = ", ".join([
                 '"{}"'.format(feature)
                 for feature in feature_values


### PR DESCRIPTION
The autoconfigured toolchain on linux uses `x86_64` currently. Changing to use the host arch makes it easier to start working on arm64 (for instance... in a docker container on an M1 mac).

It doesn't look like Swift on Windows supports `aarch64` currently; it has the same hard-coded value, but if that changes, it's the same easy fix.