### PR TITLE
Fix symbol graph with derived files

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -748,7 +748,7 @@ def compile_action_configs(
             configurators = [_emit_symbol_graph_configurator],
             features = [
                 SWIFT_FEATURE_EMIT_SYMBOL_GRAPH,
-                SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION
+                SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION,
             ],
         ),
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -739,6 +739,17 @@ def compile_action_configs(
             features = [
                 SWIFT_FEATURE_EMIT_SYMBOL_GRAPH,
             ],
+            not_features = [SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [_emit_symbol_graph_configurator],
+            features = [
+                SWIFT_FEATURE_EMIT_SYMBOL_GRAPH,
+                SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION
+            ],
         ),
 
         # When using C modules, disable the implicit search for module map files

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -93,6 +93,21 @@ split_swiftmodule_copts_test = make_action_command_line_test_rule(
         ],
     },
 )
+split_swiftmodule_symbol_graph_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_symbol_graph",
+            "swift.split_derived_files_generation",
+        ],
+    },
+)
+default_no_split_swiftmodule_symbol_graph_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_symbol_graph",
+        ],
+    },
+)
 
 def split_derived_files_test_suite(name):
     """Test suite for split derived files options.
@@ -163,6 +178,39 @@ def split_derived_files_test_suite(name):
             "-emit-module-path",
             "simple.derived_output_file_map.json",
         ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_symbol_graph_test(
+        name = "{}_symbol_graph_in_derive_action".format(name),
+        expected_argv = [
+            "-emit-symbol-graph",
+            "-emit-symbol-graph-dir",
+        ],
+        mnemonic = "SwiftDeriveFiles",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    split_swiftmodule_symbol_graph_test(
+        name = "{}_no_symbol_graph_in_compile_action".format(name),
+        not_expected_argv = [
+            "-emit-symbol-graph",
+            "-emit-symbol-graph-dir",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    default_no_split_swiftmodule_symbol_graph_test(
+        name = "{}_default_no_split_symbol_graph_in_compile_action".format(name),
+        expected_argv = [
+            "-emit-symbol-graph",
+            "-emit-symbol-graph-dir",
+        ],
+        mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
This PR attempts to fix the following issue when `split_derived_files_generation` feature is used.

When using the `split_derived_files_generation` feature, we observed that the `emit-symbol-graph` and `-emit-symbol-graph-dir` options are not passed to the `Generating derived files...` action because of which the symbol.json files were not produced.

Though the flags were passed to the compilation action, it was a no-op because of the issue described here: https://github.com/apple/swift/issues/60412.

This PR does the following:
1. If the derived files feature is not enabled, then the symbol-graph related options are passed to the compilation action. (this is the default).
2. If the derived files feature is enabled, then the symbol-graph related options are passed to the derived files action.