### PR TITLE
Moves compile_outputs.symbol_graph_directory under all_derived_outputs

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1968,7 +1968,6 @@ def compile(
         all_compile_outputs = compact([
             compile_outputs.swiftinterface_file,
             compile_outputs.indexstore_directory,
-            compile_outputs.symbol_graph_directory,
         ]) + compile_outputs.object_files
         all_derived_outputs = compact([
             # The `.swiftmodule` file is explicitly listed as the first output
@@ -1979,6 +1978,7 @@ def compile(
             compile_outputs.swiftdoc_file,
             compile_outputs.swiftsourceinfo_file,
             compile_outputs.generated_header_file,
+            compile_outputs.symbol_graph_directory,
         ]) + other_outputs
     else:
         all_compile_outputs = compact([


### PR DESCRIPTION
This PR moves the "compile_outputs.symbol_graph_directory" under "all_derived_outputs". This is because since the symbol graph-related copts are dispatched to the derived action, it becomes a derived output instead of the compilation action output. This ideally should have been a part of the previous [PR](https://github.com/bazelbuild/rules_swift/pull/873) but I missed adding this change then. 