### PR TITLE
Add basic sanitizer support for swift_test

### DIFF
--- a/examples/xplatform/xctest/BUILD
+++ b/examples/xplatform/xctest/BUILD
@@ -9,3 +9,42 @@ swift_test(
         "main.swift",
     ],
 )
+
+swift_test(
+    name = "xctest_tsan",
+    srcs = [
+        "SimpleTests.swift",
+        "main.swift",
+    ],
+    features = ["tsan"],
+)
+
+swift_test(
+    name = "xctest_asan",
+    srcs = [
+        "SimpleTests.swift",
+        "main.swift",
+    ],
+    features = ["asan"],
+)
+
+swift_test(
+    name = "xctest_ubsan",
+    srcs = [
+        "SimpleTests.swift",
+        "main.swift",
+    ],
+    features = ["ubsan"],
+)
+
+swift_test(
+    name = "xctest_tsan_and_ubsan",
+    srcs = [
+        "SimpleTests.swift",
+        "main.swift",
+    ],
+    features = [
+        "tsan",
+        "ubsan",
+    ],
+)

--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -31,7 +31,7 @@ bundle_path="$(dirname "$(dirname "$(dirname "$executable_path")")")"
 
 sanitizer_dyld_env=""
 if output=$(otool -L "$executable_path" | grep @rpath/libclang_rt | xargs | cut -d " " -f 1); then
-  rpath=$(objdump --macho --rpaths "$executable_path" | grep usr/lib/clang | head -1)
+  rpath=$(otool -l "$executable_path" | grep -A2 LC_RPATH | grep "^\s*path" | grep usr/lib/clang | head -1 | cut -d " " -f 11)
   if [[ -z "$rpath" ]]; then
     echo "Sanitizer libraries are required but rpath could not be inferred, please file an issue" >&2
     exit 1

--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -26,11 +26,36 @@ trap 'rm -rf "$tmp_dir"' EXIT
 readonly profraw="$tmp_dir/coverage.profraw"
 
 # Foo.xctest/Contents/MacOS/Foo -> Foo.xctest
-bundle_path="$(dirname "$(dirname "$(dirname "%executable%")")")"
+executable_path="%executable%"
+bundle_path="$(dirname "$(dirname "$(dirname "$executable_path")")")"
+
+sanitizer_dyld_env=""
+if output=$(otool -L "$executable_path" | grep @rpath/libclang_rt | xargs | cut -d " " -f 1); then
+  rpath=$(objdump --macho --rpaths "$executable_path" | grep usr/lib/clang | head -1)
+  if [[ -z "$rpath" ]]; then
+    echo "Sanitizer libraries are required but rpath could not be inferred, please file an issue" >&2
+    exit 1
+  fi
+
+  for lib in $output; do
+    if [[ -n "$sanitizer_dyld_env" ]]; then
+      sanitizer_dyld_env="$sanitizer_dyld_env:"
+    fi
+    sanitizer_dyld_env="${sanitizer_dyld_env}$rpath/${lib#@rpath/}"
+  done
+fi
+
+if [[ -n "${DYLD_INSERT_LIBRARIES:-}" ]]; then
+  if [[ -n "$sanitizer_dyld_env" ]]; then
+    sanitizer_dyld_env="$sanitizer_dyld_env:"
+  fi
+  sanitizer_dyld_env="$sanitizer_dyld_env$DYLD_INSERT_LIBRARIES"
+fi
 
 exit_status=0
+xctest=$(xcrun -f xctest)
 # TODO(allevato): Support Bazel's --test_filter.
-LLVM_PROFILE_FILE="$profraw" xcrun xctest -XCTest All "$bundle_path" || exit_status=$?
+DYLD_INSERT_LIBRARIES=$sanitizer_dyld_env LLVM_PROFILE_FILE="$profraw" $xctest -XCTest All "$bundle_path" || exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then
   exit "$exit_status"


### PR DESCRIPTION
rules_apple handles bundling sanitizers with test bundles that it
creates, swift_test does not handle this as it creates a very minimal
xctest bundle (ideally it wouldn't have to create that bundle at all and
you could run tests directly). Because of this we don't have the
sanitizer libs easily extracted into the bundle. Sanitizers require us
to load them when launching the binary with DYLD_INSERT_LIBRARIES, to
know which to load we can inspect the binary for these. Clang inserts an
absolute rpath to the Xcode directory containing the libraries, as well
as the library loads for each we depend on.