### PR TITLE
Require cacheable swiftmodules for -no-clang-module-breadcrumbs

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -290,6 +290,9 @@ def compile_action_configs(
                     "-no-clang-module-breadcrumbs",
                 ),
             ],
+            features = [
+                SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
+            ],
         ),
 
         # Add the output precompiled module file path to the command line.


### PR DESCRIPTION
The upstream branch did this
https://github.com/bazelbuild/rules_swift/commit/492c48e16fae85d439aa53242cb741a1c32db376
but more importantly there's otherwise no way to disable this flag when
there are bugs https://github.com/apple/swift/pull/60636