### PR TITLE
Supporting Swift 5.7 Bare Slash Regex Literal

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -57,6 +57,7 @@ load(
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_REWRITE_GENERATED_HEADER",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
+    "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_SYSTEM_MODULE",
@@ -324,6 +325,18 @@ def compile_action_configs(
             features = [
                 SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION,
                 SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION,
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg("-enable-bare-slash-regex"),
+            ],
+            features = [
+                SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX,
             ],
         ),
         swift_toolchain_config.action_config(

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -304,3 +304,8 @@ SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts
 # A feature to enable setting pch-output-dir
 # This is a directory to persist automatically created precompiled bridging headers
 SWIFT_FEATURE_USE_PCH_OUTPUT_DIR = "swift.use_pch_output_dir"
+
+# If enabled, Swift compilation actions will pass
+# `-enable-bare-slash-regex` to `swiftc`. This is a new flag as of
+# Swift 5.7 that enables `/.../` syntax regular-expression literals.
+SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX = "swift.supports_bare_slash_regex"

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -38,6 +38,7 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
+    "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
@@ -604,6 +605,10 @@ def _xcode_swift_toolchain_impl(ctx):
     # Xcode 12.5 implies Swift 5.4.
     if _is_xcode_at_least_version(xcode_config, "12.5"):
         requested_features.append(SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG)
+
+    # Xcode 14 implies Swift 5.7.
+    if _is_xcode_at_least_version(xcode_config, "14.0"):
+        requested_features.append(SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX)
 
     env = _xcode_env(target_triple = target_triple, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()


### PR DESCRIPTION
This PR adds support for passing the `-enable-bare-slash-regex` flag by default to all the swiftc actions for Swift 5.7 and above.

**Context**

The following fails to compile on Xcode 14 toolchain:

```
func regexTest() {
    let testString = "04/07/2022"
    let digits = /\d+/
    print(testString.ranges(of: digits))
}
```
**Analysis**

Swift evolution proposal: [Regex Literals](https://github.com/apple/swift-evolution/blob/main/proposals/0354-regex-literals.md)

As per the proposal, it explicitly needs the `-enable-bare-slash-regex` flag to successfully compile the above code. Xcode 14 passes the same by default. 