### PR TITLE
Remove space-in-path replacement

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1448,7 +1448,7 @@ def _declare_per_source_output_file(actions, extension, target_name, src):
         The declared `File`.
     """
     objs_dir = "{}_objs".format(target_name)
-    owner_rel_path = owner_relative_path(src).replace(" ", "__SPACE__")
+    owner_rel_path = owner_relative_path(src)
     basename = paths.basename(owner_rel_path)
     dirname = paths.join(objs_dir, paths.dirname(owner_rel_path))
 


### PR DESCRIPTION
This replacement causes issues with importing indexstores.

In 965c37304cbc0263b6a5b0a945529c66a593c34c this replacement was added to work around issues with `ar_wrapper`. I don't see `ar_wrapper` used anywhere in Bazel, so I believe this is safe to remove.