### PR TITLE
Add support for -file-prefix-map $PWD=.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -45,6 +45,7 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_FASTBUILD",
+    "SWIFT_FEATURE_FILE_PREFIX_MAP",
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
     "SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
@@ -607,6 +608,20 @@ def compile_action_configs(
             ],
             features = [
                 [SWIFT_FEATURE_COVERAGE_PREFIX_MAP, SWIFT_FEATURE_COVERAGE],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+                ),
+            ],
+            features = [
+                [SWIFT_FEATURE_FILE_PREFIX_MAP],
             ],
         ),
     ]

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -57,6 +57,14 @@ SWIFT_FEATURE_DEBUG_PREFIX_MAP = "swift.debug_prefix_map"
 # of remote builds.
 SWIFT_FEATURE_COVERAGE_PREFIX_MAP = "swift.coverage_prefix_map"
 
+# If enabled, builds will use the `-file-prefix-map` feature to remap the
+# current working directory to `.`, which avoids embedding non-hermetic
+# absolute path information in build artifacts. Specifically what this flag
+# does is subject to change in Swift, but it should imply all other
+# `-*-prefix-map` flags. How those flags compose is potentially complicated, so
+# using only this flag, or the same values for each flag, is recommended.
+SWIFT_FEATURE_FILE_PREFIX_MAP = "swift.file_prefix_map"
+
 # If enabled, C and Objective-C libraries that are direct or transitive
 # dependencies of a Swift library will emit explicit precompiled modules that
 # are compatible with Swift's ClangImporter and propagate them up the build

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -36,6 +36,7 @@ load(
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
+    "SWIFT_FEATURE_FILE_PREFIX_MAP",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
@@ -394,6 +395,24 @@ def _all_action_configs(
                     SWIFT_FEATURE_REMAP_XCODE_PATH,
                     SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
                     SWIFT_FEATURE_COVERAGE,
+                ],
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg(
+                    "-file-prefix-map",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                ),
+            ],
+            features = [
+                [
+                    SWIFT_FEATURE_REMAP_XCODE_PATH,
+                    SWIFT_FEATURE_FILE_PREFIX_MAP,
                 ],
             ],
         ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":ast_file_tests.bzl", "ast_file_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
 load(":debug_settings_tests.bzl", "debug_settings_test_suite")
+load(":features_tests.bzl", "features_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
 load(":linking_tests.bzl", "linking_test_suite")
 load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
@@ -20,6 +21,8 @@ ast_file_test_suite(name = "ast_file")
 coverage_settings_test_suite(name = "coverage_settings")
 
 debug_settings_test_suite(name = "debug_settings")
+
+features_test_suite(name = "features")
 
 generated_header_test_suite(name = "generated_header")
 

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -1,0 +1,66 @@
+"""Tests for various features that aren't large enough to need their own tests file."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+
+default_test = make_action_command_line_test_rule()
+
+file_prefix_map_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.file_prefix_map",
+        ],
+    },
+)
+
+file_prefix_xcode_remap_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.file_prefix_map",
+            "swift.remap_xcode_path",
+        ],
+    },
+)
+
+def features_test_suite(name):
+    """Test suite for various features.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+    default_test(
+        name = "{}_default_test".format(name),
+        tags = [name],
+        expected_argv = ["-emit-object"],
+        not_expected_argv = [
+            "-file-prefix-map",
+            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    file_prefix_map_test(
+        name = "{}_file_prefix_map_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    file_prefix_xcode_remap_test(
+        name = "{}_file_prefix_xcode_remap_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+            "-file-prefix-map",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+        ],
+        target_compatible_with = ["@platforms//os:macos"],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -273,20 +273,20 @@ bool SwiftRunner::ProcessArgument(
     std::string new_arg = arg;
     if (StripPrefix("-Xwrapped-swift=", new_arg)) {
       if (new_arg == "-debug-prefix-pwd-is-dot") {
-        // Get the actual current working directory (the workspace root), which
-        // we didn't know at analysis time.
+        // Replace the $PWD with . to make the paths relative to the workspace
+        // without breaking hermiticity.
         consumer("-debug-prefix-map");
         consumer(std::filesystem::current_path().string() + "=.");
         changed = true;
       } else if (new_arg == "-coverage-prefix-pwd-is-dot") {
-        // Get the actual current working directory (the workspace root), which
-        // we didn't know at analysis time.
+        // Replace the $PWD with . to make the paths relative to the workspace
+        // without breaking hermiticity.
         consumer("-coverage-prefix-map");
         consumer(std::filesystem::current_path().string() + "=.");
         changed = true;
       } else if (new_arg == "-file-prefix-pwd-is-dot") {
-        // Get the actual current working directory (the workspace root), which
-        // we didn't know at analysis time.
+        // Replace the $PWD with . to make the paths relative to the workspace
+        // without breaking hermiticity.
         consumer("-file-prefix-map");
         consumer(std::filesystem::current_path().string() + "=.");
         changed = true;

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -284,6 +284,12 @@ bool SwiftRunner::ProcessArgument(
         consumer("-coverage-prefix-map");
         consumer(std::filesystem::current_path().string() + "=.");
         changed = true;
+      } else if (new_arg == "-file-prefix-pwd-is-dot") {
+        // Get the actual current working directory (the workspace root), which
+        // we didn't know at analysis time.
+        consumer("-file-prefix-map");
+        consumer(std::filesystem::current_path().string() + "=.");
+        changed = true;
       } else if (new_arg == "-ephemeral-module-cache") {
         // Create a temporary directory to hold the module cache, which will be
         // deleted after compilation is finished.


### PR DESCRIPTION
This is a new flag in Swift 5.7, that mirrors the flag with the same
name in clang, meaning that it implies both -debug-prefix-map, and
-coverage-prefix map. Currently it is also the only flag that applies to
indexing info if you want to produce hermetic indexes. Ideally going
forward users should prefer this flag if they want their builds to be
hermetic instead of picking the other flags as needed, since this will
potentially also apply to new absolute paths in the future.

https://github.com/apple/swift/pull/58946
