### PR TITLE
Move the internal `new_objc_provider` helper function from `compiling.bzl` to `linking.bzl`.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -28,6 +28,7 @@ load(
     ":developer_dirs.bzl",
     "developer_dirs_linkopts",
 )
+load(":utils.bzl", "get_providers")
 
 def create_linking_context_from_compilation_outputs(
         *,
@@ -168,6 +169,108 @@ def create_linking_context_from_compilation_outputs(
         disallow_static_libraries = False,
         disallow_dynamic_library = True,
         grep_includes = None,
+    )
+
+def new_objc_provider(
+        *,
+        additional_link_inputs = [],
+        additional_objc_infos = [],
+        alwayslink = False,
+        deps,
+        feature_configuration,
+        is_test,
+        libraries_to_link,
+        module_context,
+        user_link_flags = [],
+        swift_toolchain):
+    """Creates an `apple_common.Objc` provider for a Swift target.
+
+    Args:
+        additional_link_inputs: Additional linker input files that should be
+            propagated to dependents.
+        additional_objc_infos: Additional `apple_common.Objc` providers from
+            transitive dependencies not provided by the `deps` argument.
+        alwayslink: If True, any binary that depends on the providers returned
+            by this function will link in all of the library's object files,
+            even if some contain no symbols referenced by the binary.
+        deps: The dependencies of the target being built, whose `Objc` providers
+            will be passed to the new one in order to propagate the correct
+            transitive fields.
+        feature_configuration: The Swift feature configuration.
+        is_test: Represents if the `testonly` value of the context.
+        libraries_to_link: A list (typically of one element) of the
+            `LibraryToLink` objects from which the static archives (`.a` files)
+            containing the target's compiled code will be retrieved.
+        module_context: The module context as returned by
+            `swift_common.compile`.
+        user_link_flags: Linker options that should be propagated to dependents.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+
+    Returns:
+        An `apple_common.Objc` provider that should be returned by the calling
+        rule.
+    """
+
+    # The link action registered by `apple_common.link_multi_arch_binary` only
+    # looks at `Objc` providers, not `CcInfo`, for libraries to link.
+    # Dependencies from an `objc_library` to a `cc_library` are handled as a
+    # special case, but other `cc_library` dependencies (such as `swift_library`
+    # to `cc_library`) would be lost since they do not receive the same
+    # treatment. Until those special cases are resolved via the unification of
+    # the Obj-C and C++ rules, we need to collect libraries from `CcInfo` and
+    # put them into the new `Objc` provider.
+    transitive_cc_libs = []
+    for cc_info in get_providers(deps, CcInfo):
+        static_libs = []
+        for linker_input in cc_info.linking_context.linker_inputs.to_list():
+            for library_to_link in linker_input.libraries:
+                library = library_to_link.static_library
+                if library:
+                    static_libs.append(library)
+        transitive_cc_libs.append(depset(static_libs, order = "topological"))
+
+    direct_libraries = []
+    force_load_libraries = []
+
+    for library_to_link in libraries_to_link:
+        library = library_to_link.static_library
+        if library:
+            direct_libraries.append(library)
+            if alwayslink:
+                force_load_libraries.append(library)
+
+    if feature_configuration and should_embed_swiftmodule_for_debugging(
+        feature_configuration = feature_configuration,
+        module_context = module_context,
+    ):
+        module_file = module_context.swift.swiftmodule
+        debug_link_flags = ["-Wl,-add_ast_path,{}".format(module_file.path)]
+        debug_link_inputs = [module_file]
+    else:
+        debug_link_flags = []
+        debug_link_inputs = []
+
+    if is_test:
+        developer_paths_linkopts = developer_dirs_linkopts(swift_toolchain.developer_dirs)
+    else:
+        developer_paths_linkopts = []
+
+    return apple_common.new_objc_provider(
+        force_load_library = depset(
+            force_load_libraries,
+            order = "topological",
+        ),
+        library = depset(
+            direct_libraries,
+            transitive = transitive_cc_libs,
+            order = "topological",
+        ),
+        link_inputs = depset(additional_link_inputs + debug_link_inputs),
+        linkopt = depset(user_link_flags + debug_link_flags + developer_paths_linkopts),
+        providers = get_providers(
+            deps,
+            apple_common.Objc,
+        ) + additional_objc_infos,
     )
 
 def register_link_binary_action(

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -18,7 +18,6 @@ load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     ":compiling.bzl",
-    "new_objc_provider",
     "output_groups_from_other_compilation_outputs",
 )
 load(
@@ -26,6 +25,7 @@ load(
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES",
 )
+load(":linking.bzl", "new_objc_provider")
 load(
     ":proto_gen_utils.bzl",
     "declare_generated_files",

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -16,8 +16,8 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":attrs.bzl", "swift_common_rule_attrs", "swift_toolchain_attrs")
-load(":compiling.bzl", "new_objc_provider")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":linking.bzl", "new_objc_provider")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "compact", "get_providers")
 

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -22,7 +22,6 @@ load(
 )
 load(
     ":compiling.bzl",
-    "new_objc_provider",
     "output_groups_from_other_compilation_outputs",
     "swift_library_output_map",
 )
@@ -32,6 +31,7 @@ load(
     "SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
 )
+load(":linking.bzl", "new_objc_provider")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -15,8 +15,9 @@
 """Implementation of the `swift_module_alias` rule."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":compiling.bzl", "new_objc_provider", "output_groups_from_other_compilation_outputs")
+load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
+load(":linking.bzl", "new_objc_provider")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "compact", "get_providers")

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -18,7 +18,7 @@ load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":attrs.bzl", "swift_config_attrs")
-load(":compiling.bzl", "new_objc_provider", "output_groups_from_other_compilation_outputs")
+load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
@@ -26,6 +26,7 @@ load(
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES",
 )
+load(":linking.bzl", "new_objc_provider")
 load(
     ":proto_gen_utils.bzl",
     "declare_generated_files",


### PR DESCRIPTION
The `Objc` provider is only created by Swift to propagate linking information to the Apple rules until that logic migrates to `CcInfo`, so this is a better home for it until it can disappear for good.

PiperOrigin-RevId: 423827285
(cherry picked from commit 899eb1e5ca6f5c8b488dbbe4cb64653ccf77604f)

 Conflicts:
	swift/internal/compiling.bzl
	swift/internal/linking.bzl
	swift/internal/swift_grpc_library.bzl
	swift/internal/swift_import.bzl
	swift/internal/swift_library.bzl
	swift/internal/swift_module_alias.bzl
	swift/internal/swift_protoc_gen_aspect.bzl
