### PR TITLE
Filter out non-standard header extensions from module maps

### DIFF
--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -93,7 +93,7 @@ def write_module_map(
 
     def _add_headers(*, headers, kind):
         content.add_all(
-            headers,
+            [h for h in headers if h.extension.lower() in ("h", "hpp", "hh")],
             allow_closure = True,
             format_each = '    {} "%s"'.format(kind),
             map_each = _relativized_header_paths,


### PR DESCRIPTION
In https://github.com/bazel-ios/rules_ios/pull/562, I realized that the hmap and vfsoverlay files are passed as `headers` on `CcInfo` as a workaround for the lack of custom providers in the Java-side rules. As a result, `rules_swift` attempts to add them to the modulemaps, which leads to failures.