### PR TITLE
Add support for imported_library when linking

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -355,6 +355,10 @@ def register_link_binary_action(
                 "-framework",
                 objc.static_framework_names.to_list(),
             ))
+            dep_link_flags.extend([
+                lib.path
+                for lib in objc.imported_library.to_list()
+            ])
 
             linking_contexts.append(
                 cc_common.create_linking_context(
@@ -362,7 +366,9 @@ def register_link_binary_action(
                         cc_common.create_linker_input(
                             owner = owner,
                             user_link_flags = dep_link_flags,
-                            additional_inputs = objc.static_framework_file,
+                            additional_inputs = depset(
+                                transitive = [objc.static_framework_file, objc.imported_library],
+                            ),
                         ),
                     ]),
                 ),


### PR DESCRIPTION
Required for https://github.com/bazelbuild/rules_apple/pull/1698 when
linking swift_binary targets
