### PR TITLE
Add initial bzlmod support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,31 @@
+module(
+    name = "rules_swift",
+    compatibility_level = 1,
+    repo_name = "build_bazel_rules_swift",
+    version = "1.2.0",
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.1.1")
+bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.1")
+bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "3.19.2")  # To be removed once rules_proto is bzlmod-ready.
+
+non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")
+
+use_repo(
+    non_module_deps,
+    "build_bazel_rules_swift_local_config",
+    "com_github_apple_swift_protobuf",
+    "com_github_grpc_grpc_swift",
+    "com_github_apple_swift_nio",
+    "com_github_apple_swift_nio_http2",
+    "com_github_apple_swift_nio_transport_services",
+    "com_github_apple_swift_nio_extras",
+    "com_github_apple_swift_log",
+    "com_github_nlohmann_json",
+    "rules_proto",
+    "build_bazel_rules_swift_index_import",
+)
+
+# Dev dependencies
+bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_skydoc", version = "0.5.3")

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -5,7 +5,7 @@
 ## swift_rules_dependencies
 
 <pre>
-swift_rules_dependencies()
+swift_rules_dependencies(<a href="#swift_rules_dependencies-include_bzlmod_ready_dependencies">include_bzlmod_ready_dependencies</a>)
 </pre>
 
 Fetches repositories that are dependencies of `rules_swift`.
@@ -14,5 +14,12 @@ Users should call this macro in their `WORKSPACE` to ensure that all of the
 dependencies of the Swift rules are downloaded and that they are isolated
 from changes to those dependencies.
 
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_rules_dependencies-include_bzlmod_ready_dependencies"></a>include_bzlmod_ready_dependencies |  Whether or not bzlmod-ready dependencies should be included.   |  <code>True</code> |
 
 

--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -1,0 +1,22 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Definitions for bzlmod module extensions."""
+
+load("//swift:repositories.bzl", "swift_rules_dependencies")
+
+def _non_module_deps_impl(_):
+    swift_rules_dependencies(include_bzlmod_ready_dependencies = False)
+
+non_module_deps = module_extension(implementation = _non_module_deps_impl)

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -31,31 +31,36 @@ def _maybe(repo_rule, name, **kwargs):
     if not native.existing_rule(name):
         repo_rule(name = name, **kwargs)
 
-def swift_rules_dependencies():
+def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     """Fetches repositories that are dependencies of `rules_swift`.
 
     Users should call this macro in their `WORKSPACE` to ensure that all of the
     dependencies of the Swift rules are downloaded and that they are isolated
     from changes to those dependencies.
-    """
-    _maybe(
-        http_archive,
-        name = "bazel_skylib",
-        urls = [
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
-        ],
-        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
-    )
 
-    _maybe(
-        http_archive,
-        name = "build_bazel_apple_support",
-        urls = [
-            "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
-        ],
-        sha256 = "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
-    )
+    Args:
+        include_bzlmod_ready_dependencies: Whether or not bzlmod-ready
+            dependencies should be included.
+    """
+    if include_bzlmod_ready_dependencies:
+        _maybe(
+            http_archive,
+            name = "bazel_skylib",
+            urls = [
+                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            ],
+            sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
+        )
+
+        _maybe(
+            http_archive,
+            name = "build_bazel_apple_support",
+            urls = [
+                "https://github.com/bazelbuild/apple_support/releases/download/1.3.1/apple_support.1.3.1.tar.gz",
+            ],
+            sha256 = "f4fdf5c9b42b92ea12f229b265d74bb8cedb8208ca7a445b383c9f866cf53392",
+        )
 
     _maybe(
         http_archive,


### PR DESCRIPTION
This is an initial implementation of bzlmod support in `rules_swift`. Still some things left to figure out, but I was able to compile a basic iOS app with WIP implementations of `rules_apple`, `rules_swift` and `apple_support`.