### PR TITLE
Update index-import to 5.7

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -154,9 +154,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "build_bazel_rules_swift_index_import",
         build_file = "@build_bazel_rules_swift//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
-        canonical_id = "index-import-5.3.2.6",
-        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.3.2.6/index-import.zip"],
-        sha256 = "61a58363f56c5fd84d4ebebe0d9b5dd90c74ae170405a7b9018e8cf698e679de",
+        canonical_id = "index-import-5.7",
+        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.7/index-import.tar.gz"],
+        sha256 = "802f33638b996abe76285d1e0246e661919c0c3222877681e66c519f78145511",
     )
 
     _maybe(


### PR DESCRIPTION
The current version used is an x86 binary, which will fail on an Apple silicon machine without Rosetta installed.