### PR TITLE
Revert "Handle objc header path with incremental compiles (#922)"

### DIFF
--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -54,11 +54,10 @@ static std::string MakeIncrementalOutputPath(std::string path,
 };  // end namespace
 
 void OutputFileMap::ReadFromPath(const std::string &path,
-                                 const std::string &emit_module_path,
-                                 const std::string &emit_objc_header_path) {
+                                 const std::string &emit_module_path) {
   std::ifstream stream(path);
   stream >> json_;
-  UpdateForIncremental(path, emit_module_path, emit_objc_header_path);
+  UpdateForIncremental(path, emit_module_path);
 }
 
 void OutputFileMap::WriteToPath(const std::string &path) {
@@ -66,9 +65,8 @@ void OutputFileMap::WriteToPath(const std::string &path) {
   stream << json_;
 }
 
-void OutputFileMap::UpdateForIncremental(
-    const std::string &path, const std::string &emit_module_path,
-    const std::string &emit_objc_header_path) {
+void OutputFileMap::UpdateForIncremental(const std::string &path,
+                                         const std::string &emit_module_path) {
   bool derived =
       path.find(".derived_output_file_map.json") != std::string::npos;
 
@@ -171,12 +169,6 @@ void OutputFileMap::UpdateForIncremental(
     auto copied_swiftsourceinfo_path =
         MakeIncrementalOutputPath(swiftsourceinfo_path, derived);
     incremental_inputs[swiftsourceinfo_path] = copied_swiftsourceinfo_path;
-  }
-
-  if (!emit_objc_header_path.empty()) {
-    auto copied_objc_header_path =
-        MakeIncrementalOutputPath(emit_objc_header_path, derived);
-    incremental_inputs[emit_objc_header_path] = copied_objc_header_path;
   }
 
   json_ = new_output_file_map;

--- a/tools/worker/output_file_map.h
+++ b/tools/worker/output_file_map.h
@@ -56,8 +56,7 @@ class OutputFileMap {
   // Reads the output file map from the JSON file at the given path, and updates
   // it to support incremental builds.
   void ReadFromPath(const std::string &path,
-                    const std::string &emit_module_path,
-                    const std::string &emit_objc_header_path);
+                    const std::string &emit_module_path);
 
   // Writes the output file map as JSON to the file at the given path.
   void WriteToPath(const std::string &path);
@@ -66,8 +65,7 @@ class OutputFileMap {
   // Modifies the output file map's JSON structure in-place to replace file
   // paths with equivalents in the incremental storage area.
   void UpdateForIncremental(const std::string &path,
-                            const std::string &emit_module_path,
-                            const std::string &emit_objc_header_path);
+                            const std::string &emit_module_path);
 
   nlohmann::json json_;
   std::map<std::string, std::string> incremental_outputs_;

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -146,7 +146,7 @@ int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
     }
 
     OutputFileMap output_file_map;
-    output_file_map.ReadFromPath(output_file_map_path_, "", "");
+    output_file_map.ReadFromPath(output_file_map_path_, "");
 
     auto outputs = output_file_map.incremental_outputs();
     std::map<std::string, std::string>::iterator it;

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -82,7 +82,6 @@ void WorkProcessor::ProcessWorkRequest(
   OutputFileMap output_file_map;
   std::string output_file_map_path;
   std::string emit_module_path;
-  std::string emit_objc_header_path;
   bool is_wmo = false;
   bool is_dump_ast = false;
 
@@ -100,8 +99,6 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (prev_arg == "-emit-module-path") {
       emit_module_path = arg;
-    } else if (prev_arg == "-emit-objc-header-path") {
-      emit_objc_header_path = arg;
     } else if (ArgumentEnablesWMO(arg)) {
       is_wmo = true;
     }
@@ -117,8 +114,7 @@ void WorkProcessor::ProcessWorkRequest(
 
   if (!output_file_map_path.empty()) {
     if (is_incremental) {
-      output_file_map.ReadFromPath(output_file_map_path, emit_module_path,
-                                   emit_objc_header_path);
+      output_file_map.ReadFromPath(output_file_map_path, emit_module_path);
 
       // Rewrite the output file map to use the incremental storage area and
       // pass the compiler the path to the rewritten file.


### PR DESCRIPTION
This reverts commit e769f8d6a4adae93c244f244480a3ae740f24384.

Context: https://app.buildbuddy.io/invocation/b8cac903-0fe3-46aa-adc5-7721ef1419b2