### PR TITLE
Add publish-to-bcr app configuration

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,30 @@
+{
+    "homepage": "https://github.com/bazelbuild/rules_swift",
+    "maintainers": [
+        {
+            "email": "keithbsmiley@gmail.com",
+            "github": "keith",
+            "name": "Keith Smiley"
+        },
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "github@brentleyjones.com",
+            "github": "brentleyjones",
+            "name": "Jones Brentley"
+        },
+        {
+            "email": "t@thi.im",
+            "github": "thii",
+            "name": "Thi Doãn"
+        }
+    ],
+    "repository": [
+        "github:bazelbuild/rules_swift"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,28 @@
+shell_commands: &shell_commands
+- "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+- "mkdir $SWIFT_HOME"
+- "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+
+matrix:
+  platform:
+  - ubuntu2004
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    environment:
+      CC: "clang"
+      SWIFT_VERSION: "5.5.3"
+      SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
+      PATH: "$PATH:$SWIFT_HOME/usr/bin"
+    shell_commands: *shell_commands
+    build_flags:
+    - "--action_env=PATH"
+    build_targets:
+    - "@rules_swift//examples/xplatform/..."
+    - "-@rules_swift//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
+  verify_targets_macos:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+    - "@rules_swift//examples/apple/..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "",
+  "url": "https://github.com/bazelbuild/rules_swift/releases/download/{TAG}/rules_swift.{TAG}.tar.gz"
+}


### PR DESCRIPTION
These configuration files are needed to get https://github.com/bazel-contrib/publish-to-bcr to publish new releases to the [bazel-central-registry](https://github.com/bazel-contrib/publish-to-bcr) every time a new release is cut.

I also requested to install the GitHub app in this repo, which is required in order for the sync to work.