### PR TITLE
Add fixedReleaser to fix BCR app pipeline

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: BalestraPatrick
+  email: me@patrickbalestra.com


### PR DESCRIPTION
The GitHub app to automatically publish new releases to the Bazel Central Registry was failing because it was looking for a BCR fork under the user who tags the release. In our case, this is automated by a GitHub action and so there’s no fork. By adding this config file, we override the default releaser to be my username, so the fork https://github.com/balestrapatrick/bazel-central-registry will be correctly found.

This behavior is documented here: https://github.com/bazel-contrib/publish-to-bcr/blob/main/templates/README.md#optional-configyml