### PR TITLE
[bzlmod] Add dependency on platforms

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", repo_name = "build_bazel_apple_support", version = "1.3.2")
 bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "3.19.2")  # To be removed once rules_proto is bzlmod-ready.
 
 non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")


### PR DESCRIPTION
This was discovered while registering the latest rules_swift release into the BCR and running the validation pipelines there. It was tricky to debug, but it seems like either a recent change in rules_swift or bzlmod and Bazel caused this to be required.

https://github.com/bazelbuild/bazel-central-registry/pull/327

Now that bzlmod is more stable, we should likely look into adding a bzlmod verification pipeline directly in this repo so we can catch regressions earlier.