### PR TITLE
Add generate_internal_visibility_from_proto_files feature

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -295,6 +295,11 @@ SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES = "swift.generate_from_raw_proto_fil
 # generating a Swift file from a proto file.
 SWIFT_FEATURE_GENERATE_PATH_TO_UNDERSCORES_FROM_PROTO_FILES = "swift.generate_path_to_underscores_from_proto_files"
 
+# If enabled, the toolchain will use `--swift_opt=Visibility=Internal`
+# (instead of `--swift_opt=Visibility=Public`) for the protoc Swift plugin arguments when
+# generating a Swift file from a proto file.
+SWIFT_FEATURE_GENERATE_INTERNAL_VISIBILITY_FROM_PROTO_FILES = "swift.generate_internal_visibility_from_proto_files"
+
 # If enabled and whole module optimisation is being used, the `*.swiftdoc`,
 # `*.swiftmodule` and `*-Swift.h` are generated with a separate action
 # rather than as part of the compilation.

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -25,8 +25,8 @@ load(
     "SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_ENABLE_TESTING",
     "SWIFT_FEATURE_GENERATE_FROM_RAW_PROTO_FILES",
-    "SWIFT_FEATURE_GENERATE_PATH_TO_UNDERSCORES_FROM_PROTO_FILES",
     "SWIFT_FEATURE_GENERATE_INTERNAL_VISIBILITY_FROM_PROTO_FILES",
+    "SWIFT_FEATURE_GENERATE_PATH_TO_UNDERSCORES_FROM_PROTO_FILES",
 )
 load(":linking.bzl", "new_objc_provider")
 load(
@@ -402,7 +402,7 @@ def _swift_protoc_gen_aspect_impl(target, aspect_ctx):
         )
         generate_internal_visibility_from_proto_files = swift_common.is_enabled(
             feature_configuration = feature_configuration,
-            feature_name = SWIFT_FEATURE_GENERATE_INTERNAL_VISIBILITY_FROM_PROTO_FILES
+            feature_name = SWIFT_FEATURE_GENERATE_INTERNAL_VISIBILITY_FROM_PROTO_FILES,
         )
 
         # Only the files for direct sources should be generated, but the

--- a/third_party/com_github_apple_swift_log/BUILD.overlay
+++ b/third_party/com_github_apple_swift_log/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 

--- a/third_party/com_github_apple_swift_nio/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -13,12 +8,12 @@ swift_library(
     srcs = glob([
         "Sources/NIOCore/*.swift",
     ]),
-    deps = [
-        ":NIOConcurrencyHelpers",
-        ":CNIOLinux",
-    ],
     module_name = "NIOCore",
     visibility = ["//visibility:public"],
+    deps = [
+        ":CNIOLinux",
+        ":NIOConcurrencyHelpers",
+    ],
 )
 
 swift_library(
@@ -29,8 +24,8 @@ swift_library(
     module_name = "NIOEmbedded",
     visibility = ["//visibility:public"],
     deps = [
-        "NIOCore",
         "NIOConcurrencyHelpers",
+        "NIOCore",
         "_NIODataStructures",
     ],
 )
@@ -43,8 +38,8 @@ swift_library(
     module_name = "NIOPosix",
     visibility = ["//visibility:public"],
     deps = [
-        "CNIOLinux",
         "CNIODarwin",
+        "CNIOLinux",
         "CNIOWindows",
         "NIOConcurrencyHelpers",
         "NIOCore",
@@ -73,7 +68,10 @@ swift_library(
     ]),
     module_name = "_NIOConcurrency",
     visibility = ["//visibility:public"],
-    deps = ["NIO", "NIOCore"],
+    deps = [
+        "NIO",
+        "NIOCore",
+    ],
 )
 
 swift_library(
@@ -179,8 +177,8 @@ swift_library(
     module_name = "NIOHTTP1",
     visibility = ["//visibility:public"],
     deps = [
-        ":NIOCore",
         ":CNIOHTTPParser",
+        ":NIOCore",
     ],
 )
 
@@ -202,9 +200,9 @@ swift_library(
     module_name = "_NIODataStructures",
     visibility = ["//visibility:public"],
     deps = [
-        "NIOCore",
-        "NIOConcurrencyHelpers",
         "CNIOHTTPParser",
+        "NIOConcurrencyHelpers",
+        "NIOCore",
     ],
 )
 

--- a/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -13,9 +8,9 @@ swift_library(
     srcs = glob([
         "Sources/NIOExtras/**/*.swift",
     ]),
+    module_name = "NIOExtras",
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_apple_swift_nio//:NIOCore",
     ],
-    module_name = "NIOExtras",
-    visibility = ["//visibility:public"],
 )

--- a/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -13,13 +8,13 @@ swift_library(
     srcs = glob([
         "Sources/NIOHPACK/**/*.swift",
     ]),
+    module_name = "NIOHPACK",
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_apple_swift_nio//:NIOCore",
         "@com_github_apple_swift_nio//:NIOHTTP1",
         "@com_github_apple_swift_nio//:NIOTLS",
     ],
-    module_name = "NIOHPACK",
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
@@ -27,9 +22,9 @@ swift_library(
     srcs = glob([
         "Sources/NIOHTTP2/**/*.swift",
     ]),
+    module_name = "NIOHTTP2",
+    visibility = ["//visibility:public"],
     deps = [
         ":NIOHPACK",
     ],
-    module_name = "NIOHTTP2",
-    visibility = ["//visibility:public"],
 )

--- a/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -13,11 +8,11 @@ swift_library(
     srcs = glob([
         "Sources/NIOTransportServices/**/*.swift",
     ]),
+    module_name = "NIOTransportServices",
+    visibility = ["//visibility:public"],
     deps = [
         "@com_github_apple_swift_nio//:NIOCore",
         "@com_github_apple_swift_nio//:NIOFoundationCompat",
         "@com_github_apple_swift_nio//:NIOTLS",
     ],
-    module_name = "NIOTransportServices",
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Fixes #961

**Change**
Create a new feature `swift.generate_internal_visibility_from_proto_files` which will set protoc's swift_opt `Visibility` from `Public` to `Internal`.

**Test**
- Create a valid rule for `swift_grpc_library` or `swift_proto_library`
  - Verify the generated sources still have the "public" access modifier
- Add the `swift.generate_internal_visibility_from_proto_files` to the `features` attribute for the above rule
  - Verify the generated sources now omit access modifiers (implicitly `internal`)

**Note**
The ideal solution would be to make the `Public` setting opt-in for this feature, thereby mirroring default protoc Swift plugin behavior. Since rules_swift has always defaulted to public visibility this should instead remain the default.