### PR TITLE
Fix runfiles lookup under bzlmod in Bazel 6

### DIFF
--- a/tools/worker/worker_main.cc
+++ b/tools/worker/worker_main.cc
@@ -25,7 +25,11 @@ using bazel::tools::cpp::runfiles::Runfiles;
 
 int main(int argc, char *argv[]) {
   std::string index_import_path;
-  std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0]));
+  #ifdef BAZEL_CURRENT_REPOSITORY
+    std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY));
+  #else
+    std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0]));
+  #endif  // BAZEL_CURRENT_REPOSITORY
   if (runfiles != nullptr) {
     // We silently ignore errors here, we will report an error later if this
     // path is accessed


### PR DESCRIPTION
When building Swift code with `--enable_bzlmod`, it currently fails due to the worker failing to find the `index-import` executable in the runfiles. This is because the naming is different under bzlmod and the C++ runfiles library was updated to support this new mapping as described in this [talk](https://www.youtube.com/watch?v=5NbgUMH1OGo). Since rules_swift supports both Bazel 5 and 6, we need to check `BAZEL_CURRENT_REPOSITORY` is defined to  simply make use of the new constructor which will make it so the runfiles lookup will happen relative to the `rules_swift` repo under Bazel 6.

I tested this locally with a `local_path_override` while iterating on getting the `rules_xcodeproj` to work under bzlmod (and also continues to work with bzlmod disabled in Bazel 6): https://github.com/buildbuddy-io/rules_xcodeproj/pull/1502