### PR TITLE
Fix sanitizers on Linux

### DIFF
--- a/examples/xplatform/xctest/BUILD
+++ b/examples/xplatform/xctest/BUILD
@@ -25,6 +25,8 @@ swift_test(
         "XCTEST_BINDIR_ENV_VAR": "$(BINDIR)",
     },
     features = ["tsan"],
+    # TODO: Re-enable on Linux once Swift race is figured out (or maybe Swift is upgraded)
+    target_compatible_with = ["@platforms//os:macos"],
 )
 
 swift_test(

--- a/examples/xplatform/xctest/BUILD
+++ b/examples/xplatform/xctest/BUILD
@@ -38,6 +38,8 @@ swift_test(
         "XCTEST_BINDIR_ENV_VAR": "$(BINDIR)",
     },
     features = ["asan"],
+    # TODO: Re-enable on Linux once Swift memory leak is figured out (or maybe Swift is upgraded)
+    target_compatible_with = ["@platforms//os:macos"],
 )
 
 swift_test(
@@ -51,6 +53,8 @@ swift_test(
         "XCTEST_BINDIR_ENV_VAR": "$(BINDIR)",
     },
     features = ["ubsan"],
+    # TODO: Re-enable on Linux if Swift ever supports ubsan on linux
+    target_compatible_with = ["@platforms//os:macos"],
 )
 
 swift_test(
@@ -67,4 +71,6 @@ swift_test(
         "tsan",
         "ubsan",
     ],
+    # TODO: Re-enable on Linux if Swift ever supports ubsan on linux
+    target_compatible_with = ["@platforms//os:macos"],
 )


### PR DESCRIPTION
When a feature name doesn't start with `swift.` we check if it's enabled
by checking against the C++ features, not against all features.
Previously the Linux CC toolchain didn't support sanitizers so these
just never worked on Linux and the features were silently ignored from
Swift. Today these features were added to the Linux CC toolchain
https://github.com/bazelbuild/bazel/commit/abae5ca3e8142f93cf0c2597e3410ed955c4dd59
which broke Linux CI because ubsan doesn't work with Swift on Linux and
asan fails because of a memory leak in Swift
