### PR TITLE
Fix tests for bzlmod

### DIFF
--- a/test/module_cache_settings_tests.bzl
+++ b/test/module_cache_settings_tests.bzl
@@ -63,7 +63,7 @@ def module_cache_settings_test_suite(name):
         ],
         not_expected_argv = [
             "-Xwrapped-swift=-ephemeral-module-cache",
-            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/$(WORKSPACE_NAME)",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],
@@ -76,7 +76,7 @@ def module_cache_settings_test_suite(name):
         name = "{}_tmpdir_module_cache_build".format(name),
         expected_argv = [
             "-module-cache-path",
-            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/$(WORKSPACE_NAME)",
         ],
         not_expected_argv = [
             "-Xwrapped-swift=-ephemeral-module-cache",
@@ -91,7 +91,7 @@ def module_cache_settings_test_suite(name):
     incorrect_global_module_cache_uses_tmpdir_action_command_line_test(
         name = "{}_incorrect_tmpdir_module_cache_build".format(name),
         not_expected_argv = [
-            "/tmp/__build_bazel_rules_swift/swift_module_cache/build_bazel_rules_swift",
+            "/tmp/__build_bazel_rules_swift/swift_module_cache/$(WORKSPACE_NAME)",
         ],
         mnemonic = "SwiftCompile",
         tags = [name],

--- a/test/rules/action_command_line_test.bzl
+++ b/test/rules/action_command_line_test.bzl
@@ -79,7 +79,7 @@ def _action_command_line_test_impl(ctx):
     concatenated_args = " ".join(action.argv) + " "
     bin_dir = analysistest.target_bin_dir_path(env)
     for expected in ctx.attr.expected_argv:
-        expected = expected.replace("$(BIN_DIR)", bin_dir)
+        expected = expected.replace("$(BIN_DIR)", bin_dir).replace("$(WORKSPACE_NAME)", ctx.workspace_name)
         if expected + " " not in concatenated_args and expected + "=" not in concatenated_args:
             unittest.fail(
                 env,
@@ -90,7 +90,7 @@ def _action_command_line_test_impl(ctx):
                 ),
             )
     for not_expected in ctx.attr.not_expected_argv:
-        not_expected = not_expected.replace("$(BIN_DIR)", bin_dir)
+        not_expected = not_expected.replace("$(BIN_DIR)", bin_dir).replace("$(WORKSPACE_NAME)", ctx.workspace_name)
         if not_expected + " " in concatenated_args or not_expected + "=" in concatenated_args:
             unittest.fail(
                 env,


### PR DESCRIPTION
This adds string replacement for the workspace name since it is `_main`
when using bzlmod
