### PR TITLE
Fix testing everything on Linux

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,14 +23,10 @@ x_defaults:
       - "--action_env=PATH"
     build_targets:
       - "//examples/..."
-      - "-//examples/apple/..."
-      - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
     test_flags: *linux_flags
     test_targets:
       - "//examples/..."
       - "//test/..."
-      - "-//examples/apple/..."
-      - "-//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
   windows_common: &windows_common
     platform: windows
     build_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -76,6 +76,13 @@ tasks:
       - "mkdir $SWIFT_HOME"
       - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     <<: *linux_common
+    build_targets:
+      - "//examples/..."
+      - "-//examples/apple/..."
+    test_targets:
+      - "//examples/..."
+      - "//test/..."
+      - "-//examples/apple/..."
 
   ubuntu2004_latest:
     name: "Current LTS"

--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -14,6 +14,7 @@ objc_library(
     name = "PrintStream",
     srcs = ["OIPrintStream.m"],
     hdrs = ["OIPrintStream.h"],
+    target_compatible_with = ["@platforms//os:macos"],
 )
 
 swift_library(
@@ -27,6 +28,7 @@ swift_library(
 objc_library(
     name = "main",
     srcs = ["main.m"],
+    target_compatible_with = ["@platforms//os:macos"],
     deps = [":Printer"],
 )
 

--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -66,7 +66,10 @@ swift_binary(
 
 swift_test(
     name = "echo_client_unit_test",
-    srcs = ["client_unit_test.swift"],
+    srcs = [
+        "client_unit_test.swift",
+        "main.swift",
+    ],
     deps = [
         ":echo_client_services_swift",
         ":echo_client_test_stubs_swift",

--- a/examples/xplatform/grpc/client_unit_test.swift
+++ b/examples/xplatform/grpc/client_unit_test.swift
@@ -18,8 +18,7 @@ import examples_xplatform_grpc_echo_proto
 
 @testable import examples_xplatform_grpc_echo_client_test_stubs_swift
 
-class ClientUnitTest {
-
+class ClientUnitTest: XCTestCase {
   func testSynchronousCall() throws {
     let client: RulesSwift_Examples_Grpc_EchoServiceClientProtocol = {
       let stub = RulesSwift_Examples_Grpc_EchoServiceTestClient()
@@ -32,4 +31,8 @@ class ClientUnitTest {
    let response = try! call.response.wait()
    XCTAssertEqual(response.contents, "Hello")
   }
+
+  static var allTests = [
+    ("testSynchronousCall", testSynchronousCall),
+  ]
 }

--- a/examples/xplatform/grpc/main.swift
+++ b/examples/xplatform/grpc/main.swift
@@ -1,0 +1,7 @@
+#if os(Linux)
+import XCTest
+
+XCTMain([
+  testCase(ClientUnitTest.allTests),
+])
+#endif

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -13,8 +13,8 @@ cc_library(
     hdrs = glob([
         "Sources/CGRPCZlib/**/*.h",
     ]),
-    copts = [],
     includes = ["Sources/CGRPCZlib/include"],
+    linkopts = ["-lz"],
     tags = ["swift_module=CGRPCZlib"],
 )
 


### PR DESCRIPTION
This way you can do `bazel test ...`. It also means we're testing gRPC
which was fixed at some point.
