### PR TITLE
Remove obsolete `incompatible_use_toolchain_transition`

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -465,6 +465,5 @@ The version of XCTest that the toolchain packages.
     doc = "Represents a Swift compiler toolchain.",
     fragments = ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -830,6 +830,5 @@ for incremental compilation using a persistent mode.
         "swift",
     ],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     implementation = _xcode_swift_toolchain_impl,
 )


### PR DESCRIPTION
https://github.com/bazelbuild/bazel/issues/14127#issuecomment-1396053583