### PR TITLE
Always add isFramework to explicit module map

### DIFF
--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -39,7 +39,10 @@ def write_explicit_swift_module_map_file(
             continue
 
         swift_context = module_context.swift
-        module_description = {"moduleName": module_context.name}
+        module_description = {
+            "moduleName": module_context.name,
+            "isFramework": False,
+        }
         if swift_context.swiftmodule:
             module_description["modulePath"] = swift_context.swiftmodule.path
         module_descriptions.append(module_description)


### PR DESCRIPTION
Without this value you get UB https://github.com/apple/swift/pull/63119

This hit us where it defaults to true with Swift 5.7.2 on Ubuntu 22.04,
but not on Ubuntu 20.04. I don't think this ever needs to be true for
bazel
