### PR TITLE
Revert "Remove obsolete `incompatible_use_toolchain_transition` (#988)"

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -465,5 +465,6 @@ The version of XCTest that the toolchain packages.
     doc = "Represents a Swift compiler toolchain.",
     fragments = ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,
 )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -830,5 +830,6 @@ for incremental compilation using a persistent mode.
         "swift",
     ],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
     implementation = _xcode_swift_toolchain_impl,
 )


### PR DESCRIPTION
This reverts commit da30f00a2aae92bd32feb5f0cef0af23d6dabcfc.

We need to keep this until we drop Bazel 5 support: https://github.com/bazelbuild/bazel/issues/14127#issuecomment-1402082370.