### PR TITLE
Bump shas of non-release rules_swift deps

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -88,7 +88,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_protobuf",
         urls = ["https://github.com/apple/swift-protobuf/archive/1.19.0.tar.gz"],
-        sha256 = "f057930b9dbd17abeaaceaa45e9f8b3e87188c05211710563d2311b9edf490aa",
+        sha256 = "294443cd9ef26a7669220b7c4866775b96d5120b1fc9759c8bb5654124b534fe",
         strip_prefix = "swift-protobuf-1.19.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
     )
@@ -97,7 +97,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_grpc_grpc_swift",
         urls = ["https://github.com/grpc/grpc-swift/archive/1.7.3.tar.gz"],
-        sha256 = "833a150bdebb8ec0282fd91761aec0705a9b05645de42619b60fb6b9ec04b786",
+        sha256 = "c2337d2c6fe9605c653759ac6a79426eca215fc0e67658b4c3562b960261e94e",
         strip_prefix = "grpc-swift-1.7.3/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
     )
@@ -106,7 +106,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_nio",
         urls = ["https://github.com/apple/swift-nio/archive/2.40.0.tar.gz"],
-        sha256 = "fd0418e9cc64d5c05012b37147c819978ac162c5ec7aa874a488846f6b3a90e6",
+        sha256 = "65a57678a27e86dfdecf7fc8145e8c2299a246ed18a32c5464d04d2144f50f16",
         strip_prefix = "swift-nio-2.40.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio/BUILD.overlay",
     )
@@ -115,7 +115,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_nio_http2",
         urls = ["https://github.com/apple/swift-nio-http2/archive/1.21.0.tar.gz"],
-        sha256 = "f034bd793d2170e1b85b6feb8cb796154d96ae43ff3a912ac6b992367faef09c",
+        sha256 = "4c6d1f1bfd8e2d98a45b3ff898b169a6e9186233abae1c28777e6b3a023af84a",
         strip_prefix = "swift-nio-http2-1.21.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
     )
@@ -124,7 +124,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_nio_transport_services",
         urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.12.0.tar.gz"],
-        sha256 = "bf0fa49564263048b988b9767a05ca2c43c167d27172886c5f070720c3adbe8d",
+        sha256 = "5e1e2a96a2cb80f3fa1796530342142d2cb800f666533dd0bc4f62d17a1b8d05",
         strip_prefix = "swift-nio-transport-services-1.12.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
     )
@@ -133,7 +133,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_nio_extras",
         urls = ["https://github.com/apple/swift-nio-extras/archive/1.11.0.tar.gz"],
-        sha256 = "57ef8b0a19bd3d4233ee18d4b96c0d2fc95d66ae53c5d6d2105e1428f672bd0d",
+        sha256 = "d8e8e07216690f1bb1bebd1e8c7432e3a9c3166e927562357e8d00637d05beaf",
         strip_prefix = "swift-nio-extras-1.11.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
     )
@@ -142,7 +142,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         http_archive,
         name = "com_github_apple_swift_log",
         urls = ["https://github.com/apple/swift-log/archive/1.4.2.tar.gz"],
-        sha256 = "de51662b35f47764b6e12e9f1d43e7de28f6dd64f05bc30a318cf978cf3bc473",
+        sha256 = "7507ff8904cc139c7d8fe81c7b49224035e09767413f546ce3cebe97e2360202",
         strip_prefix = "swift-log-1.4.2/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_log/BUILD.overlay",
     )


### PR DESCRIPTION
Update shas of rules_swift non release dependencies.

Github guarantees the release archives only unfortunately so this broke CI for a number of OSS repos that don't have other mirroring strategies. 

Per github's official comms
> The default compression for Git archives has recently changed.
> As result, archives downloaded from GitHub may have different checksums
> even though the contents are completely unchanged.

https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/
https://github.com/bazel-contrib/SIG-rules-authors/issues/11#issuecomment-1409390654