### PR TITLE
Build with incompatible_disallow_empty_glob

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 
+# Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
+build --incompatible_disallow_empty_glob
+
 # Since there's no way to set the deployment version for swift_{binary,test},
 # this forces all targets' minimum macOS to Catalina until Bazel CI has
 # upgraded their Mac machines to Big Sur.


### PR DESCRIPTION
In order to flip the flag, all downstream projects should be adapted. However, it is hard to fix them all if there are constant regressions. Adding it to the CI will ensure that once the project can build with incompatible_disallow_empty_glob it can keep building like that.
See: https://github.com/bazelbuild/bazel/pull/15327