### PR TITLE
Remove overlay glob patterns with empty results

### DIFF
--- a/third_party/com_github_apple_swift_nio/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio/BUILD.overlay
@@ -93,7 +93,6 @@ cc_library(
     name = "CNIOAtomics",
     srcs = glob([
         "Sources/CNIOAtomics/**/*.c",
-        "Sources/CNIOAtomics/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CNIOAtomics/**/*.h",
@@ -107,7 +106,6 @@ cc_library(
     name = "CNIOSHA1",
     srcs = glob([
         "Sources/CNIOSHA1/**/*.c",
-        "Sources/CNIOSHA1/**/*.cc",
     ]),
     hdrs = [
         "Sources/CNIOSHA1/**/*.h",
@@ -121,7 +119,6 @@ cc_library(
     name = "CNIOLinux",
     srcs = glob([
         "Sources/CNIOLinux/**/*.c",
-        "Sources/CNIOLinux/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CNIOLinux/**/*.h",
@@ -135,7 +132,6 @@ cc_library(
     name = "CNIODarwin",
     srcs = glob([
         "Sources/CNIODarwin/**/*.c",
-        "Sources/CNIODarwin/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CNIODarwin/**/*.h",
@@ -149,7 +145,6 @@ cc_library(
     name = "CNIOWindows",
     srcs = glob([
         "Sources/CNIOWindows/**/*.c",
-        "Sources/CNIOWindows/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CNIOWindows/**/*.h",
@@ -212,7 +207,6 @@ cc_library(
     name = "CNIOHTTPParser",
     srcs = glob([
         "Sources/CNIOHTTPParser/**/*.c",
-        "Sources/CNIOHTTPParser/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CNIOHTTPParser/**/*.h",

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -8,7 +8,6 @@ cc_library(
     name = "CGRPCZlib",
     srcs = glob([
         "Sources/CGRPCZlib/**/*.c",
-        "Sources/CGRPCZlib/**/*.cc",
     ]),
     hdrs = glob([
         "Sources/CGRPCZlib/**/*.h",


### PR DESCRIPTION
Allows https://github.com/bazelbuild/rules_swift/pull/995 to apply cleanly.