### PR TITLE
Fix bzlmod for tests as well

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -54,6 +54,8 @@ tasks:
     <<: *mac_common
     build_flags:
       - "--enable_bzlmod"
+    test_flags:
+      - "--enable_bzlmod"
 
   macos_last_green:
     name: "Last Green Bazel"


### PR DESCRIPTION
Always surprised that build_flags aren't used for the test invocation
