### PR TITLE
Add simple feature tests for `swift.use_global_index_store`

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -156,7 +156,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         build_file = "@build_bazel_rules_swift//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
         canonical_id = "index-import-5.7.0.1",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.7.0.1/index-import.tar.gz"],
-        sha256 = "9e26765efd7cda24dbe9195dfb1ff8abcaa9ac7bafc3afa7fc1d081dea47d7f",
+        sha256 = "9e26765efd7cda24dbe91965dfb1ff8abcaa9ac7bafc3afa7fc1d081dea47d7f",
     )
 
     _maybe(

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -156,7 +156,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         build_file = "@build_bazel_rules_swift//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
         canonical_id = "index-import-5.7.0.1",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.7.0.1/index-import.tar.gz"],
-        sha256 = "9e26765efd7cda24dbe91965dfb1ff8abcaa9ac7bafc3afa7fc1d081dea47d7f",
+        sha256 = "9e26765efd7cda24dbe9195dfb1ff8abcaa9ac7bafc3afa7fc1d081dea47d7f",
     )
 
     _maybe(

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -38,6 +38,23 @@ file_prefix_xcode_remap_test = make_action_command_line_test_rule(
     },
 )
 
+use_global_index_store_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_global_index_store",
+        ],
+    },
+)
+
+use_global_index_store_index_while_building_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.index_while_building",
+            "swift.use_global_index_store",
+        ],
+    },
+)
+
 vfsoverlay_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
@@ -94,6 +111,26 @@ def features_test_suite(name):
             "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    use_global_index_store_test(
+        name = "{}_use_global_index_store_test".format(name),
+        tags = [name],
+        not_expected_argv = [
+            "-Xwrapped-swift=-global-index-store-import-path=",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    use_global_index_store_index_while_building_test(
+        name = "{}_use_global_index_store_index_while_building_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xwrapped-swift=-global-index-store-import-path=bazel-out/_global_index_store",
+        ],
         mnemonic = "SwiftCompile",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
I mainly wanted this to have CI pull down the `build_bazel_rules_swift_index_import` repository. Later we can add tests that would verify the interaction of `swift.use_global_index_store` and `swift.file_prefix_map`.