### PR TITLE
Add support for removing -ObjC flag

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -331,3 +331,8 @@ SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX = "swift.supports_bare_slash_regex"
 # this feature if you have a version of Swift that fixes it and you care about
 # minor binary size improvements
 SWIFT_FEATURE_LLD_GC_WORKAROUND = "swift.lld_gc_workaround"
+
+# Enable the default -ObjC link flags that otherwise wouldn't be passed to
+# non-Apple binary top level targets. Disable this to avoid over-linking
+# objects if you know that isn't required.
+SWIFT_FEATURE_OBJC_LINK_FLAGS = "swift.objc_link_flags"

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -24,7 +24,11 @@ load(
 )
 load(":derived_files.bzl", "derived_files")
 load(":features.bzl", "get_cc_feature_configuration", "is_feature_enabled")
-load(":feature_names.bzl", "SWIFT_FEATURE_LLD_GC_WORKAROUND")
+load(
+    ":feature_names.bzl",
+    "SWIFT_FEATURE_LLD_GC_WORKAROUND",
+    "SWIFT_FEATURE_OBJC_LINK_FLAGS",
+)
 load(
     ":developer_dirs.bzl",
     "developer_dirs_linkopts",
@@ -157,6 +161,25 @@ def create_linking_context_from_compilation_outputs(
                     cc_common.create_linker_input(
                         owner = label,
                         user_link_flags = depset(["-Wl,-z,nostart-stop-gc"]),
+                    ),
+                ]),
+            ),
+        )
+
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_OBJC_LINK_FLAGS,
+    ):
+        # TODO(b/112000244): These should get added by the C++ Starlark API,
+        # but we're using the "c++-link-executable" action right now instead of
+        # "objc-executable" because the latter requires additional variables
+        # not provided by cc_common. Figure out how to handle this correctly.
+        extra_linking_contexts.append(
+            cc_common.create_linking_context(
+                linker_inputs = depset([
+                    cc_common.create_linker_input(
+                        owner = label,
+                        user_link_flags = depset(["-ObjC"]),
                     ),
                 ]),
             ),

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -39,6 +39,7 @@ load(
     "SWIFT_FEATURE_ENABLE_SKIP_FUNCTION_BODIES",
     "SWIFT_FEATURE_FILE_PREFIX_MAP",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
+    "SWIFT_FEATURE_OBJC_LINK_FLAGS",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
@@ -230,7 +231,6 @@ def _swift_linkopts_providers(
         # of "objc-executable" because the latter requires additional
         # variables not provided by cc_common. Figure out how to handle this
         # correctly.
-        "-ObjC",
         "-Wl,-objc_abi_version,2",
     ]
 
@@ -612,6 +612,7 @@ def _xcode_swift_toolchain_impl(ctx):
         SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
         SWIFT_FEATURE_DEBUG_PREFIX_MAP,
         SWIFT_FEATURE_ENABLE_BATCH_MODE,
+        SWIFT_FEATURE_OBJC_LINK_FLAGS,
         SWIFT_FEATURE_OPT_USES_WMO,
         SWIFT_FEATURE_REMAP_XCODE_PATH,
         SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION,

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -62,6 +62,14 @@ explicit_swift_module_map_test = make_action_command_line_test_rule(
     },
 )
 
+disable_objc_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "-swift.objc_link_flags",
+        ],
+    },
+)
+
 def features_test_suite(name):
     """Test suite for various features.
 
@@ -168,4 +176,32 @@ def features_test_suite(name):
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
+    )
+
+    default_test(
+        name = "{}_default_link_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-L/usr/lib/swift",
+            "-ObjC",
+            "-Wl,-objc_abi_version,2",
+            "-Wl,-rpath,/usr/lib/swift",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    disable_objc_test(
+        name = "{}_disable_objc_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-L/usr/lib/swift",
+            "-Wl,-objc_abi_version,2",
+            "-Wl,-rpath,/usr/lib/swift",
+        ],
+        not_expected_argv = ["-ObjC"],
+        mnemonic = "CppLink",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
+        target_compatible_with = ["@platforms//os:macos"],
     )


### PR DESCRIPTION
-ObjC is used when linking to automatically force the linker to
over-discover things that appear unused to find things like Objective-C
categories and Swift protocol extensions that actually do affect
behavior. In the case that you've audited libraries for these, avoiding
passing these flags can reduce binary size.
