### PR TITLE
Remove -ObjC link flag by default

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -230,7 +230,6 @@ def _swift_linkopts_providers(
         # of "objc-executable" because the latter requires additional
         # variables not provided by cc_common. Figure out how to handle this
         # correctly.
-        "-ObjC",
         "-Wl,-objc_abi_version,2",
     ]
 

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -61,6 +61,13 @@ explicit_swift_module_map_test = make_action_command_line_test_rule(
         ],
     },
 )
+disable_objc_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "-objc_link_flag",
+        ],
+    },
+)
 
 def features_test_suite(name):
     """Test suite for various features.
@@ -168,4 +175,32 @@ def features_test_suite(name):
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
+    )
+
+    default_test(
+        name = "{}_default_link_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-L/usr/lib/swift",
+            "-ObjC",
+            "-Wl,-objc_abi_version,2",
+            "-Wl,-rpath,/usr/lib/swift",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    disable_objc_test(
+        name = "{}_disable_objc_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-L/usr/lib/swift",
+            "-Wl,-objc_abi_version,2",
+            "-Wl,-rpath,/usr/lib/swift",
+        ],
+        not_expected_argv = ["-ObjC"],
+        mnemonic = "CppLink",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
+        target_compatible_with = ["@platforms//os:macos"],
     )


### PR DESCRIPTION
This is moving into the cc toolchain instead so it can be more easily
disabled. If users are using the toolchain built in to bazel it's possible
their cc_binary / swift_binary / swift_test targets need to add this flag
manually until they move to the new toolchain.