### PR TITLE
Revert "Add support for imported_library when linking (#917)"

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -395,10 +395,6 @@ def register_link_binary_action(
                 "-framework",
                 objc.static_framework_names.to_list(),
             ))
-            dep_link_flags.extend([
-                lib.path
-                for lib in objc.imported_library.to_list()
-            ])
 
             linking_contexts.append(
                 cc_common.create_linking_context(
@@ -406,9 +402,7 @@ def register_link_binary_action(
                         cc_common.create_linker_input(
                             owner = owner,
                             user_link_flags = dep_link_flags,
-                            additional_inputs = depset(
-                                transitive = [objc.static_framework_file, objc.imported_library],
-                            ),
+                            additional_inputs = objc.static_framework_file,
                         ),
                     ]),
                 ),


### PR DESCRIPTION
With recent rules_apple updates, libraries are added both to CcInfo and
ObjcProvider's imported_library, which results in duplicate symbols.
Removing this and only relying on CcInfo for this is the path moving
forward. Theoretically a custom rule that produced objc info with
imported_librarys would be broken by this, but they will have to migrate
either way as this provider goes away for linking.

This reverts commit b83db34c861c1dec08c2907afd2bb9850ac88d62.
