### PR TITLE
Add a private feature for force alwayslink=True.

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -336,3 +336,7 @@ SWIFT_FEATURE_LLD_GC_WORKAROUND = "swift.lld_gc_workaround"
 # non-Apple binary top level targets. Disable this to avoid over-linking
 # objects if you know that isn't required.
 SWIFT_FEATURE_OBJC_LINK_FLAGS = "swift.objc_link_flag"
+
+# A private feature that is set by the toolchain if the given toolchain wants
+# all Swift compilations to always be linked.
+SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE = "swift._force_alwayslink_true"

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -28,6 +28,7 @@ load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_LLD_GC_WORKAROUND",
     "SWIFT_FEATURE_OBJC_LINK_FLAGS",
+    "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
 )
 load(
     ":developer_dirs.bzl",
@@ -149,6 +150,12 @@ def create_linking_context_from_compilation_outputs(
             cc_common.create_linking_context(
                 linker_inputs = depset(post_compile_linker_inputs),
             ),
+        )
+
+    if not alwayslink:
+        alwayslink = is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE,
         )
 
     if is_feature_enabled(


### PR DESCRIPTION
This can then be used by a toolchain that needs the behavior to ensure
all Swift code makes it into the final binary.

PiperOrigin-RevId: 516553733
(cherry picked from commit b48dda98f02cb6ea63990560eb3c21d55af0e4b0)
