### PR TITLE
Always add `index_import` to `data` for Apple based `swift_worker`

### DIFF
--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -3,14 +3,6 @@ load("@build_bazel_apple_support//rules:universal_binary.bzl", "universal_binary
 
 licenses(["notice"])
 
-# Internal hinge for index while building V2 feature
-config_setting(
-    name = "use_global_index_store",
-    values = {
-        "features": "swift.use_global_index_store",
-    },
-)
-
 cc_library(
     name = "compile_with_worker",
     srcs = [
@@ -83,7 +75,7 @@ cc_library(
         ],
     }),
     data = select({
-        ":use_global_index_store": [
+        "//swift/internal:apple": [
             "@build_bazel_rules_swift_index_import//:index_import",
         ],
         "//conditions:default": [],


### PR DESCRIPTION
With `--incompatible_use_host_features`, the select as it was no longer works, as it’s evaluated as `--host_fearture` instead of `—feature`.