### PR TITLE
[ReproAttempt]Seeing llvm profiles written to root

### DIFF
--- a/examples/apple/llvm_profile_leak/BUILD
+++ b/examples/apple/llvm_profile_leak/BUILD
@@ -1,0 +1,13 @@
+load("//swift:swift.bzl", "swift_binary", "swift_test")
+
+swift_binary(
+    name = "coverage",
+    srcs = ["main.swift"],
+)
+
+swift_test(
+    name = "tests",
+    srcs = [
+        "tests.swift",
+    ],
+)

--- a/examples/apple/llvm_profile_leak/main.swift
+++ b/examples/apple/llvm_profile_leak/main.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+let process: Process = .init()
+process.launchPath = "/usr/bin/env"
+process.currentDirectoryPath = "/Users/maxwellelliott/Development/rules_swift"
+process.arguments = [
+    "bazel",
+    "coverage",
+    "//examples/apple/llvm_profile_leak/...",
+    "--experimental_use_llvm_covmap",
+    "--action_env=LCOV_MERGER=/usr/bin/true",
+    "--spawn_strategy=worker,sandboxed,local",
+    "--experimental_inprocess_symlink_creation",
+    "--define=apple.experimental.tree_artifact_outputs=1",
+    "--incompatible_strict_action_env"
+]
+let outputPipe: Pipe = .init()
+let errorPipe: Pipe = .init()
+process.standardOutput = outputPipe
+process.standardError = errorPipe
+process.launch()
+process.waitUntilExit()
+
+let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+let output = String(decoding: outputData, as: UTF8.self)
+let error = String(decoding: errorData, as: UTF8.self)
+print("output: \(output)")
+print("error: \(error)")

--- a/examples/apple/llvm_profile_leak/tests.swift
+++ b/examples/apple/llvm_profile_leak/tests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+class PassTests: XCTestCase {
+
+    func test_pass() {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
In one of our repositories we are seeing `default.profraw` files written to the root of the repository when executing
coverage. This repro tries to
do this but is unable to get this file to appear