### PR TITLE
Mark swift_autoconfiguration as local

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -413,4 +413,5 @@ def _swift_autoconfiguration_impl(repository_ctx):
 swift_autoconfiguration = repository_rule(
     environ = ["CC", "PATH", "ProgramData", "Path"],
     implementation = _swift_autoconfiguration_impl,
+    local = True,
 )


### PR DESCRIPTION
This makes sure the rule is evaluated whenever a new Bazel server starts, which gives it a chance to regenerate the `swift-version` file which will be used in the resulting action keys.

One example to reproduce the issue without `local = True`:

```sh
ln -sf /opt/swift-5.7/bin/swift* /usr/local/bin/
bazel build //:swift-binary
cat $(bazel info output_base)/external/build_bazel_rules_swift_local_config/swift_version
# Swift version 5.7.3 (swift-5.7.3-RELEASE)
# Target: x86_64-unknown-linux-gnu

bazel shutdown
ln -sf /opt/swift-5.8/bin/swift* /usr/local/bin/

bazel build //:swift-binary # cache hit (should be a miss)
cat $(bazel info output_base)/external/build_bazel_rules_swift_local_config/swift_version
# Swift version 5.7.3 (swift-5.7.3-RELEASE)
# Target: x86_64-unknown-linux-gnu
```

with `local = True` the example above works as expected.

Fixes #1041 