### PR TITLE
Remove Bitcode support

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -29,7 +29,6 @@ load(":explicit_module_map_file.bzl", "write_explicit_swift_module_map_file")
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_BITCODE_EMBEDDED",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
     "SWIFT_FEATURE_CODEVIEW_DEBUG_INFO",
     "SWIFT_FEATURE_COVERAGE",
@@ -2665,12 +2664,6 @@ def _declare_compile_outputs(
         feature_name = SWIFT_FEATURE_EMIT_BC,
     )
 
-    # If enabled the compiler will embed LLVM BC in the object files.
-    embeds_bc = is_feature_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_BITCODE_EMBEDDED,
-    )
-
     if not output_nature.emits_multiple_objects:
         # If we're emitting a single object, we don't use an object map; we just
         # declare the output file that the compiler will generate and there are
@@ -2697,7 +2690,6 @@ def _declare_compile_outputs(
         # object files so that we can pass them all to the archive action.
         output_info = _declare_multiple_outputs_and_write_output_file_map(
             actions = actions,
-            embeds_bc = embeds_bc,
             emits_bc = emits_bc,
             split_derived_file_generation = split_derived_file_generation,
             srcs = srcs,
@@ -2757,7 +2749,6 @@ def _declare_compile_outputs(
 
 def _declare_multiple_outputs_and_write_output_file_map(
         actions,
-        embeds_bc,
         emits_bc,
         split_derived_file_generation,
         srcs,
@@ -2766,8 +2757,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
 
     Args:
         actions: The object used to register actions.
-        embeds_bc: If `True` the compiler will embed LLVM BC in the object
-            files.
         emits_bc: If `True` the compiler will generate LLVM BC files instead of
             object files.
         split_derived_file_generation: Whether objects and modules are produced
@@ -2824,7 +2813,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
     for src in srcs:
         src_output_map = {}
 
-        if embeds_bc or emits_bc:
+        if emits_bc:
             # Declare the llvm bc file (there is one per source file).
             obj = derived_files.intermediate_bc_file(
                 actions = actions,
@@ -2833,8 +2822,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
             )
             (output_objs if emits_bc else other_outputs).append(obj)
             src_output_map["llvm-bc"] = obj.path
-
-        if not emits_bc:
+        else:
             # Declare the object file (there is one per source file).
             obj = derived_files.intermediate_object_file(
                 actions = actions,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -30,12 +30,6 @@ SWIFT_FEATURE_DBG = "swift.dbg"
 SWIFT_FEATURE_FASTBUILD = "swift.fastbuild"
 SWIFT_FEATURE_OPT = "swift.opt"
 
-# These features correspond to the current Bitcode mode as specified by the
-# `apple` configuration fragment when targeting Apple platforms. At most one of
-# these will be enabled by the toolchain.
-SWIFT_FEATURE_BITCODE_EMBEDDED = "swift.bitcode_embedded"
-SWIFT_FEATURE_BITCODE_EMBEDDED_MARKERS = "swift.bitcode_embedded_markers"
-
 # This feature is enabled if coverage collection is enabled for the build. (See
 # the note above about not depending on the C++ features.)
 SWIFT_FEATURE_COVERAGE = "swift.coverage"

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -23,7 +23,7 @@ load(
 output_file_map_embed_bitcode_test = make_output_file_map_test_rule(
     config_settings = {
         "//command_line_option:features": [
-            "swift.bitcode_embedded",
+            "swift.emit_bc",
         ],
     },
 )
@@ -34,7 +34,7 @@ output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [
-            "swift.bitcode_embedded",
+            "swift.emit_bc",
         ],
     },
 )
@@ -63,7 +63,6 @@ def output_file_map_test_suite(name):
         name = "{}_embed_bitcode".format(name),
         expected_mapping = {
             "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
-            "object": "test/fixtures/debug_settings/simple_objs/Empty.swift.o",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
@@ -75,7 +74,6 @@ def output_file_map_test_suite(name):
         name = "{}_embed_bitcode_wmo".format(name),
         expected_mapping = {
             "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
-            "object": "test/fixtures/debug_settings/simple_objs/Empty.swift.o",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -66,17 +66,9 @@ split_swiftmodule_indexing_test = make_action_command_line_test_rule(
 )
 split_swiftmodule_bitcode_test = make_action_command_line_test_rule(
     config_settings = {
-        "//command_line_option:apple_bitcode": "embedded",
         "//command_line_option:features": [
             "swift.split_derived_files_generation",
-        ],
-    },
-)
-split_swiftmodule_bitcode_markers_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:apple_bitcode": "embedded_markers",
-        "//command_line_option:features": [
-            "swift.split_derived_files_generation",
+            "swift.emit_bc",
         ],
     },
 )
@@ -385,8 +377,7 @@ def split_derived_files_test_suite(name):
 
     split_swiftmodule_bitcode_test(
         name = "{}_bitcode_compile".format(name),
-        expected_argv = ["-embed-bitcode"],
-        target_compatible_with = ["@platforms//os:macos"],
+        expected_argv = ["-emit-bc"],
         mnemonic = "SwiftCompile",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
@@ -395,26 +386,7 @@ def split_derived_files_test_suite(name):
     split_swiftmodule_bitcode_test(
         name = "{}_bitcode_derive_files".format(name),
         not_expected_argv = [
-            "-embed-bitcode",
-        ],
-        mnemonic = "SwiftDeriveFiles",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
-    split_swiftmodule_bitcode_markers_test(
-        name = "{}_bitcode_markers_compile".format(name),
-        expected_argv = ["-embed-bitcode-marker"],
-        target_compatible_with = ["@platforms//os:macos"],
-        mnemonic = "SwiftCompile",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
-    split_swiftmodule_bitcode_markers_test(
-        name = "{}_bitcode_markers_derive_files".format(name),
-        not_expected_argv = [
-            "-embed-bitcode-marker",
+            "-emit-bc",
         ],
         mnemonic = "SwiftDeriveFiles",
         tags = [name],


### PR DESCRIPTION
Now that Xcode 14.1 is the minimum supported to the App Store, and Xcode
14.0 dropped support for bitcode, we don't need to handle these flags
anymore.

This keeps support for emitting LLVM Bitcode (confusing naming) for use
with LTO. This changes the relevant tests to test that behavior instead.

(cherry picked from commit 797660a758f924d9121689ba666d3f92044c2e5a)
