### PR TITLE
Disable zlib warning with Xcode 14.3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,8 @@
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 
+build --enable_platform_specific_config
+
 # Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
 build --incompatible_disallow_empty_glob
 
@@ -39,4 +41,4 @@ build --cxxopt='-std=c++14'
 # There is an open issue about it on the zlib repository here:
 # https://github.com/madler/zlib/issues/633
 build --per_file_copt="external/.*zlib.*/.*.c@-Wno-deprecated-non-prototype"
-build --host_copt=-Wno-deprecated-non-prototype
+build:macos --host_copt=-Wno-deprecated-non-prototype

--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,9 @@ build --host_cxxopt="-Wno-unused-function"
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
 build --cxxopt='-std=c++14'
 
+# TODO: Remove once we drop bazel 6.x support with bad zlib version
 # This C2K warning causes zlib to fail to compile.
 # There is an open issue about it on the zlib repository here:
 # https://github.com/madler/zlib/issues/633
 build --per_file_copt="external/.*zlib.*/.*.c@-Wno-deprecated-non-prototype"
+build --host_copt=-Wno-deprecated-non-prototype


### PR DESCRIPTION
https://buildkite.com/bazel/rules-swift-swift/builds/4233#018826fa-aba7-4586-afec-b473d6b327a5

Fixes https://github.com/bazelbuild/rules_swift/issues/1050