### PR TITLE
Upgrade GRPC and dependencies for async/await support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,7 +34,7 @@ build --host_cxxopt="-Wno-unused-function"
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
 build --cxxopt='-std=c++14'
 
-# This C2K warning causes zlib to fail.
+# This C2K warning causes zlib to fail to compile.
 # There is an open issue about it on the zlib repository here:
 # https://github.com/madler/zlib/issues/633
-build --cxxopt='-Wno-deprecated-non-prototype'
+build --per_file_copt="external/.*zlib.*/.*.c@-Wno-deprecated-non-prototype"

--- a/.bazelrc
+++ b/.bazelrc
@@ -33,3 +33,8 @@ build --host_cxxopt="-Wno-unused-function"
 # For more details on how to enable this in Bazel: 
 # https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
 build --cxxopt='-std=c++14'
+
+# This C2K warning causes zlib to fail.
+# There is an open issue about it on the zlib repository here:
+# https://github.com/madler/zlib/issues/633
+build --cxxopt='-Wno-deprecated-non-prototype'

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,3 +28,8 @@ build --host_cxxopt="-Wno-deprecated-declarations"
 build --per_file_copt="external/.*protobuf.*/.*.cc@-Wno-unused-function"
 # TODO: Use --host_per_file_copt here once we drop bazel 5.x
 build --host_cxxopt="-Wno-unused-function"
+
+# The CNIOBoringSSL library uses C++14 features like 'enable_if_t' macro support.
+# For more details on how to enable this in Bazel: 
+# https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
+build --cxxopt='-std=c++14'

--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -72,8 +72,8 @@ swift_test(
     ],
     deps = [
         ":echo_client_services_swift",
-        ":echo_server_services_swift",
         ":echo_proto_swift",
+        ":echo_server_services_swift",
     ],
 )
 

--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -72,7 +72,8 @@ swift_test(
     ],
     deps = [
         ":echo_client_services_swift",
-        ":echo_client_test_stubs_swift",
+        ":echo_server_services_swift",
+        ":echo_proto_swift",
     ],
 )
 

--- a/examples/xplatform/grpc/client_main.swift
+++ b/examples/xplatform/grpc/client_main.swift
@@ -41,7 +41,7 @@ struct ClientMain {
     )
 
     // Initialize the client using the same address the server is started on.
-    let client = RulesSwift_Examples_Grpc_EchoServiceClient(channel: channel)
+    let client = RulesSwift_Examples_Grpc_EchoServiceNIOClient(channel: channel)
 
     // Construct a request to the echo service.
     let request = RulesSwift_Examples_Grpc_EchoRequest.with {

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -86,7 +86,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_protobuf",
-        urls = ["https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"], # pinned to grpc-swift version
+        urls = ["https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"],  # pinned to grpc-swift version
         sha256 = "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
         strip_prefix = "swift-protobuf-1.20.2/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
@@ -95,7 +95,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc_swift",
-        urls = ["https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"], # latest at time of writing
+        urls = ["https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"],  # latest at time of writing
         sha256 = "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
         strip_prefix = "grpc-swift-1.16.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
@@ -104,7 +104,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio",
-        urls = ["https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"], # pinned to grpc swift version
+        urls = ["https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"],  # pinned to grpc swift version
         sha256 = "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
         strip_prefix = "swift-nio-2.42.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio/BUILD.overlay",
@@ -113,7 +113,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_http2",
-        urls = ["https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"], # pinned to grpc-swift version
+        urls = ["https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
         strip_prefix = "swift-nio-http2-1.26.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
@@ -122,7 +122,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_transport_services",
-        urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"], # pinned to grpc-swift version
+        urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
         strip_prefix = "swift-nio-transport-services-1.15.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
@@ -131,7 +131,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_extras",
-        urls = ["https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"], # pinned to grpc-swift version
+        urls = ["https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
         strip_prefix = "swift-nio-extras-1.4.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
@@ -140,7 +140,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_log",
-        urls = ["https://github.com/apple/swift-log/archive/1.4.4.tar.gz"], # pinned to grpc-swift version
+        urls = ["https://github.com/apple/swift-log/archive/1.4.4.tar.gz"],  # pinned to grpc-swift version
         sha256 = "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
         strip_prefix = "swift-log-1.4.4/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_log/BUILD.overlay",
@@ -149,7 +149,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_ssl",
-        urls = ["https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"], # pinned to grpc swift version
+        urls = ["https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"],  # pinned to grpc swift version
         sha256 = "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
         strip_prefix = "swift-nio-ssl-2.23.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay",
@@ -158,7 +158,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_collections",
-        urls = ["https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"], # pinned to swift-nio @ grpc-swift version
+        urls = ["https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"],  # pinned to swift-nio @ grpc-swift version
         sha256 = "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
         strip_prefix = "swift-collections-1.0.4/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_collections/BUILD.overlay",
@@ -167,7 +167,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_atomics",
-        urls = ["https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"], # pinned to swift-nio @ grpc-swift version
+        urls = ["https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"],  # pinned to swift-nio @ grpc-swift version
         sha256 = "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
         strip_prefix = "swift-atomics-1.1.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_atomics/BUILD.overlay",

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -86,64 +86,91 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "com_github_apple_swift_protobuf",
-        urls = ["https://github.com/apple/swift-protobuf/archive/1.19.0.tar.gz"],
-        sha256 = "f057930b9dbd17abeaaceaa45e9f8b3e87188c05211710563d2311b9edf490aa",
-        strip_prefix = "swift-protobuf-1.19.0/",
+        urls = ["https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"], # pinned to grpc-swift version
+        sha256 = "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
+        strip_prefix = "swift-protobuf-1.20.2/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_grpc_grpc_swift",
-        urls = ["https://github.com/grpc/grpc-swift/archive/1.7.3.tar.gz"],
-        sha256 = "833a150bdebb8ec0282fd91761aec0705a9b05645de42619b60fb6b9ec04b786",
-        strip_prefix = "grpc-swift-1.7.3/",
+        urls = ["https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"], # latest at time of writing
+        sha256 = "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
+        strip_prefix = "grpc-swift-1.16.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio",
-        urls = ["https://github.com/apple/swift-nio/archive/2.40.0.tar.gz"],
-        sha256 = "fd0418e9cc64d5c05012b37147c819978ac162c5ec7aa874a488846f6b3a90e6",
-        strip_prefix = "swift-nio-2.40.0/",
+        urls = ["https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"], # pinned to grpc swift version
+        sha256 = "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
+        strip_prefix = "swift-nio-2.42.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_http2",
-        urls = ["https://github.com/apple/swift-nio-http2/archive/1.21.0.tar.gz"],
-        sha256 = "f034bd793d2170e1b85b6feb8cb796154d96ae43ff3a912ac6b992367faef09c",
-        strip_prefix = "swift-nio-http2-1.21.0/",
+        urls = ["https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"], # pinned to grpc-swift version
+        sha256 = "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
+        strip_prefix = "swift-nio-http2-1.26.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_transport_services",
-        urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.12.0.tar.gz"],
-        sha256 = "bf0fa49564263048b988b9767a05ca2c43c167d27172886c5f070720c3adbe8d",
-        strip_prefix = "swift-nio-transport-services-1.12.0/",
+        urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"], # pinned to grpc-swift version
+        sha256 = "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
+        strip_prefix = "swift-nio-transport-services-1.15.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_nio_extras",
-        urls = ["https://github.com/apple/swift-nio-extras/archive/1.11.0.tar.gz"],
-        sha256 = "57ef8b0a19bd3d4233ee18d4b96c0d2fc95d66ae53c5d6d2105e1428f672bd0d",
-        strip_prefix = "swift-nio-extras-1.11.0/",
+        urls = ["https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"], # pinned to grpc-swift version
+        sha256 = "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
+        strip_prefix = "swift-nio-extras-1.4.0/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
     )
 
     _maybe(
         http_archive,
         name = "com_github_apple_swift_log",
-        urls = ["https://github.com/apple/swift-log/archive/1.4.2.tar.gz"],
-        sha256 = "de51662b35f47764b6e12e9f1d43e7de28f6dd64f05bc30a318cf978cf3bc473",
-        strip_prefix = "swift-log-1.4.2/",
+        urls = ["https://github.com/apple/swift-log/archive/1.4.4.tar.gz"], # pinned to grpc-swift version
+        sha256 = "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
+        strip_prefix = "swift-log-1.4.4/",
         build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_log/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_nio_ssl",
+        urls = ["https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"], # pinned to grpc swift version
+        sha256 = "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
+        strip_prefix = "swift-nio-ssl-2.23.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_collections",
+        urls = ["https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"], # pinned to swift-nio @ grpc-swift version
+        sha256 = "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
+        strip_prefix = "swift-collections-1.0.4/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_collections/BUILD.overlay",
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_apple_swift_atomics",
+        urls = ["https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"], # pinned to swift-nio @ grpc-swift version
+        sha256 = "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
+        strip_prefix = "swift-atomics-1.1.0/",
+        build_file = "@build_bazel_rules_swift//third_party:com_github_apple_swift_atomics/BUILD.overlay",
     )
 
     # It relies on `index-import` to import indexes into Bazel's remote

--- a/third_party/com_github_apple_swift_atomics/BUILD.overlay
+++ b/third_party/com_github_apple_swift_atomics/BUILD.overlay
@@ -1,0 +1,32 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "Atomics",
+    copts = [],
+    srcs = glob([
+        "Sources/Atomics/**/*.swift",
+    ]),
+    module_name = "Atomics",
+    alwayslink = True,
+    deps = [
+        ":_AtomicsShims",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "_AtomicsShims",
+    srcs = glob([
+        "Sources/_AtomicsShims/**/*.c",
+    ]),
+    hdrs = glob([
+        "Sources/_AtomicsShims/**/*.h",
+    ]),
+    copts = [],
+    includes = ["Sources/_AtomicsShims/include"],
+    tags = ["swift_module=_AtomicsShims"],
+    visibility = ["//visibility:private"],
+)

--- a/third_party/com_github_apple_swift_collections/BUILD.overlay
+++ b/third_party/com_github_apple_swift_collections/BUILD.overlay
@@ -1,0 +1,35 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "Collections",
+    srcs = glob([
+        "Sources/Collections/**/*.swift",
+    ]),
+    module_name = "Collections",
+    deps = [
+        ":DequeModule",
+        ":OrderedCollections",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "DequeModule",
+    srcs = glob([
+        "Sources/DequeModule/**/*.swift",
+    ]),
+    module_name = "DequeModule",
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "OrderedCollections",
+    srcs = glob([
+        "Sources/OrderedCollections/**/*.swift",
+    ]),
+    module_name = "OrderedCollections",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_apple_swift_log/BUILD.overlay
+++ b/third_party/com_github_apple_swift_log/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 

--- a/third_party/com_github_apple_swift_nio/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio/BUILD.overlay
@@ -1,92 +1,6 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
-)
-
-swift_library(
-    name = "NIOCore",
-    srcs = glob([
-        "Sources/NIOCore/*.swift",
-    ]),
-    deps = [
-        ":NIOConcurrencyHelpers",
-        ":CNIOLinux",
-    ],
-    module_name = "NIOCore",
-    visibility = ["//visibility:public"],
-)
-
-swift_library(
-    name = "NIOEmbedded",
-    srcs = glob([
-        "Sources/NIOEmbedded/*.swift",
-    ]),
-    module_name = "NIOEmbedded",
-    visibility = ["//visibility:public"],
-    deps = [
-        "NIOCore",
-        "NIOConcurrencyHelpers",
-        "_NIODataStructures",
-    ],
-)
-
-swift_library(
-    name = "NIOPosix",
-    srcs = glob([
-        "Sources/NIOPosix/*.swift",
-    ]),
-    module_name = "NIOPosix",
-    visibility = ["//visibility:public"],
-    deps = [
-        "CNIOLinux",
-        "CNIODarwin",
-        "CNIOWindows",
-        "NIOConcurrencyHelpers",
-        "NIOCore",
-        "_NIODataStructures",
-    ],
-)
-
-swift_library(
-    name = "NIO",
-    srcs = glob([
-        "Sources/NIO/*.swift",
-    ]),
-    module_name = "NIO",
-    visibility = ["//visibility:public"],
-    deps = [
-        "NIOCore",
-        "NIOEmbedded",
-        "NIOPosix",
-    ],
-)
-
-swift_library(
-    name = "_NIOConcurrency",
-    srcs = glob([
-        "Sources/_NIOConcurrency/*.swift",
-    ]),
-    module_name = "_NIOConcurrency",
-    visibility = ["//visibility:public"],
-    deps = ["NIO", "NIOCore"],
-)
-
-swift_library(
-    name = "NIOFoundationCompat",
-    srcs = glob([
-        "Sources/NIOFoundationCompat/*.swift",
-    ]),
-    module_name = "NIOFoundationCompat",
-    visibility = ["//visibility:public"],
-    deps = [
-        "NIO",
-        "NIOCore",
-    ],
 )
 
 cc_library(
@@ -103,16 +17,34 @@ cc_library(
 )
 
 cc_library(
-    name = "CNIOSHA1",
+    name = "CNIODarwin",
     srcs = glob([
-        "Sources/CNIOSHA1/**/*.c",
+        "Sources/CNIODarwin/**/*.c",
     ]),
-    hdrs = [
-        "Sources/CNIOSHA1/**/*.h",
+    hdrs = glob([
+        "Sources/CNIODarwin/**/*.h",
+    ]),
+    defines = [
+        "__APPLE_USE_RFC_3542",
     ],
+    includes = ["Sources/CNIODarwin/include"],
+    tags = ["swift_module=CNIODarwin"],
+)
+
+cc_library(
+    name = "CNIOLLHTTP",
+    srcs = glob([
+        "Sources/CNIOLLHTTP/**/*.c",
+    ]),
+    hdrs = glob([
+        "Sources/CNIOLLHTTP/**/*.h",
+    ]),
     copts = [],
-    includes = ["Sources/CNIOSHA1/include"],
-    tags = ["swift_module=CNIOSHA1"],
+    defines = [
+        "LLHTTP_STRICT_MODE",
+    ],
+    includes = ["Sources/CNIOLLHTTP/include"],
+    tags = ["swift_module=CNIOLLHTTP"],
 )
 
 cc_library(
@@ -129,16 +61,16 @@ cc_library(
 )
 
 cc_library(
-    name = "CNIODarwin",
+    name = "CNIOSHA1",
     srcs = glob([
-        "Sources/CNIODarwin/**/*.c",
+        "Sources/CNIOSHA1/**/*.c",
     ]),
-    hdrs = glob([
-        "Sources/CNIODarwin/**/*.h",
-    ]),
-    copts = ["-D__APPLE_USE_RFC_3542"],
-    includes = ["Sources/CNIODarwin/include"],
-    tags = ["swift_module=CNIODarwin"],
+    hdrs = [
+        "Sources/CNIOSHA1/**/*.h",
+    ],
+    copts = [],
+    includes = ["Sources/CNIOSHA1/include"],
+    tags = ["swift_module=CNIOSHA1"],
 )
 
 cc_library(
@@ -155,13 +87,73 @@ cc_library(
 )
 
 swift_library(
-    name = "NIOTLS",
+    name = "NIO",
     srcs = glob([
-        "Sources/NIOTLS/*.swift",
+        "Sources/NIO/*.swift",
     ]),
-    module_name = "NIOTLS",
+    module_name = "NIO",
     visibility = ["//visibility:public"],
     deps = [
+        ":NIOCore",
+        ":NIOEmbedded",
+        ":NIOPosix",
+    ],
+)
+
+swift_library(
+    name = "NIOConcurrencyHelpers",
+    srcs = glob([
+        "Sources/NIOConcurrencyHelpers/*.swift",
+    ]),
+    module_name = "NIOConcurrencyHelpers",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":CNIOAtomics"
+    ],
+)
+
+swift_library(
+    name = "NIOCore",
+    copts = [],
+    srcs = glob([
+        "Sources/NIOCore/**/*.swift",
+    ]),
+    deps = [
+        ":NIOConcurrencyHelpers",
+        ":CNIOLinux",
+        ":CNIOWindows",
+        "@com_github_apple_swift_atomics//:Atomics",
+        "@com_github_apple_swift_collections//:DequeModule",
+    ],
+    module_name = "NIOCore",
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "NIOEmbedded",
+    copts = [],
+    srcs = glob([
+        "Sources/NIOEmbedded/*.swift",
+    ]),
+    module_name = "NIOEmbedded",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NIOCore",
+        ":NIOConcurrencyHelpers",
+        ":_NIODataStructures",
+        "@com_github_apple_swift_atomics//:Atomics",
+    ],
+)
+
+swift_library(
+    name = "NIOFoundationCompat",
+    srcs = glob([
+        "Sources/NIOFoundationCompat/*.swift",
+    ]),
+    module_name = "NIOFoundationCompat",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NIO",
         ":NIOCore",
     ],
 )
@@ -174,19 +166,44 @@ swift_library(
     module_name = "NIOHTTP1",
     visibility = ["//visibility:public"],
     deps = [
+        ":NIO",
         ":NIOCore",
-        ":CNIOHTTPParser",
+        ":NIOConcurrencyHelpers",
+        ":CNIOLLHTTP",
     ],
 )
 
 swift_library(
-    name = "NIOConcurrencyHelpers",
+    name = "NIOPosix",
+    copts = [],
     srcs = glob([
-        "Sources/NIOConcurrencyHelpers/*.swift",
+        "Sources/NIOPosix/*.swift",
     ]),
-    module_name = "NIOConcurrencyHelpers",
+    module_name = "NIOPosix",
     visibility = ["//visibility:public"],
-    deps = ["CNIOAtomics"],
+    deps = [
+        ":CNIOLinux",
+        ":CNIODarwin",
+        ":CNIOWindows",
+        ":NIOConcurrencyHelpers",
+        ":NIOCore",
+        ":_NIODataStructures",
+        "@com_github_apple_swift_atomics//:Atomics",
+    ],
+)
+
+swift_library(
+    name = "NIOTLS",
+    srcs = glob([
+        "Sources/NIOTLS/*.swift",
+    ]),
+    module_name = "NIOTLS",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":NIO",
+        ":NIOCore",
+        "@com_github_apple_swift_collections//:DequeModule",
+    ],
 )
 
 swift_library(
@@ -196,22 +213,5 @@ swift_library(
     ]),
     module_name = "_NIODataStructures",
     visibility = ["//visibility:public"],
-    deps = [
-        "NIOCore",
-        "NIOConcurrencyHelpers",
-        "CNIOHTTPParser",
-    ],
-)
-
-cc_library(
-    name = "CNIOHTTPParser",
-    srcs = glob([
-        "Sources/CNIOHTTPParser/**/*.c",
-    ]),
-    hdrs = glob([
-        "Sources/CNIOHTTPParser/**/*.h",
-    ]),
-    copts = [],
-    includes = ["Sources/CNIOHTTPParser/include"],
-    tags = ["swift_module=CNIOHTTPParser"],
+    deps = [],
 )

--- a/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_extras/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -14,7 +9,9 @@ swift_library(
         "Sources/NIOExtras/**/*.swift",
     ]),
     deps = [
+        "@com_github_apple_swift_nio//:NIO",
         "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOHTTP1",
     ],
     module_name = "NIOExtras",
     visibility = ["//visibility:public"],

--- a/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_http2/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -14,9 +9,10 @@ swift_library(
         "Sources/NIOHPACK/**/*.swift",
     ]),
     deps = [
+        "@com_github_apple_swift_nio//:NIO",
         "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOConcurrencyHelpers",
         "@com_github_apple_swift_nio//:NIOHTTP1",
-        "@com_github_apple_swift_nio//:NIOTLS",
     ],
     module_name = "NIOHPACK",
     visibility = ["//visibility:public"],
@@ -29,6 +25,12 @@ swift_library(
     ]),
     deps = [
         ":NIOHPACK",
+        "@com_github_apple_swift_nio//:NIO",
+        "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOHTTP1",
+        "@com_github_apple_swift_nio//:NIOTLS",
+        "@com_github_apple_swift_nio//:NIOConcurrencyHelpers",
+        "@com_github_apple_swift_atomics//:Atomics",
     ],
     module_name = "NIOHTTP2",
     visibility = ["//visibility:public"],

--- a/third_party/com_github_apple_swift_nio_ssl/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_ssl/BUILD.overlay
@@ -1,0 +1,55 @@
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_library",
+)
+
+swift_library(
+    name = "NIOSSL",
+    deps = [
+        ":CNIOBoringSSL",
+        ":CNIOBoringSSLShims",
+        "@com_github_apple_swift_nio//:NIO",
+        "@com_github_apple_swift_nio//:NIOCore",
+        "@com_github_apple_swift_nio//:NIOConcurrencyHelpers",
+        "@com_github_apple_swift_nio//:NIOTLS",
+    ],
+    module_name = "NIOSSL",
+    srcs = glob([
+        "Sources/NIOSSL/**/*.swift",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CNIOBoringSSLShims",
+    copts = [],
+    deps = [":CNIOBoringSSL"],
+    hdrs = glob([
+        "Sources/CNIOBoringSSLShims/include/**/*.h",
+    ]),
+    includes = ["Sources/CNIOBoringSSLShims/include"],
+    srcs = glob([
+        "Sources/CNIOBoringSSLShims/**/*.c",
+    ]),
+    tags = ["swift_module=CNIOBoringSSLShims"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CNIOBoringSSL",
+    copts = [],
+    deps = [],
+    hdrs = glob([
+        "Sources/CNIOBoringSSL/include/**/*.h",
+        "Sources/CNIOBoringSSL/include/**/*.inc",
+    ]),
+    includes = ["Sources/CNIOBoringSSL/include"],
+    srcs = glob([
+        "Sources/CNIOBoringSSL/**/*.h",
+        "Sources/CNIOBoringSSL/**/*.c",
+        "Sources/CNIOBoringSSL/**/*.cc",
+        "Sources/CNIOBoringSSL/**/*.S",
+    ]),
+    tags = ["swift_module=CNIOBoringSSL"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
+++ b/third_party/com_github_apple_swift_nio_transport_services/BUILD.overlay
@@ -1,10 +1,5 @@
 load(
-    "@build_bazel_apple_support//rules:universal_binary.bzl",
-    "universal_binary",
-)
-load(
     "@build_bazel_rules_swift//swift:swift.bzl",
-    "swift_binary",
     "swift_library",
 )
 
@@ -14,9 +9,11 @@ swift_library(
         "Sources/NIOTransportServices/**/*.swift",
     ]),
     deps = [
+        "@com_github_apple_swift_nio//:NIO",
         "@com_github_apple_swift_nio//:NIOCore",
         "@com_github_apple_swift_nio//:NIOFoundationCompat",
         "@com_github_apple_swift_nio//:NIOTLS",
+        "@com_github_apple_swift_atomics//:Atomics",
     ],
     module_name = "NIOTransportServices",
     visibility = ["//visibility:public"],

--- a/third_party/com_github_grpc_grpc_swift/BUILD.overlay
+++ b/third_party/com_github_grpc_grpc_swift/BUILD.overlay
@@ -22,18 +22,24 @@ swift_library(
     srcs = glob([
         "Sources/GRPC/**/*.swift",
     ]),
-    copts = ["-DSWIFT_PACKAGE"],  # activates CgRPC imports
+    defines = ["SWIFT_PACKAGE"],  # activates CgRPC imports
     module_name = "GRPC",
     visibility = ["//visibility:public"],
     deps = [
         ":CGRPCZlib",
-        "@com_github_apple_swift_log//:Logging",
+        "@com_github_apple_swift_nio//:NIO",
         "@com_github_apple_swift_nio//:NIOCore",
-        "@com_github_apple_swift_nio_extras//:NIOExtras",
-        "@com_github_apple_swift_nio_http2//:NIOHPACK",
-        "@com_github_apple_swift_nio_http2//:NIOHTTP2",
+        "@com_github_apple_swift_nio//:NIOPosix",
+        "@com_github_apple_swift_nio//:NIOEmbedded",
+        "@com_github_apple_swift_nio//:NIOFoundationCompat",
+        "@com_github_apple_swift_nio//:NIOTLS",
         "@com_github_apple_swift_nio_transport_services//:NIOTransportServices",
+        "@com_github_apple_swift_nio//:NIOHTTP1",
+        "@com_github_apple_swift_nio_http2//:NIOHTTP2",
+        "@com_github_apple_swift_nio_extras//:NIOExtras",
+        "@com_github_apple_swift_log//:Logging",
         "@com_github_apple_swift_protobuf//:SwiftProtobuf",
+        "@com_github_apple_swift_nio_ssl//:NIOSSL",
     ],
 )
 


### PR DESCRIPTION
I'm interested in using the async/await support which was added to grpc-swift about a year ago in version 1.8.0. In master, rules_swift is using version 1.4.2. The current version is 1.16.0.

I asked in the #apple channel on the Bazel slack about plans to update the GRPC version, and @brentleyjones said there were no current plans but the maintainers would review the PR if I made one.

This PR updates the grpc-swift version to 1.16.0 and all of its dependencies to compatible versions as determined by its Package.swift file.

The only notable changes here were that the newer Swift NIO versions have added dependencies on Swift Collections and Swift Atomics (https://github.com/apple/swift-collections and https://github.com/apple/swift-atomics) so I had to create BUILD.overlay files for those as well.

I tested the changes by building the grpc examples in the tree and verifying that the new AsyncClients were being generated:
```
@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
public protocol RulesSwift_Examples_Grpc_EchoServiceAsyncClientProtocol: GRPCClient {
  static var serviceDescriptor: GRPCServiceDescriptor { get }
  var interceptors: RulesSwift_Examples_Grpc_EchoServiceClientInterceptorFactoryProtocol? { get }

  func makeEchoCall(
    _ request: RulesSwift_Examples_Grpc_EchoRequest,
    callOptions: CallOptions?
  ) -> GRPCAsyncUnaryCall<RulesSwift_Examples_Grpc_EchoRequest, RulesSwift_Examples_Grpc_EchoResponse>
}
```

Please let me know if you need any additional information or if there are other tests you would like me to run. Thanks!