### PR TITLE
Add --host_macos_minimum_os to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ common --incompatible_allow_tags_propagation
 # Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
 build --incompatible_disallow_empty_glob
 
+build --host_macos_minimum_os=12.0
 build --macos_minimum_os=12.0
 
 # Make sure no warnings slip into the C++ tools we vendor


### PR DESCRIPTION
This is required for testing tools in the host configuration with the
new Xcode otherwise it's possible the binary doesn't launch on your OS
