### PR TITLE
Bump minimum test version to macOS 13.0

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,8 +4,8 @@ common --incompatible_allow_tags_propagation
 # Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
 build --incompatible_disallow_empty_glob
 
-build --host_macos_minimum_os=12.0
-build --macos_minimum_os=12.0
+build --host_macos_minimum_os=13.0
+build --macos_minimum_os=13.0
 
 # Make sure no warnings slip into the C++ tools we vendor
 build --features treat_warnings_as_errors


### PR DESCRIPTION
With Xcode 15 XCTest is built for 13.0+, this should be ok since we
require Xcode 14.1+ which requires macOS 13.0+
