### PR TITLE
Add test validating global index store builds

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -181,8 +181,8 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         name = "build_bazel_rules_swift_index_import",
         build_file = "@build_bazel_rules_swift//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
         canonical_id = "index-import-5.8",
-        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"],
-        sha256 = "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",
+        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8/index-import.tar.gz"],
+        sha256 = "9f0a5339ccc90a26361b013735b45044ed491bd000e2d3705451ee0327f17148",
     )
 
     _maybe(

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -181,8 +181,8 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         name = "build_bazel_rules_swift_index_import",
         build_file = "@build_bazel_rules_swift//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
         canonical_id = "index-import-5.8",
-        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8/index-import.tar.gz"],
-        sha256 = "9f0a5339ccc90a26361b013735b45044ed491bd000e2d3705451ee0327f17148",
+        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"],
+        sha256 = "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",
     )
 
     _maybe(

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -4,6 +4,10 @@ load(
     "@build_bazel_rules_swift//test/rules:action_command_line_test.bzl",
     "make_action_command_line_test_rule",
 )
+load(
+    "@bazel_skylib//rules:build_test.bzl",
+    "build_test",
+)
 
 default_test = make_action_command_line_test_rule()
 default_opt_test = make_action_command_line_test_rule(
@@ -234,4 +238,12 @@ def features_test_suite(name):
         mnemonic = "CppLink",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:cc_bin",
         target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    build_test(
+        name = "{}_global_index_store_builds".format(name),
+        tags = [name],
+        targets = [
+            "//test/fixtures/global_index_store:simple",
+        ],
     )

--- a/test/fixtures/global_index_store/BUILD
+++ b/test/fixtures/global_index_store/BUILD
@@ -1,0 +1,20 @@
+load("//swift:swift.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+swift_library(
+    name = "simple",
+    srcs = [
+        "first.swift",
+        "second.swift",
+    ],
+    features = [
+        "swift.use_global_index_store",
+        "swift.index_while_building",
+    ],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+)

--- a/test/fixtures/global_index_store/first.swift
+++ b/test/fixtures/global_index_store/first.swift
@@ -1,0 +1,4 @@
+func first() {
+    print("first")
+    second()
+}

--- a/test/fixtures/global_index_store/second.swift
+++ b/test/fixtures/global_index_store/second.swift
@@ -1,0 +1,3 @@
+func second() {
+    print("second")
+}


### PR DESCRIPTION
Previously only arguments were validated, now we validate that the
actions actually succeed, which makes sure we successfully run
index-import
