### PR TITLE
Move CI back to 14.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   mac_common: &mac_common
     platform: macos
-    xcode_version: "14.3"
+    xcode_version: "14.2"
     build_targets:
       - "//examples/..."
     test_targets:


### PR DESCRIPTION
Realistically we're mostly getting 14.2 anyways since 14.3 isn't rolled
out on CI. This should make that more clear and will make sure we don't
get 14.3 machines as it starts rolling out again until we ask for it.
