### PR TITLE
Replace DEVELOPER_DIR remapping with '/PLACEHOLDER_DEVELOPER_DIR'

### DIFF
--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -328,7 +328,7 @@ def _all_action_configs(
             configurators = [
                 swift_toolchain_config.add_arg(
                     "-debug-prefix-map",
-                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
                 ),
             ],
             features = [
@@ -343,7 +343,7 @@ def _all_action_configs(
             configurators = [
                 swift_toolchain_config.add_arg(
                     "-coverage-prefix-map",
-                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
                 ),
             ],
             features = [
@@ -362,7 +362,7 @@ def _all_action_configs(
             configurators = [
                 swift_toolchain_config.add_arg(
                     "-file-prefix-map",
-                    "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                    "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
                 ),
             ],
             features = [

--- a/test/coverage_settings_tests.bzl
+++ b/test/coverage_settings_tests.bzl
@@ -66,7 +66,7 @@ def coverage_settings_test_suite(name):
         tags = [name],
         expected_argv = [
             "-coverage-prefix-map",
-            "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],
         mnemonic = "SwiftCompile",

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -231,7 +231,7 @@ def debug_settings_test_suite(name):
         name = "{}_remap_xcode_path".format(name),
         expected_argv = [
             "-debug-prefix-map",
-            "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],
         mnemonic = "SwiftCompile",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -105,7 +105,7 @@ def features_test_suite(name):
         expected_argv = [
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
             "-file-prefix-map",
-            "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],
         mnemonic = "SwiftCompile",


### PR DESCRIPTION
This makes it easier to understand this variable is different from
`$DEVELOPER_DIR` and also makes it "absolute" so that tools like
index-import don't try to absolutize it.
