### PR TITLE
Added target_name to output paths of files  

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2613,6 +2613,7 @@ def _declare_compile_outputs(
     if generated_header_name:
         generated_header = _declare_validated_generated_header(
             actions = actions,
+            target_name = target_name,
             generated_header_name = generated_header_name,
         )
     else:
@@ -2864,7 +2865,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
         derived_files_output_file_map = derived_files_output_map_file,
     )
 
-def _declare_validated_generated_header(actions, generated_header_name):
+def _declare_validated_generated_header(actions, target_name, generated_header_name):
     """Validates and declares the explicitly named generated header.
 
     If the file does not have a `.h` extension, the build will fail.
@@ -2883,7 +2884,7 @@ def _declare_validated_generated_header(actions, generated_header_name):
             "extension (got '{}').".format(generated_header_name),
         )
 
-    return actions.declare_file(generated_header_name)
+    return actions.declare_file(paths.join(target_name, generated_header_name))
 
 def _merge_targets_providers(implicit_deps_providers, targets):
     """Merges the compilation-related providers for the given targets.

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2579,14 +2579,17 @@ def _declare_compile_outputs(
     # depending on compilation mode, like WMO vs. non-WMO).
     swiftmodule_file = derived_files.swiftmodule(
         actions = actions,
+        target_name = target_name,
         module_name = module_name,
     )
     swiftdoc_file = derived_files.swiftdoc(
         actions = actions,
+        target_name = target_name,
         module_name = module_name,
     )
     swiftsourceinfo_file = derived_files.swiftsourceinfo(
         actions = actions,
+        target_name = target_name,
         module_name = module_name,
     )
 
@@ -2599,6 +2602,7 @@ def _declare_compile_outputs(
     ):
         swiftinterface_file = derived_files.swiftinterface(
             actions = actions,
+            target_name = target_name,
             module_name = module_name,
         )
     else:

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -17,6 +17,16 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "owner_relative_path")
 
+def _default_path(ctx, basename):
+    target_name = ctx.label.name
+    return paths.join(target_name, basename)
+
+def _declare_file(actions, target_name, basename):
+    return actions.declare_file(paths.join(target_name, basename))
+
+def _declare_directory(actions, target_name, directory):
+    return actions.declare_directory(paths.join(target_name, directory))
+
 def _ast(actions, target_name, src):
     """Declares a file for an ast file during compilation.
 
@@ -29,7 +39,9 @@ def _ast(actions, target_name, src):
         The declared `File` where the given src's AST will be dumped to.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.ast".format(basename)),
     )
 
@@ -43,7 +55,11 @@ def _autolink_flags(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.autolink".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.autolink".format(target_name),
+    )
 
 def _executable(actions, target_name):
     """Declares a file for the executable created by a binary or test rule.
@@ -55,7 +71,11 @@ def _executable(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(target_name)
+    return _declare_file(
+        actions,
+        target_name,
+        target_name,
+    )
 
 def _indexstore_directory(actions, target_name):
     """Declares a directory in which the compiler's indexstore will be written.
@@ -67,7 +87,11 @@ def _indexstore_directory(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_directory("{}.indexstore".format(target_name))
+    return _declare_directory(
+        actions,
+        target_name,
+        "{}.indexstore".format(target_name),
+    )
 
 def _symbol_graph_directory(actions, target_name):
     """Declares a directory in which the compiler's symbol graph will be written.
@@ -79,7 +103,11 @@ def _symbol_graph_directory(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_directory("{}.symbolgraph".format(target_name))
+    return _declare_directory(
+        actions,
+        target_name,
+        "{}.symbolgraph".format(target_name),
+    )
 
 def _intermediate_bc_file(actions, target_name, src):
     """Declares a file for an intermediate llvm bc file during compilation.
@@ -93,7 +121,9 @@ def _intermediate_bc_file(actions, target_name, src):
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.bc".format(basename)),
     )
 
@@ -135,7 +165,9 @@ def _intermediate_object_file(actions, target_name, src):
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.o".format(basename)),
     )
 
@@ -153,7 +185,11 @@ def _module_map(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swift.modulemap".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swift.modulemap".format(target_name),
+    )
 
 def _modulewrap_object(actions, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.
@@ -165,7 +201,11 @@ def _modulewrap_object(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.modulewrap.o".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.modulewrap.o".format(target_name),
+    )
 
 def _precompiled_module(actions, target_name):
     """Declares the precompiled module for a C/Objective-C target.
@@ -177,7 +217,11 @@ def _precompiled_module(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swift.pcm".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swift.pcm".format(target_name),
+    )
 
 def _reexport_modules_src(actions, target_name):
     """Declares a source file used to re-export other Swift modules.
@@ -189,13 +233,18 @@ def _reexport_modules_src(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}_exports.swift".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}_exports.swift".format(target_name),
+    )
 
-def _static_archive(actions, alwayslink, link_name):
+def _static_archive(actions, target_name, alwayslink, link_name):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         alwayslink: Indicates whether the object files in the library should
             always be always be linked into any binaries that depend on it, even
             if some contain no symbols referenced by the binary.
@@ -206,7 +255,11 @@ def _static_archive(actions, alwayslink, link_name):
         The declared `File`.
     """
     extension = "lo" if alwayslink else "a"
-    return actions.declare_file("lib{}.{}".format(link_name, extension))
+    return _declare_file(
+        actions,
+        target_name,
+        "lib{}.{}".format(link_name, extension)
+    )
 
 def _swiftc_output_file_map(actions, target_name):
     """Declares a file for the output file map for a compilation action.
@@ -222,7 +275,11 @@ def _swiftc_output_file_map(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.output_file_map.json".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.output_file_map.json".format(target_name),
+    )
 
 def _swiftc_derived_output_file_map(actions, target_name):
     """Declares a file for the output file map for a swiftmodule only action.
@@ -238,57 +295,79 @@ def _swiftc_derived_output_file_map(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         "{}.derived_output_file_map.json".format(target_name),
     )
 
-def _swiftdoc(actions, module_name):
+def _swiftdoc(actions, target_name, module_name):
     """Declares a file for the Swift doc file created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftdoc".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftdoc".format(module_name),
+    )
 
-def _swiftinterface(actions, module_name):
+def _swiftinterface(actions, target_name, module_name):
     """Declares a file for the Swift interface created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftinterface".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftinterface".format(module_name),
+    )
 
-def _swiftmodule(actions, module_name):
+def _swiftmodule(actions, target_name, module_name):
     """Declares a file for the Swift module created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftmodule".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftmodule".format(module_name),
+    )
 
-def _swiftsourceinfo(actions, module_name):
+def _swiftsourceinfo(actions, target_name, module_name):
     """Declares a file for the Swift sourceinfo created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftsourceinfo".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftsourceinfo".format(module_name),
+    )
 
 def _vfsoverlay(actions, target_name):
     """Declares a file for the VFS overlay for a compilation action.
@@ -304,7 +383,11 @@ def _vfsoverlay(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.vfsoverlay.yaml".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.vfsoverlay.yaml".format(target_name),
+    )
 
 def _whole_module_object_file(actions, target_name):
     """Declares a file for object files created with whole module optimization.
@@ -320,7 +403,11 @@ def _whole_module_object_file(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.o".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.o".format(target_name),
+    )
 
 def _xctest_runner_script(actions, target_name):
     """Declares a file for the script that runs an `.xctest` bundle on Darwin.
@@ -332,7 +419,11 @@ def _xctest_runner_script(actions, target_name):
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.test-runner.sh".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.test-runner.sh".format(target_name),
+    )
 
 derived_files = struct(
     ast = _ast,
@@ -343,6 +434,7 @@ derived_files = struct(
     intermediate_object_file = _intermediate_object_file,
     module_map = _module_map,
     modulewrap_object = _modulewrap_object,
+    path = _default_path,
     precompiled_module = _precompiled_module,
     reexport_modules_src = _reexport_modules_src,
     static_archive = _static_archive,

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -344,7 +344,7 @@ def _swift_binary_impl(ctx):
 
     _, linking_outputs, providers = _swift_linking_rule_impl(
         ctx,
-        binary_path = ctx.label.name,
+        binary_path = derived_files.path(ctx, ctx.label.name),
         feature_configuration = feature_configuration,
         swift_toolchain = swift_toolchain,
     )

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -29,7 +29,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_no_deps".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/lower_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -40,7 +40,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_deps".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -51,7 +51,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_private_swift_deps".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_swift_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -62,7 +62,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_private_cc_deps".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -73,8 +73,8 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_multiple_swift_files".format(name),
         expected_files = [
-            "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
-            "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -82,7 +82,7 @@ def features_test_suite(name):
         tags = [name],
         expected_argv = [
             "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-I$(BIN_DIR)/test/fixtures/basic/first",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -154,7 +154,7 @@ def features_test_suite(name):
         name = "{}_vfsoverlay_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
+            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
             "-I/__build_bazel_rules_swift/swiftmodules",
         ],
         not_expected_argv = [
@@ -172,7 +172,7 @@ def features_test_suite(name):
             "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/basic/second.swift-explicit-module-map.json",
         ],
         not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-I$(BIN_DIR)/test/fixtures/basic/second",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
         ],

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -49,10 +49,10 @@ def output_file_map_test_suite(name):
     output_file_map_test(
         name = "{}_default".format(name),
         expected_mapping = {
-            "object": "test/fixtures/debug_settings/simple_objs/Empty.swift.o",
+            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
@@ -62,10 +62,10 @@ def output_file_map_test_suite(name):
     output_file_map_embed_bitcode_test(
         name = "{}_emit_bc".format(name),
         expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
@@ -73,10 +73,10 @@ def output_file_map_test_suite(name):
     output_file_map_embed_bitcode_wmo_test(
         name = "{}_emit_bc_wmo".format(name),
         expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -94,8 +94,8 @@ def private_deps_test_suite(name):
     private_deps_provider_test(
         name = "{}_client_cc_deps_modulemaps".format(name),
         expected_files = [
-            "/test/fixtures/private_deps/public_cc.swift.modulemap",
-            "-/test/fixtures/private_deps/private_cc.swift.modulemap",
+            "/test/fixtures/private_deps/public_cc/public_cc.swift.modulemap",
+            "-/test/fixtures/private_deps/public_cc/private_cc.swift.modulemap",
         ],
         field = "transitive_modules.clang!.module_map!",
         provider = "SwiftInfo",


### PR DESCRIPTION
To be able to build multiple flavours of same target, we needed to add target_name to output paths as bazel were conflicting with same output path names