### PR TITLE
Added target name to output path to support multiple builds of same module

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2306,8 +2306,8 @@ def compile(
     ):
         vfsoverlay_file = derived_files.vfsoverlay(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )
         write_vfsoverlay(
             actions = actions,
@@ -2595,8 +2595,8 @@ def _precompile_clang_module(
 
     precompiled_module = derived_files.precompiled_module(
         actions = actions,
-        target_name = target_name,
         add_target_name_to_output_path = add_target_name_to_output_path,
+        target_name = target_name,
     )
 
     if not is_swift_generated_header:
@@ -2778,21 +2778,21 @@ def _declare_compile_outputs(
     # depending on compilation mode, like WMO vs. non-WMO).
     swiftmodule_file = derived_files.swiftmodule(
         actions = actions,
+        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = target_name,
         module_name = module_name,
-        add_target_name_to_output_path = add_target_name_to_output_path,
     )
     swiftdoc_file = derived_files.swiftdoc(
         actions = actions,
+        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = target_name,
         module_name = module_name,
-        add_target_name_to_output_path = add_target_name_to_output_path,
     )
     swiftsourceinfo_file = derived_files.swiftsourceinfo(
         actions = actions,
+        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = target_name,
         module_name = module_name,
-        add_target_name_to_output_path = add_target_name_to_output_path,
     )
 
     if are_all_features_enabled(
@@ -2804,9 +2804,9 @@ def _declare_compile_outputs(
     ):
         swiftinterface_file = derived_files.swiftinterface(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = target_name,
             module_name = module_name,
-            add_target_name_to_output_path = add_target_name_to_output_path,
         )
     else:
         swiftinterface_file = None
@@ -2816,9 +2816,9 @@ def _declare_compile_outputs(
     if generated_header_name:
         generated_header = derived_files.generated_header(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = target_name,
             generated_header_name = generated_header_name,
-            add_target_name_to_output_path = add_target_name_to_output_path,
         )
     else:
         generated_header = None
@@ -2845,8 +2845,8 @@ def _declare_compile_outputs(
 
         generated_module_map = derived_files.module_map(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )
         write_module_map(
             actions = actions,
@@ -2880,14 +2880,14 @@ def _declare_compile_outputs(
         # no other partial outputs.
         object_files = [derived_files.whole_module_object_file(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )]
         ast_files = [derived_files.ast(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = target_name,
             src = srcs[0],
-            add_target_name_to_output_path = add_target_name_to_output_path,
         )]
         other_outputs = []
         output_file_map = None

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2965,11 +2965,11 @@ def _declare_compile_outputs(
         # object files so that we can pass them all to the archive action.
         output_info = _declare_multiple_outputs_and_write_output_file_map(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             emits_bc = emits_bc,
             split_derived_file_generation = split_derived_file_generation,
             srcs = srcs,
             target_name = target_name,
-            add_target_name_to_output_path = add_target_name_to_output_path,
         )
         object_files = output_info.object_files
         ast_files = output_info.ast_files
@@ -2990,8 +2990,8 @@ def _declare_compile_outputs(
     ):
         indexstore_directory = derived_files.indexstore_directory(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )
     else:
         indexstore_directory = None
@@ -3003,8 +3003,8 @@ def _declare_compile_outputs(
     if (emit_symbol_graph):
         symbol_graph_directory = derived_files.symbol_graph_directory(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )
     else:
         symbol_graph_directory = None
@@ -3027,15 +3027,16 @@ def _declare_compile_outputs(
 
 def _declare_multiple_outputs_and_write_output_file_map(
         actions,
+        add_target_name_to_output_path,
         emits_bc,
         split_derived_file_generation,
         srcs,
-        target_name,
-        add_target_name_to_output_path):
+        target_name):
     """Declares low-level outputs and writes the output map for a compilation.
 
     Args:
         actions: The object used to register actions.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         emits_bc: If `True` the compiler will generate LLVM BC files instead of
             object files.
         split_derived_file_generation: Whether objects and modules are produced
@@ -3043,7 +3044,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
         srcs: The list of source files that will be compiled.
         target_name: The name (excluding package path) of the target being
             built.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         A `struct` with the following fields:
@@ -3064,15 +3064,15 @@ def _declare_multiple_outputs_and_write_output_file_map(
     """
     output_map_file = derived_files.swiftc_output_file_map(
         actions = actions,
-        target_name = target_name,
         add_target_name_to_output_path = add_target_name_to_output_path,
+        target_name = target_name,
     )
 
     if split_derived_file_generation:
         derived_files_output_map_file = derived_files.swiftc_derived_output_file_map(
             actions = actions,
-            target_name = target_name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = target_name,
         )
     else:
         derived_files_output_map_file = None
@@ -3099,9 +3099,9 @@ def _declare_multiple_outputs_and_write_output_file_map(
             # Declare the llvm bc file (there is one per source file).
             obj = derived_files.intermediate_bc_file(
                 actions = actions,
+                add_target_name_to_output_path = add_target_name_to_output_path,
                 target_name = target_name,
                 src = src,
-                add_target_name_to_output_path = add_target_name_to_output_path,
             )
             output_objs.append(obj)
             src_output_map["llvm-bc"] = obj.path
@@ -3109,18 +3109,18 @@ def _declare_multiple_outputs_and_write_output_file_map(
             # Declare the object file (there is one per source file).
             obj = derived_files.intermediate_object_file(
                 actions = actions,
+                add_target_name_to_output_path = add_target_name_to_output_path,
                 target_name = target_name,
                 src = src,
-                add_target_name_to_output_path = add_target_name_to_output_path,
             )
             output_objs.append(obj)
             src_output_map["object"] = obj.path
 
         ast = derived_files.ast(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = target_name,
             src = src,
-            add_target_name_to_output_path = add_target_name_to_output_path,
         )
         ast_files.append(ast)
         src_output_map["ast-dump"] = ast.path

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2089,6 +2089,11 @@ def compile_module_interface(
             continue
         transitive_swiftmodules.append(swift_module.swiftmodule)
 
+    add_target_name_to_output_path = is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+    )
+
     # We need this when generating the VFS overlay file and also when
     # configuring inputs for the compile action, so it's best to precompute it
     # here.
@@ -2098,6 +2103,7 @@ def compile_module_interface(
     ):
         vfsoverlay_file = derived_files.vfsoverlay(
             actions = actions,
+            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = module_name,
         )
         write_vfsoverlay(

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -23,6 +23,7 @@ load(
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE",
@@ -58,12 +59,18 @@ def ensure_swiftmodule_is_embedded(
         action_name = swift_action_names.MODULEWRAP,
         swift_toolchain = swift_toolchain,
     ):
+        add_target_name_to_output_path = is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+        )
+
         # For ELF-format binaries, we need to invoke a Swift modulewrap action
         # to wrap the .swiftmodule file in a .o file that gets propagated to the
         # linker.
         modulewrap_obj = derived_files.modulewrap_object(
             actions,
             target_name = label.name,
+            add_target_name_to_output_path = add_target_name_to_output_path,
         )
         _register_modulewrap_action(
             actions = actions,

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -69,8 +69,8 @@ def ensure_swiftmodule_is_embedded(
         # linker.
         modulewrap_obj = derived_files.modulewrap_object(
             actions,
-            target_name = label.name,
             add_target_name_to_output_path = add_target_name_to_output_path,
+            target_name = label.name,
         )
         _register_modulewrap_action(
             actions = actions,

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -17,84 +17,132 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "owner_relative_path")
 
-def _ast(actions, target_name, src):
+def _default_path(ctx, basename):
+    target_name = ctx.label.name
+    return paths.join(target_name, basename)
+
+def _declare_file(actions, target_name, basename, add_target_name_to_output_path):
+    if add_target_name_to_output_path:
+        return actions.declare_file(paths.join(target_name, basename))
+    else:
+        return actions.declare_file(basename)
+
+def _declare_directory(actions, target_name, directory, add_target_name_to_output_path):
+    if add_target_name_to_output_path:
+        return actions.declare_directory("{}_{}".format(target_name, directory))
+    else:
+        return actions.declare_directory(directory)
+
+def _ast(actions, target_name, src, add_target_name_to_output_path):
     """Declares a file for an ast file during compilation.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File` where the given src's AST will be dumped to.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.ast".format(basename)),
+        add_target_name_to_output_path,
     )
 
-def _autolink_flags(actions, target_name):
+def _autolink_flags(actions, target_name, add_target_name_to_output_path):
     """Declares the response file into which autolink flags will be extracted.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.autolink".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.autolink".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _executable(actions, target_name):
+def _executable(actions, target_name, add_target_name_to_output_path):
     """Declares a file for the executable created by a binary or test rule.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(target_name)
+    return _declare_file(
+        actions,
+        target_name,
+        target_name,
+        add_target_name_to_output_path,
+    )
 
-def _indexstore_directory(actions, target_name):
+def _indexstore_directory(actions, target_name, add_target_name_to_output_path):
     """Declares a directory in which the compiler's indexstore will be written.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_directory("{}.indexstore".format(target_name))
+    return _declare_directory(
+        actions,
+        target_name,
+        "{}.indexstore".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _symbol_graph_directory(actions, target_name):
+def _symbol_graph_directory(actions, target_name, add_target_name_to_output_path):
     """Declares a directory in which the compiler's symbol graph will be written.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_directory("{}.symbolgraph".format(target_name))
+    return _declare_directory(
+        actions,
+        target_name,
+        "{}.symbolgraph".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _intermediate_bc_file(actions, target_name, src):
+def _intermediate_bc_file(actions, target_name, src, add_target_name_to_output_path):
     """Declares a file for an intermediate llvm bc file during compilation.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.bc".format(basename)),
+        add_target_name_to_output_path,
     )
 
 def _intermediate_frontend_file_path(target_name, src):
@@ -118,7 +166,7 @@ def _intermediate_frontend_file_path(target_name, src):
 
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
 
-def _intermediate_object_file(actions, target_name, src):
+def _intermediate_object_file(actions, target_name, src, add_target_name_to_output_path):
     """Declares a file for an intermediate object file during compilation.
 
     These files are produced when the compiler is invoked with multiple frontend
@@ -130,16 +178,20 @@ def _intermediate_object_file(actions, target_name, src):
         actions: The context's actions object.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         paths.join(dirname, "{}.o".format(basename)),
+        add_target_name_to_output_path,
     )
 
-def _module_map(actions, target_name):
+def _module_map(actions, target_name, add_target_name_to_output_path):
     """Declares the module map for a target.
 
     These module maps are used when generating a Swift-compatible module map for
@@ -149,35 +201,81 @@ def _module_map(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swift.modulemap".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swift.modulemap".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _modulewrap_object(actions, target_name):
+def _modulewrap_object(actions, target_name, add_target_name_to_output_path):
     """Declares the object file used to wrap Swift modules for ELF binaries.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.modulewrap.o".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.modulewrap.o".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _precompiled_module(actions, target_name):
+def _declare_validated_generated_header(actions, target_name, generated_header_name, add_target_name_to_output_path):
+    """Validates and declares the explicitly named generated header.
+
+    If the file does not have a `.h` extension, the build will fail.
+
+    Args:
+        actions: The context's `actions` object.
+        target_name: Executable target name.
+        generated_header_name: The desired name of the generated header.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+
+    Returns:
+        A `File` that should be used as the output for the generated header.
+    """
+    extension = paths.split_extension(generated_header_name)[1]
+    if extension != ".h":
+        fail(
+            "The generated header for a Swift module must have a '.h' " +
+            "extension (got '{}').".format(generated_header_name),
+        )
+
+    return _declare_file(
+        actions,
+        target_name,
+        generated_header_name,
+        add_target_name_to_output_path,
+    )
+
+def _precompiled_module(actions, target_name, add_target_name_to_output_path):
     """Declares the precompiled module for a C/Objective-C target.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swift.pcm".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swift.pcm".format(target_name),
+        add_target_name_to_output_path,
+    )
 
 def _reexport_modules_src(actions, target_name):
     """Declares a source file used to re-export other Swift modules.
@@ -189,26 +287,34 @@ def _reexport_modules_src(actions, target_name):
     Returns:
         The declared `File`.
     """
+
     return actions.declare_file("{}_exports.swift".format(target_name))
 
-def _static_archive(actions, alwayslink, link_name):
+def _static_archive(actions, target_name, alwayslink, link_name, add_target_name_to_output_path):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         alwayslink: Indicates whether the object files in the library should
             always be always be linked into any binaries that depend on it, even
             if some contain no symbols referenced by the binary.
         link_name: The name of the library being built, without a `lib` prefix
             or file extension.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     extension = "lo" if alwayslink else "a"
-    return actions.declare_file("lib{}.{}".format(link_name, extension))
+    return _declare_file(
+        actions,
+        target_name,
+        "lib{}.{}".format(link_name, extension),
+        add_target_name_to_output_path,
+    )
 
-def _swiftc_output_file_map(actions, target_name):
+def _swiftc_output_file_map(actions, target_name, add_target_name_to_output_path):
     """Declares a file for the output file map for a compilation action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -218,13 +324,19 @@ def _swiftc_output_file_map(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.output_file_map.json".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.output_file_map.json".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _swiftc_derived_output_file_map(actions, target_name):
+def _swiftc_derived_output_file_map(actions, target_name, add_target_name_to_output_path):
     """Declares a file for the output file map for a swiftmodule only action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -234,63 +346,95 @@ def _swiftc_derived_output_file_map(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file(
+    return _declare_file(
+        actions,
+        target_name,
         "{}.derived_output_file_map.json".format(target_name),
+        add_target_name_to_output_path,
     )
 
-def _swiftdoc(actions, module_name):
+def _swiftdoc(actions, target_name, module_name, add_target_name_to_output_path):
     """Declares a file for the Swift doc file created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftdoc".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftdoc".format(module_name),
+        add_target_name_to_output_path,
+    )
 
-def _swiftinterface(actions, module_name):
+def _swiftinterface(actions, target_name, module_name, add_target_name_to_output_path):
     """Declares a file for the Swift interface created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftinterface".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftinterface".format(module_name),
+        add_target_name_to_output_path,
+    )
 
-def _swiftmodule(actions, module_name):
+def _swiftmodule(actions, target_name, module_name, add_target_name_to_output_path):
     """Declares a file for the Swift module created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftmodule".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftmodule".format(module_name),
+        add_target_name_to_output_path,
+    )
 
-def _swiftsourceinfo(actions, module_name):
+def _swiftsourceinfo(actions, target_name, module_name, add_target_name_to_output_path):
     """Declares a file for the Swift sourceinfo created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        target_name: The name of the target being built.
         module_name: The name of the module being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.swiftsourceinfo".format(module_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.swiftsourceinfo".format(module_name),
+        add_target_name_to_output_path,
+    )
 
-def _vfsoverlay(actions, target_name):
+def _vfsoverlay(actions, target_name, add_target_name_to_output_path):
     """Declares a file for the VFS overlay for a compilation action.
 
     The VFS overlay is YAML-formatted file that allows us to place the
@@ -300,13 +444,19 @@ def _vfsoverlay(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.vfsoverlay.yaml".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.vfsoverlay.yaml".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _whole_module_object_file(actions, target_name):
+def _whole_module_object_file(actions, target_name, add_target_name_to_output_path):
     """Declares a file for object files created with whole module optimization.
 
     This is the output of a compile action when whole module optimization is
@@ -316,23 +466,35 @@ def _whole_module_object_file(actions, target_name):
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.o".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.o".format(target_name),
+        add_target_name_to_output_path,
+    )
 
-def _xctest_runner_script(actions, target_name):
+def _xctest_runner_script(actions, target_name, add_target_name_to_output_path):
     """Declares a file for the script that runs an `.xctest` bundle on Darwin.
 
     Args:
         actions: The context's actions object.
         target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
-    return actions.declare_file("{}.test-runner.sh".format(target_name))
+    return _declare_file(
+        actions,
+        target_name,
+        "{}.test-runner.sh".format(target_name),
+        add_target_name_to_output_path,
+    )
 
 derived_files = struct(
     ast = _ast,
@@ -343,6 +505,7 @@ derived_files = struct(
     intermediate_object_file = _intermediate_object_file,
     module_map = _module_map,
     modulewrap_object = _modulewrap_object,
+    path = _default_path,
     precompiled_module = _precompiled_module,
     reexport_modules_src = _reexport_modules_src,
     static_archive = _static_archive,
@@ -356,4 +519,5 @@ derived_files = struct(
     vfsoverlay = _vfsoverlay,
     whole_module_object_file = _whole_module_object_file,
     xctest_runner_script = _xctest_runner_script,
+    generated_header = _declare_validated_generated_header,
 )

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -21,26 +21,26 @@ def _default_path(ctx, basename):
     target_name = ctx.label.name
     return paths.join(target_name, basename)
 
-def _declare_file(actions, target_name, basename, add_target_name_to_output_path):
+def _declare_file(actions, add_target_name_to_output_path, target_name, basename):
     if add_target_name_to_output_path:
         return actions.declare_file(paths.join(target_name, basename))
     else:
         return actions.declare_file(basename)
 
-def _declare_directory(actions, target_name, directory, add_target_name_to_output_path):
+def _declare_directory(actions, add_target_name_to_output_path, target_name, directory):
     if add_target_name_to_output_path:
         return actions.declare_directory("{}_{}".format(target_name, directory))
     else:
         return actions.declare_directory(directory)
 
-def _ast(actions, target_name, src, add_target_name_to_output_path):
+def _ast(actions, add_target_name_to_output_path, target_name, src):
     """Declares a file for an ast file during compilation.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File` where the given src's AST will be dumped to.
@@ -48,91 +48,91 @@ def _ast(actions, target_name, src, add_target_name_to_output_path):
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         paths.join(dirname, "{}.ast".format(basename)),
-        add_target_name_to_output_path,
     )
 
-def _autolink_flags(actions, target_name, add_target_name_to_output_path):
+def _autolink_flags(actions, add_target_name_to_output_path, target_name):
     """Declares the response file into which autolink flags will be extracted.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.autolink".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _executable(actions, target_name, add_target_name_to_output_path):
+def _executable(actions, add_target_name_to_output_path, target_name):
     """Declares a file for the executable created by a binary or test rule.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
-        target_name,
-        target_name,
         add_target_name_to_output_path,
+        target_name,
+        target_name,
     )
 
-def _indexstore_directory(actions, target_name, add_target_name_to_output_path):
+def _indexstore_directory(actions, add_target_name_to_output_path, target_name):
     """Declares a directory in which the compiler's indexstore will be written.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_directory(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.indexstore".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _symbol_graph_directory(actions, target_name, add_target_name_to_output_path):
+def _symbol_graph_directory(actions, add_target_name_to_output_path, target_name):
     """Declares a directory in which the compiler's symbol graph will be written.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_directory(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.symbolgraph".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _intermediate_bc_file(actions, target_name, src, add_target_name_to_output_path):
+def _intermediate_bc_file(actions, add_target_name_to_output_path, target_name, src):
     """Declares a file for an intermediate llvm bc file during compilation.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
@@ -140,9 +140,9 @@ def _intermediate_bc_file(actions, target_name, src, add_target_name_to_output_p
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         paths.join(dirname, "{}.bc".format(basename)),
-        add_target_name_to_output_path,
     )
 
 def _intermediate_frontend_file_path(target_name, src):
@@ -166,7 +166,7 @@ def _intermediate_frontend_file_path(target_name, src):
 
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
 
-def _intermediate_object_file(actions, target_name, src, add_target_name_to_output_path):
+def _intermediate_object_file(actions, add_target_name_to_output_path, target_name, src):
     """Declares a file for an intermediate object file during compilation.
 
     These files are produced when the compiler is invoked with multiple frontend
@@ -176,9 +176,9 @@ def _intermediate_object_file(actions, target_name, src, add_target_name_to_outp
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
@@ -186,12 +186,12 @@ def _intermediate_object_file(actions, target_name, src, add_target_name_to_outp
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         paths.join(dirname, "{}.o".format(basename)),
-        add_target_name_to_output_path,
     )
 
-def _module_map(actions, target_name, add_target_name_to_output_path):
+def _module_map(actions, add_target_name_to_output_path, target_name):
     """Declares the module map for a target.
 
     These module maps are used when generating a Swift-compatible module map for
@@ -200,47 +200,47 @@ def _module_map(actions, target_name, add_target_name_to_output_path):
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swift.modulemap".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _modulewrap_object(actions, target_name, add_target_name_to_output_path):
+def _modulewrap_object(actions, add_target_name_to_output_path, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.modulewrap.o".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _declare_validated_generated_header(actions, target_name, generated_header_name, add_target_name_to_output_path):
+def _declare_validated_generated_header(actions, add_target_name_to_output_path, target_name, generated_header_name):
     """Validates and declares the explicitly named generated header.
 
     If the file does not have a `.h` extension, the build will fail.
 
     Args:
         actions: The context's `actions` object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: Executable target name.
         generated_header_name: The desired name of the generated header.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         A `File` that should be used as the output for the generated header.
@@ -254,27 +254,27 @@ def _declare_validated_generated_header(actions, target_name, generated_header_n
 
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         generated_header_name,
-        add_target_name_to_output_path,
     )
 
-def _precompiled_module(actions, target_name, add_target_name_to_output_path):
+def _precompiled_module(actions, add_target_name_to_output_path, target_name):
     """Declares the precompiled module for a C/Objective-C target.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swift.pcm".format(target_name),
-        add_target_name_to_output_path,
     )
 
 def _reexport_modules_src(actions, target_name):
@@ -290,18 +290,18 @@ def _reexport_modules_src(actions, target_name):
 
     return actions.declare_file("{}_exports.swift".format(target_name))
 
-def _static_archive(actions, target_name, alwayslink, link_name, add_target_name_to_output_path):
+def _static_archive(actions, add_target_name_to_output_path, alwayslink, link_name, target_name):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         alwayslink: Indicates whether the object files in the library should
             always be always be linked into any binaries that depend on it, even
             if some contain no symbols referenced by the binary.
         link_name: The name of the library being built, without a `lib` prefix
             or file extension.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
@@ -309,12 +309,12 @@ def _static_archive(actions, target_name, alwayslink, link_name, add_target_name
     extension = "lo" if alwayslink else "a"
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "lib{}.{}".format(link_name, extension),
-        add_target_name_to_output_path,
     )
 
-def _swiftc_output_file_map(actions, target_name, add_target_name_to_output_path):
+def _swiftc_output_file_map(actions, add_target_name_to_output_path, target_name):
     """Declares a file for the output file map for a compilation action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -323,20 +323,20 @@ def _swiftc_output_file_map(actions, target_name, add_target_name_to_output_path
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.output_file_map.json".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _swiftc_derived_output_file_map(actions, target_name, add_target_name_to_output_path):
+def _swiftc_derived_output_file_map(actions, add_target_name_to_output_path, target_name):
     """Declares a file for the output file map for a swiftmodule only action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -345,96 +345,96 @@ def _swiftc_derived_output_file_map(actions, target_name, add_target_name_to_out
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.derived_output_file_map.json".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _swiftdoc(actions, target_name, module_name, add_target_name_to_output_path):
+def _swiftdoc(actions, add_target_name_to_output_path, target_name, module_name):
     """Declares a file for the Swift doc file created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         module_name: The name of the module being built.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swiftdoc".format(module_name),
-        add_target_name_to_output_path,
     )
 
-def _swiftinterface(actions, target_name, module_name, add_target_name_to_output_path):
+def _swiftinterface(actions, add_target_name_to_output_path, target_name, module_name):
     """Declares a file for the Swift interface created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         module_name: The name of the module being built.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swiftinterface".format(module_name),
-        add_target_name_to_output_path,
     )
 
-def _swiftmodule(actions, target_name, module_name, add_target_name_to_output_path):
+def _swiftmodule(actions, add_target_name_to_output_path, target_name, module_name):
     """Declares a file for the Swift module created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         module_name: The name of the module being built.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swiftmodule".format(module_name),
-        add_target_name_to_output_path,
     )
 
-def _swiftsourceinfo(actions, target_name, module_name, add_target_name_to_output_path):
+def _swiftsourceinfo(actions, add_target_name_to_output_path, target_name, module_name):
     """Declares a file for the Swift sourceinfo created by a compilation rule.
 
     Args:
         actions: The context's actions object.
+        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         module_name: The name of the module being built.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.swiftsourceinfo".format(module_name),
-        add_target_name_to_output_path,
     )
 
-def _vfsoverlay(actions, target_name, add_target_name_to_output_path):
+def _vfsoverlay(actions, add_target_name_to_output_path, target_name):
     """Declares a file for the VFS overlay for a compilation action.
 
     The VFS overlay is YAML-formatted file that allows us to place the
@@ -443,20 +443,20 @@ def _vfsoverlay(actions, target_name, add_target_name_to_output_path):
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.vfsoverlay.yaml".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _whole_module_object_file(actions, target_name, add_target_name_to_output_path):
+def _whole_module_object_file(actions, add_target_name_to_output_path, target_name):
     """Declares a file for object files created with whole module optimization.
 
     This is the output of a compile action when whole module optimization is
@@ -465,35 +465,35 @@ def _whole_module_object_file(actions, target_name, add_target_name_to_output_pa
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.o".format(target_name),
-        add_target_name_to_output_path,
     )
 
-def _xctest_runner_script(actions, target_name, add_target_name_to_output_path):
+def _xctest_runner_script(actions, add_target_name_to_output_path, target_name):
     """Declares a file for the script that runs an `.xctest` bundle on Darwin.
 
     Args:
         actions: The context's actions object.
-        target_name: The name of the target being built.
         add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
+        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     return _declare_file(
         actions,
+        add_target_name_to_output_path,
         target_name,
         "{}.test-runner.sh".format(target_name),
-        add_target_name_to_output_path,
     )
 
 derived_files = struct(

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -334,3 +334,7 @@ SWIFT_FEATURE_OBJC_LINK_FLAGS = "swift.objc_link_flag"
 # A private feature that is set by the toolchain if the given toolchain wants
 # all Swift compilations to always be linked.
 SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE = "swift._force_alwayslink_true"
+
+# A feature that adds target_name in output path to support building
+# multiple frameworks with different target name, but same module name.
+SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT = "swift.add_target_name_to_output"

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -26,6 +26,7 @@ load(":derived_files.bzl", "derived_files")
 load(":features.bzl", "get_cc_feature_configuration", "is_feature_enabled")
 load(
     ":feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_LLD_GC_WORKAROUND",
     "SWIFT_FEATURE_OBJC_LINK_FLAGS",
     "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
@@ -125,9 +126,14 @@ def create_linking_context_from_compilation_outputs(
             action_name = swift_action_names.AUTOLINK_EXTRACT,
             swift_toolchain = swift_toolchain,
         ):
+            add_target_name_to_output_path = is_feature_enabled(
+                feature_configuration = feature_configuration,
+                feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+            )
             autolink_file = derived_files.autolink_flags(
                 actions = actions,
                 target_name = label.name,
+                add_target_name_to_output_path = add_target_name_to_output_path,
             )
             register_autolink_extract_action(
                 actions = actions,

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -132,8 +132,8 @@ def create_linking_context_from_compilation_outputs(
             )
             autolink_file = derived_files.autolink_flags(
                 actions = actions,
-                target_name = label.name,
                 add_target_name_to_output_path = add_target_name_to_output_path,
+                target_name = label.name,
             )
             register_autolink_extract_action(
                 actions = actions,

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -17,7 +17,10 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
-load(":feature_names.bzl", "SWIFT_FEATURE_BUNDLED_XCTESTS")
+load(
+    ":feature_names.bzl",
+    "SWIFT_FEATURE_BUNDLED_XCTESTS",
+)
 load(":linking.bzl", "register_link_binary_action")
 load(":providers.bzl", "SwiftToolchainInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
@@ -323,6 +326,7 @@ def _create_xctest_runner(name, actions, executable, xctest_runner_template):
     xctest_runner = derived_files.xctest_runner_script(
         actions = actions,
         target_name = name,
+        add_target_name_to_output_path = False,
     )
 
     actions.expand_template(
@@ -345,7 +349,7 @@ def _swift_binary_impl(ctx):
 
     _, linking_outputs, providers = _swift_linking_rule_impl(
         ctx,
-        binary_path = ctx.label.name,
+        binary_path = derived_files.path(ctx, ctx.label.name),
         feature_configuration = feature_configuration,
         swift_toolchain = swift_toolchain,
     )

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -325,8 +325,8 @@ def _create_xctest_runner(name, actions, executable, xctest_runner_template):
     """
     xctest_runner = derived_files.xctest_runner_script(
         actions = actions,
-        target_name = name,
         add_target_name_to_output_path = False,
+        target_name = name,
     )
 
     actions.expand_template(

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -19,6 +19,7 @@ load(":compiling.bzl", "derive_module_name", "precompile_clang_module")
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
 )
@@ -251,9 +252,14 @@ def _generate_module_map(
     else:
         private_headers = compilation_context.direct_private_headers
 
+    add_target_name_to_output_path = is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+    )
     module_map_file = derived_files.module_map(
         actions = actions,
         target_name = target.label.name,
+        add_target_name_to_output_path = add_target_name_to_output_path,
     )
 
     # Sort dependent module names and the headers to ensure a deterministic

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -258,8 +258,8 @@ def _generate_module_map(
     )
     module_map_file = derived_files.module_map(
         actions = actions,
-        target_name = target.label.name,
         add_target_name_to_output_path = add_target_name_to_output_path,
+        target_name = target.label.name,
     )
 
     # Sort dependent module names and the headers to ensure a deterministic

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -16,7 +16,14 @@
 
 load(
     "@build_bazel_rules_swift//test/rules:provider_test.bzl",
+    "make_provider_test_rule",
     "provider_test",
+)
+
+private_deps_provider_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": ["swift.add_target_name_to_output"],
+    },
 )
 
 def ast_file_test_suite(name):
@@ -37,10 +44,32 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
     )
 
+    private_deps_provider_test(
+        name = "{}_with_no_deps_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
+    )
+
     provider_test(
         name = "{}_with_deps".format(name),
         expected_files = [
             "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
+    )
+
+    private_deps_provider_test(
+        name = "{}_with_deps_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -59,10 +88,32 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
     )
 
+    private_deps_provider_test(
+        name = "{}_with_private_swift_deps_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
+    )
+
     provider_test(
         name = "{}_with_private_cc_deps".format(name),
         expected_files = [
             "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    private_deps_provider_test(
+        name = "{}_with_private_cc_deps_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -75,6 +126,18 @@ def ast_file_test_suite(name):
         expected_files = [
             "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
             "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
+        ],
+        field = "swift_ast_file",
+        provider = "OutputGroupInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/multiple_files",
+    )
+
+    private_deps_provider_test(
+        name = "{}_with_multiple_swift_files_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -10,6 +10,16 @@ load(
 )
 
 default_test = make_action_command_line_test_rule()
+
+# Test with enabled `swift.add_target_name_to_output` feature
+default_with_target_name_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.add_target_name_to_output",
+        ],
+    },
+)
+
 default_opt_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:compilation_mode": "opt",
@@ -58,10 +68,30 @@ vfsoverlay_test = make_action_command_line_test_rule(
     },
 )
 
+# Test with enabled `swift.add_target_name_to_output` feature
+vfsoverlay_with_target_name_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.vfsoverlay",
+            "swift.add_target_name_to_output",
+        ],
+    },
+)
+
 explicit_swift_module_map_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.use_explicit_swift_module_map",
+        ],
+    },
+)
+
+# Test with enabled `swift.add_target_name_to_output` feature
+explicit_swift_module_map_with_target_name_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_explicit_swift_module_map",
+            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -87,6 +117,18 @@ def features_test_suite(name):
         expected_argv = [
             "-emit-object",
             "-I$(BIN_DIR)/test/fixtures/basic",
+            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
+    )
+
+    default_with_target_name_test(
+        name = "{}_default_with_target_name_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-emit-object",
+            "-I$(BIN_DIR)/test/fixtures/basic/first",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -169,6 +211,21 @@ def features_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
+    vfsoverlay_with_target_name_test(
+        name = "{}_vfsoverlay_with_target_name_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
+            "-I/__build_bazel_rules_swift/swiftmodules",
+        ],
+        not_expected_argv = [
+            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-explicit-swift-module-map-file",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
+    )
+
     explicit_swift_module_map_test(
         name = "{}_explicit_swift_module_map_test".format(name),
         tags = [name],
@@ -177,6 +234,21 @@ def features_test_suite(name):
         ],
         not_expected_argv = [
             "-I$(BIN_DIR)/test/fixtures/basic",
+            "-I/__build_bazel_rules_swift/swiftmodules",
+            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
+    )
+
+    explicit_swift_module_map_with_target_name_test(
+        name = "{}_explicit_swift_module_map_with_target_name_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/basic/second.swift-explicit-module-map.json",
+        ],
+        not_expected_argv = [
+            "-I$(BIN_DIR)/test/fixtures/basic/second",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
         ],

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -20,7 +20,14 @@ load(
 )
 load(
     "@build_bazel_rules_swift//test/rules:provider_test.bzl",
+    "make_provider_test_rule",
     "provider_test",
+)
+
+private_deps_with_target_name_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": ["swift.add_target_name_to_output"],
+    },
 )
 
 def generated_header_test_suite(name):
@@ -36,6 +43,18 @@ def generated_header_test_suite(name):
         name = "{}_automatically_named_header_is_rule_output".format(name),
         expected_files = [
             "test/fixtures/generated_header/auto_header-Swift.h",
+            "*",
+        ],
+        field = "files",
+        provider = "DefaultInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:auto_header",
+    )
+
+    private_deps_with_target_name_test(
+        name = "{}_automatically_named_header_is_rule_output_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/generated_header/auto_header/auto_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -73,6 +92,19 @@ def generated_header_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:explicit_header",
     )
 
+    private_deps_with_target_name_test(
+        name = "{}_explicit_header_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/generated_header/explicit_header/SomeOtherName.h",
+            "-test/fixtures/generated_header/explicit_header-Swift.h",
+            "*",
+        ],
+        field = "files",
+        provider = "DefaultInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:explicit_header",
+    )
+
     # Verify that the build fails to analyze if an invalid extension is used.
     analysis_failure_test(
         name = "{}_invalid_extension".format(name),
@@ -86,6 +118,18 @@ def generated_header_test_suite(name):
         name = "{}_valid_path_separator".format(name),
         expected_files = [
             "test/fixtures/generated_header/Valid/Separator.h",
+            "*",
+        ],
+        field = "files",
+        provider = "DefaultInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:valid_path_separator",
+    )
+
+    private_deps_with_target_name_test(
+        name = "{}_valid_path_separator_with_target_name".format(name),
+        expected_files = [
+            "test/fixtures/generated_header/valid_path_separator/Valid/Separator.h",
             "*",
         ],
         field = "files",

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -20,10 +20,29 @@ load(
     "output_file_map_test",
 )
 
+# Test with enabled `swift.add_target_name_to_output` feature
+output_file_map_target_name_test = make_output_file_map_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.add_target_name_to_output",
+        ],
+    },
+)
+
 output_file_map_embed_bitcode_test = make_output_file_map_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.emit_bc",
+        ],
+    },
+)
+
+# Test with enabled `swift.add_target_name_to_output` feature
+output_file_map_target_name_embed_bitcode_test = make_output_file_map_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_bc",
+            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -35,6 +54,19 @@ output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
         ],
         "//command_line_option:features": [
             "swift.emit_bc",
+        ],
+    },
+)
+
+# Test with enabled `swift.add_target_name_to_output` feature
+output_file_map_embed_target_name_bitcode_wmo_test = make_output_file_map_test_rule(
+    config_settings = {
+        "//command_line_option:swiftcopt": [
+            "-whole-module-optimization",
+        ],
+        "//command_line_option:features": [
+            "swift.emit_bc",
+            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -57,6 +89,17 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
+    output_file_map_target_name_test(
+        name = "{}_target_name_default".format(name),
+        expected_mapping = {
+            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
     # In Xcode13, the bitcode file needs to be in the output file map
     # (https://github.com/bazelbuild/rules_swift/issues/682).
     output_file_map_embed_bitcode_test(
@@ -70,6 +113,17 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
+    output_file_map_target_name_embed_bitcode_test(
+        name = "{}_target_name_emit_bc".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
     output_file_map_embed_bitcode_wmo_test(
         name = "{}_emit_bc_wmo".format(name),
         expected_mapping = {
@@ -77,6 +131,17 @@ def output_file_map_test_suite(name):
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_embed_target_name_bitcode_wmo_test(
+        name = "{}_target_name_emit_bc_wmo".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -27,6 +27,16 @@ private_deps_provider_test = make_provider_test_rule(
     },
 )
 
+# Test with enabled `swift.add_target_name_to_output` feature
+private_deps_provider_target_name_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.supports_private_deps",
+            "swift.add_target_name_to_output",
+        ],
+    },
+)
+
 def private_deps_test_suite(name):
     """Test suite for propagation behavior of `swift_library.private_deps`.
 
@@ -96,6 +106,18 @@ def private_deps_test_suite(name):
         expected_files = [
             "/test/fixtures/private_deps/public_cc.swift.modulemap",
             "-/test/fixtures/private_deps/private_cc.swift.modulemap",
+        ],
+        field = "transitive_modules.clang!.module_map!",
+        provider = "SwiftInfo",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
+    )
+
+    private_deps_provider_target_name_test(
+        name = "{}_client_cc_deps_modulemaps_target_name".format(name),
+        expected_files = [
+            "/test/fixtures/private_deps/public_cc/public_cc.swift.modulemap",
+            "-/test/fixtures/private_deps/public_cc/private_cc.swift.modulemap",
         ],
         field = "transitive_modules.clang!.module_map!",
         provider = "SwiftInfo",


### PR DESCRIPTION
**Why it's needed?**
To be able to make builds of same framework with different module names, we need to modify output path so bazel won't have conflicts.
Right now, if we call:
`bazelisk build //PathToModule/ModuleName:Target1 //PathToModule/ModuleName:Target2`
where `Target1` and `Target2` are targets with different files but same module name
bazel will fail because it will try to build 2 different frameworks to same output.
By adding `--features=swift.add_target_name_to_output`, the output will be generated to separate folders, and as output, we will have 2 different framework binaries with different files, but same framework name