### PR TITLE
Add an API to compile a `.swiftinterface` file into a `.swiftmodule`.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -135,6 +135,40 @@ A tuple containing three elements:
           will be `None`.
 
 
+<a id="swift_common.compile_module_interface"></a>
+
+## swift_common.compile_module_interface
+
+<pre>
+swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>,
+                                      <a href="#swift_common.compile_module_interface-module_name">module_name</a>, <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>)
+</pre>
+
+Compiles a Swift module interface.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.compile_module_interface-actions"></a>actions |  The context's <code>actions</code> object.   |  none |
+| <a id="swift_common.compile_module_interface-compilation_contexts"></a>compilation_contexts |  A list of <code>CcCompilationContext</code>s that represent C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from the <code>CcInfo</code> providers of a target's dependencies.   |  none |
+| <a id="swift_common.compile_module_interface-feature_configuration"></a>feature_configuration |  A feature configuration obtained from <code>swift_common.configure_features</code>.   |  none |
+| <a id="swift_common.compile_module_interface-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use <code>swift_common.derive_module_name</code> to generate a default from the target's label if needed.   |  none |
+| <a id="swift_common.compile_module_interface-swiftinterface_file"></a>swiftinterface_file |  The Swift module interface file to compile.   |  none |
+| <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of <code>SwiftInfo</code> providers from dependencies of the target being compiled.   |  none |
+| <a id="swift_common.compile_module_interface-swift_toolchain"></a>swift_toolchain |  The <code>SwiftToolchainInfo</code> provider of the toolchain.   |  none |
+
+**RETURNS**
+
+A Swift module context (as returned by `swift_common.create_module`)
+  that contains the Swift (and potentially C/Objective-C) compilation
+  prerequisites of the compiled module. This should typically be
+  propagated by a `SwiftInfo` provider of the calling rule, and the
+  `CcCompilationContext` inside the Clang module substructure should be
+  propagated by the `CcInfo` provider of the calling rule.
+
+
 <a id="swift_common.configure_features"></a>
 
 ## swift_common.configure_features

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -242,10 +242,10 @@ swift_grpc_library(
 ## swift_import
 
 <pre>
-swift_import(<a href="#swift_import-name">name</a>, <a href="#swift_import-archives">archives</a>, <a href="#swift_import-data">data</a>, <a href="#swift_import-deps">deps</a>, <a href="#swift_import-module_name">module_name</a>, <a href="#swift_import-swiftdoc">swiftdoc</a>, <a href="#swift_import-swiftmodule">swiftmodule</a>)
+swift_import(<a href="#swift_import-name">name</a>, <a href="#swift_import-archives">archives</a>, <a href="#swift_import-data">data</a>, <a href="#swift_import-deps">deps</a>, <a href="#swift_import-module_name">module_name</a>, <a href="#swift_import-swiftdoc">swiftdoc</a>, <a href="#swift_import-swiftinterface">swiftinterface</a>, <a href="#swift_import-swiftmodule">swiftmodule</a>)
 </pre>
 
-Allows for the use of precompiled Swift modules as dependencies in other
+Allows for the use of Swift textual module interfaces and/or precompiled Swift modules as dependencies in other
 `swift_library` and `swift_binary` targets.
 
 
@@ -255,12 +255,13 @@ Allows for the use of precompiled Swift modules as dependencies in other
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="swift_import-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="swift_import-archives"></a>archives |  The list of <code>.a</code> files provided to Swift targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
+| <a id="swift_import-archives"></a>archives |  The list of <code>.a</code> files provided to Swift targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="swift_import-data"></a>data |  The list of files needed by this target at runtime.<br><br>Files and targets named in the <code>data</code> attribute will appear in the <code>*.runfiles</code> area of this target, if it has one. This may include data files needed by a binary or library, or other programs needed by it.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="swift_import-deps"></a>deps |  A list of targets that are dependencies of the target being built, which will be linked into that target.<br><br>If the Swift toolchain supports implementation-only imports (<code>private_deps</code> on <code>swift_library</code>), then targets in <code>deps</code> are treated as regular (non-implementation-only) imports that are propagated both to their direct and indirect (transitive) dependents.<br><br>Allowed kinds of dependencies are:<br><br>*   <code>swift_c_module</code>, <code>swift_import</code> and <code>swift_library</code> (or anything     propagating <code>SwiftInfo</code>)<br><br>*   <code>cc_library</code> (or anything propagating <code>CcInfo</code>)<br><br>Additionally, on platforms that support Objective-C interop, <code>objc_library</code> targets (or anything propagating the <code>apple_common.Objc</code> provider) are allowed as dependencies. On platforms that do not support Objective-C interop (such as Linux), those dependencies will be **ignored.**   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
 | <a id="swift_import-module_name"></a>module_name |  The name of the module represented by this target.   | String | required |  |
 | <a id="swift_import-swiftdoc"></a>swiftdoc |  The <code>.swiftdoc</code> file provided to Swift targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
-| <a id="swift_import-swiftmodule"></a>swiftmodule |  The <code>.swiftmodule</code> file provided to Swift targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="swift_import-swiftinterface"></a>swiftinterface |  The <code>.swiftinterface</code> file that defines the module interface for this target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
+| <a id="swift_import-swiftmodule"></a>swiftmodule |  The <code>.swiftmodule</code> file provided to Swift targets that depend on this target.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | <code>None</code> |
 
 
 <a id="swift_library"></a>

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -51,6 +51,7 @@ bzl_library(
         ":toolchain_config",
         ":utils",
         ":vfsoverlay",
+        "//swift/toolchains/config:compile_module_interface_config",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",

--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -30,6 +30,9 @@ swift_action_names = struct(
     # object files.
     COMPILE = "SwiftCompile",
 
+    # Compiles a `.swiftinterface` file into a `.swiftmodule` file.
+    COMPILE_MODULE_INTERFACE = "SwiftCompileModuleInterface",
+
     # Wraps a `.swiftmodule` in a `.o` file on ELF platforms so that it can be
     # linked into a binary for debugging.
     MODULEWRAP = "SwiftModuleWrap",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -93,6 +93,7 @@ load(
     "compact",
     "compilation_context_for_explicit_module_compilation",
     "get_providers",
+    "merge_compilation_contexts",
     "struct_fields",
 )
 load(":vfsoverlay.bzl", "write_vfsoverlay")
@@ -1953,6 +1954,128 @@ def create_compilation_context(defines, srcs, transitive_modules):
         module_maps = tuple(module_maps),
         swiftmodules = tuple(swiftmodules),
     )
+
+def compile_module_interface(
+        *,
+        actions,
+        compilation_contexts,
+        feature_configuration,
+        module_name,
+        swiftinterface_file,
+        swift_infos,
+        swift_toolchain):
+    """Compiles a Swift module interface.
+
+    Args:
+        actions: The context's `actions` object.
+        compilation_contexts: A list of `CcCompilationContext`s that represent
+            C/Objective-C requirements of the target being compiled, such as
+            Swift-compatible preprocessor defines, header search paths, and so
+            forth. These are typically retrieved from the `CcInfo` providers of
+            a target's dependencies.
+        feature_configuration: A feature configuration obtained from
+            `swift_common.configure_features`.
+        module_name: The name of the Swift module being compiled. This must be
+            present and valid; use `swift_common.derive_module_name` to generate
+            a default from the target's label if needed.
+        swiftinterface_file: The Swift module interface file to compile.
+        swift_infos: A list of `SwiftInfo` providers from dependencies of the
+            target being compiled.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+
+    Returns:
+        A Swift module context (as returned by `swift_common.create_module`)
+        that contains the Swift (and potentially C/Objective-C) compilation
+        prerequisites of the compiled module. This should typically be
+        propagated by a `SwiftInfo` provider of the calling rule, and the
+        `CcCompilationContext` inside the Clang module substructure should be
+        propagated by the `CcInfo` provider of the calling rule.
+    """
+    swiftmodule_file = actions.declare_file("{}.swiftmodule".format(module_name))
+
+    merged_compilation_context = merge_compilation_contexts(
+        transitive_compilation_contexts = compilation_contexts + [
+            cc_info.compilation_context
+            for cc_info in swift_toolchain.implicit_deps_providers.cc_infos
+        ],
+    )
+    merged_swift_info = create_swift_info(
+        swift_infos = (
+            swift_infos + swift_toolchain.implicit_deps_providers.swift_infos
+        ),
+    )
+
+    # Flattening this `depset` is necessary because we need to extract the
+    # module maps or precompiled modules out of structured values and do so
+    # conditionally. This should not lead to poor performance because the
+    # flattening happens only once as the action is being registered, rather
+    # than the same `depset` being flattened and re-merged multiple times up
+    # the build graph.
+    transitive_modules = merged_swift_info.transitive_modules.to_list()
+    transitive_swiftmodules = []
+    for module in transitive_modules:
+        swift_module = module.swift
+        if not swift_module:
+            continue
+        transitive_swiftmodules.append(swift_module.swiftmodule)
+
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+    ):
+        explicit_swift_module_map_file = actions.declare_file(
+            "{}.swift-explicit-module-map.json".format(module_name),
+        )
+        write_explicit_swift_module_map_file(
+            actions = actions,
+            explicit_swift_module_map_file = explicit_swift_module_map_file,
+            module_contexts = transitive_modules,
+        )
+    else:
+        explicit_swift_module_map_file = None
+
+    prerequisites = struct(
+        bin_dir = feature_configuration._bin_dir,
+        cc_compilation_context = merged_compilation_context,
+        explicit_swift_module_map_file = explicit_swift_module_map_file,
+        genfiles_dir = feature_configuration._genfiles_dir,
+        is_swift = True,
+        module_name = module_name,
+        source_files = [swiftinterface_file],
+        swiftmodule_file = swiftmodule_file,
+        transitive_modules = transitive_modules,
+        transitive_swiftmodules = transitive_swiftmodules,
+        user_compile_flags = [],
+    )
+
+    run_toolchain_action(
+        actions = actions,
+        action_name = swift_action_names.COMPILE_MODULE_INTERFACE,
+        feature_configuration = feature_configuration,
+        outputs = [swiftmodule_file],
+        prerequisites = prerequisites,
+        progress_message = "Compiling Swift module {} from textual interface".format(module_name),
+        swift_toolchain = swift_toolchain,
+    )
+
+    module_context = create_module(
+        name = module_name,
+        clang = create_clang_module(
+            compilation_context = merged_compilation_context,
+            module_map = None,
+        ),
+        is_system = is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_SYSTEM_MODULE,
+        ),
+        swift = create_swift_module(
+            swiftdoc = None,
+            swiftinterface = swiftinterface_file,
+            swiftmodule = swiftmodule_file,
+        ),
+    )
+
+    return module_context
 
 def compile(
         *,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -102,6 +102,10 @@ load(
     "platform_developer_framework_dir",
     "swift_developer_lib_dir",
 )
+load(
+    "//swift/toolchains/config:compile_module_interface_config.bzl",
+    "compile_module_interface_action_configs",
+)
 
 # VFS root where all .swiftmodule files will be placed when
 # SWIFT_FEATURE_VFSOVERLAY is enabled.
@@ -161,6 +165,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -177,6 +182,7 @@ def compile_action_configs(
             swift_toolchain_config.action_config(
                 actions = [
                     swift_action_names.COMPILE,
+                    swift_action_names.COMPILE_MODULE_INTERFACE,
                     swift_action_names.DERIVE_FILES,
                     swift_action_names.PRECOMPILE_C_MODULE,
                     swift_action_names.DUMP_AST,
@@ -195,6 +201,7 @@ def compile_action_configs(
                 swift_toolchain_config.action_config(
                     actions = [
                         swift_action_names.COMPILE,
+                        swift_action_names.COMPILE_MODULE_INTERFACE,
                         swift_action_names.DERIVE_FILES,
                         swift_action_names.PRECOMPILE_C_MODULE,
                         swift_action_names.DUMP_AST,
@@ -214,6 +221,7 @@ def compile_action_configs(
                     swift_toolchain_config.action_config(
                         actions = [
                             swift_action_names.COMPILE,
+                            swift_action_names.COMPILE_MODULE_INTERFACE,
                             swift_action_names.DERIVE_FILES,
                             swift_action_names.PRECOMPILE_C_MODULE,
                             swift_action_names.DUMP_AST,
@@ -332,6 +340,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
@@ -424,6 +433,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
@@ -434,6 +444,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
@@ -445,6 +456,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
@@ -694,6 +706,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -713,6 +726,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -739,6 +753,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -790,6 +805,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -806,6 +822,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 # swift_action_names.SYMBOL_GRAPH_EXTRACT, # TODO: Enable once supported
             ],
@@ -874,6 +891,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -886,6 +904,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -897,6 +916,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -912,6 +932,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -941,6 +962,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -956,6 +978,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -966,6 +989,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -990,6 +1014,14 @@ def compile_action_configs(
                     "-Xfrontend",
                     "-color-diagnostics",
                 ),
+            ],
+        ),
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE_MODULE_INTERFACE,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg("-color-diagnostics"),
             ],
         ),
 
@@ -1140,6 +1172,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.DUMP_AST,
             ],
@@ -1151,6 +1184,7 @@ def compile_action_configs(
             swift_toolchain_config.action_config(
                 actions = [
                     swift_action_names.COMPILE,
+                    swift_action_names.COMPILE_MODULE_INTERFACE,
                     swift_action_names.DERIVE_FILES,
                     swift_action_names.PRECOMPILE_C_MODULE,
                     swift_action_names.DUMP_AST,
@@ -1171,6 +1205,7 @@ def compile_action_configs(
                 # actions, or if we should advise against/forbid that.
                 actions = [
                     swift_action_names.COMPILE,
+                    swift_action_names.COMPILE_MODULE_INTERFACE,
                     swift_action_names.DERIVE_FILES,
                     swift_action_names.DUMP_AST,
                 ],
@@ -1184,6 +1219,7 @@ def compile_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -1204,6 +1240,7 @@ def compile_action_configs(
         ),
     )
 
+    action_configs.extend(compile_module_interface_action_configs())
     return action_configs
 
 def _output_or_file_map(output_file_map, outputs, args):
@@ -2041,6 +2078,8 @@ def compile_module_interface(
         genfiles_dir = feature_configuration._genfiles_dir,
         is_swift = True,
         module_name = module_name,
+        objc_include_paths_workaround = depset(),
+        objc_info = None,
         source_files = [swiftinterface_file],
         swiftmodule_file = swiftmodule_file,
         transitive_modules = transitive_modules,

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -32,6 +32,7 @@ load(
 load(
     ":compiling.bzl",
     "compile",
+    "compile_module_interface",
     "create_compilation_context",
     "derive_module_name",
     "precompile_clang_module",
@@ -58,6 +59,7 @@ swift_common = struct(
     cc_feature_configuration = get_cc_feature_configuration,
     compilation_attrs = swift_compilation_attrs,
     compile = compile,
+    compile_module_interface = compile_module_interface,
     configure_features = configure_features,
     create_clang_module = create_clang_module,
     create_compilation_context = create_compilation_context,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -468,6 +468,7 @@ def _all_tool_configs(
         swift_action_names.COMPILE_MODULE_INTERFACE: (
             swift_toolchain_config.driver_tool_config(
                 driver_mode = "swiftc",
+                args = ["-frontend"],
                 env = env,
                 execution_requirements = execution_requirements,
                 swift_executable = swift_executable,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -301,6 +301,7 @@ def _all_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
                 swift_action_names.PRECOMPILE_C_MODULE,
                 swift_action_names.DUMP_AST,
@@ -338,6 +339,7 @@ def _all_action_configs(
         swift_toolchain_config.action_config(
             actions = [
                 swift_action_names.COMPILE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
@@ -453,6 +455,17 @@ def _all_tool_configs(
         swift_action_names.DERIVE_FILES: tool_config,
         swift_action_names.DUMP_AST: tool_config,
         swift_action_names.PRECOMPILE_C_MODULE: (
+            swift_toolchain_config.driver_tool_config(
+                driver_mode = "swiftc",
+                env = env,
+                execution_requirements = execution_requirements,
+                swift_executable = swift_executable,
+                toolchain_root = toolchain_root,
+                use_param_file = True,
+                worker_mode = "wrap",
+            )
+        ),
+        swift_action_names.COMPILE_MODULE_INTERFACE: (
             swift_toolchain_config.driver_tool_config(
                 driver_mode = "swiftc",
                 env = env,

--- a/swift/toolchains/BUILD
+++ b/swift/toolchains/BUILD
@@ -1,0 +1,11 @@
+# Consumed by Bazel integration tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]) + [
+        "//swift/toolchains/config:for_bazel_tests",
+    ],
+    visibility = [
+        "//swift:__pkg__",
+    ],
+)

--- a/swift/toolchains/config/BUILD
+++ b/swift/toolchains/config/BUILD
@@ -1,0 +1,27 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+package(
+    default_visibility = [
+        "//swift/internal:__pkg__",
+        "//swift/toolchains:__pkg__",
+    ],
+)
+
+bzl_library(
+    name = "compile_module_interface_config",
+    srcs = ["compile_module_interface_config.bzl"],
+    deps = [
+        "//swift/internal:actions",
+        "//swift/internal:toolchain_config",
+    ],
+)
+
+# Consumed by Bazel integration tests.
+filegroup(
+    name = "for_bazel_tests",
+    testonly = 1,
+    srcs = glob(["**"]),
+    visibility = [
+        "//swift/toolchains:__pkg__",
+    ],
+)

--- a/swift/toolchains/config/compile_module_interface_config.bzl
+++ b/swift/toolchains/config/compile_module_interface_config.bzl
@@ -1,0 +1,52 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common configuration for compile module interface actions."""
+
+load(
+    "@build_bazel_rules_swift//swift/internal:action_names.bzl",
+    "SWIFT_ACTION_COMPILE_MODULE_INTERFACE",
+)
+load(":action_config.bzl", "ActionConfigInfo", "add_arg")
+
+def compile_module_interface_action_configs():
+    return [
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [add_arg("-enable-library-evolution")],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [_emit_module_path_from_module_interface_configurator],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [
+                add_arg("-compile-module-from-interface"),
+            ],
+        ),
+        # Library evolution is implied since we've already produced a
+        # .swiftinterface file. So we want to unconditionally enable the flag
+        # for this action.
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+            ],
+            configurators = [add_arg("-enable-library-evolution")],
+        ),
+    ]
+
+def _emit_module_path_from_module_interface_configurator(prerequisites, args):
+    """Adds the `.swiftmodule` output path to the command line."""
+    args.add("-o", prerequisites.swiftmodule_file)

--- a/swift/toolchains/config/compile_module_interface_config.bzl
+++ b/swift/toolchains/config/compile_module_interface_config.bzl
@@ -14,36 +14,33 @@
 
 """Common configuration for compile module interface actions."""
 
-load(
-    "@build_bazel_rules_swift//swift/internal:action_names.bzl",
-    "SWIFT_ACTION_COMPILE_MODULE_INTERFACE",
-)
-load(":action_config.bzl", "ActionConfigInfo", "add_arg")
+load("//swift/internal:actions.bzl", "swift_action_names")
+load("//swift/internal:toolchain_config.bzl", "swift_toolchain_config")
 
 def compile_module_interface_action_configs():
     return [
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
-            configurators = [add_arg("-enable-library-evolution")],
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE_MODULE_INTERFACE],
+            configurators = [swift_toolchain_config.add_arg("-enable-library-evolution")],
         ),
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE_MODULE_INTERFACE],
             configurators = [_emit_module_path_from_module_interface_configurator],
         ),
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+        swift_toolchain_config.action_config(
+            actions = [swift_action_names.COMPILE_MODULE_INTERFACE],
             configurators = [
-                add_arg("-compile-module-from-interface"),
+                swift_toolchain_config.add_arg("-compile-module-from-interface"),
             ],
         ),
         # Library evolution is implied since we've already produced a
         # .swiftinterface file. So we want to unconditionally enable the flag
         # for this action.
-        ActionConfigInfo(
+        swift_toolchain_config.action_config(
             actions = [
-                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                swift_action_names.COMPILE_MODULE_INTERFACE,
             ],
-            configurators = [add_arg("-enable-library-evolution")],
+            configurators = [swift_toolchain_config.add_arg("-enable-library-evolution")],
         ),
     ]
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,6 +9,7 @@ load(":imported_framework_tests.bzl", "imported_framework_test_suite")
 load(":mainattr_tests.bzl", "mainattr_test_suite")
 load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":output_file_map_tests.bzl", "output_file_map_test_suite")
+load(":module_interface_tests.bzl", "module_interface_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
 load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
@@ -37,6 +38,8 @@ mainattr_test_suite(name = "mainattr")
 module_cache_settings_test_suite(name = "module_cache_settings")
 
 output_file_map_test_suite(name = "output_file_map")
+
+module_interface_test_suite(name = "module_interface")
 
 private_deps_test_suite(name = "private_deps")
 

--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -56,4 +56,5 @@ swift_library_artifact_collector(
     swiftinterface = "toy_outputs/ToyModule.swiftinterface",
     tags = FIXTURE_TAGS,
     target = ":toy_module_library",
+    target_compatible_with = ["@platforms//os:macos"],
 )

--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -1,0 +1,59 @@
+load(
+    "//swift:swift.bzl",
+    "swift_binary",
+    "swift_import",
+    "swift_library",
+)
+load(
+    "//test/fixtures:common.bzl",
+    "FIXTURE_TAGS",
+)
+load(
+    "//test/rules:swift_library_artifact_collector.bzl",
+    "swift_library_artifact_collector",
+)
+
+package(
+    default_testonly = True,
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+swift_binary(
+    name = "client",
+    srcs = ["Client.swift"],
+    tags = FIXTURE_TAGS,
+    deps = [":toy_module"],
+)
+
+swift_import(
+    name = "toy_module",
+    archives = [":toy_outputs/libToyModule.a"],
+    module_name = "ToyModule",
+    swiftdoc = ":toy_outputs/ToyModule.swiftdoc",
+    swiftinterface = ":toy_outputs/ToyModule.swiftinterface",
+    tags = FIXTURE_TAGS,
+)
+
+# Checking in pre-built artifacts like a `.swiftinterface` and static libraries
+# would require different artifacts for every platform the test might run on.
+# Instead, build it on-demand but forward the outputs using the "artifact
+# collector" rule below to make them act as if they were pre-built outputs when
+# referenced by the `swift_import` rule.
+
+swift_library(
+    name = "toy_module_library",
+    srcs = ["ToyModule.swift"],
+    module_name = "ToyModule",
+    tags = FIXTURE_TAGS,
+)
+
+swift_library_artifact_collector(
+    name = "toy_module_artifact_collector",
+    static_library = "toy_outputs/libToyModule.a",
+    swiftdoc = "toy_outputs/ToyModule.swiftdoc",
+    swiftinterface = "toy_outputs/ToyModule.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target = ":toy_module_library",
+)

--- a/test/fixtures/module_interface/Client.swift
+++ b/test/fixtures/module_interface/Client.swift
@@ -1,0 +1,19 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ToyModule
+
+let value = ToyValue(number: 10)
+print(value.hexString)
+print(value.squared())

--- a/test/fixtures/module_interface/Client.swift
+++ b/test/fixtures/module_interface/Client.swift
@@ -14,6 +14,11 @@
 
 import ToyModule
 
-let value = ToyValue(number: 10)
-print(value.hexString)
-print(value.squared())
+@main
+struct Main {
+  static func main() {
+    let value = ToyValue(number: 10)
+    print(value.hexString)
+    print(value.squared())
+  }
+}

--- a/test/fixtures/module_interface/ToyModule.swift
+++ b/test/fixtures/module_interface/ToyModule.swift
@@ -1,0 +1,37 @@
+// Copyright 2022 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// A toy value.
+@frozen
+public struct ToyValue {
+  /// The numeric value.
+  public var number: Int
+
+  /// The hexadecimal value of the numeric value.
+  public var hexString: String {
+    String(format: "0x%x", number)
+  }
+
+  /// Creates a new toy value with the given numeric value.
+  public init(number: Int) {
+    self.number = number
+  }
+
+  /// Returns the square of the receiver's numeric value.
+  public func squared() -> Int {
+    number * number
+  }
+}

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -1,0 +1,42 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for interoperability with `cc_library`-specific features."""
+
+load(
+    "@bazel_skylib//rules:build_test.bzl",
+    "build_test",
+)
+
+def module_interface_test_suite(name):
+    """Test suite for features that compile Swift module interfaces.
+
+    Args:
+        name: The base name to be used in targets created by this macro.
+    """
+
+    # Verify that a `swift_binary` builds properly when depending on a
+    # `swift_import` target that references a `.swiftinterface` file.
+    build_test(
+        name = "{}_swift_binary_imports_swiftinterface".format(name),
+        targets = [
+            "@build_bazel_rules_swift//test/fixtures/module_interface:client",
+        ],
+        tags = [name],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/test/rules/swift_library_artifact_collector.bzl
+++ b/test/rules/swift_library_artifact_collector.bzl
@@ -1,0 +1,110 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A rule to collect the outputs of a `swift_library`.
+
+This rule is used in tests to simulate "pre-built" artifacts without having to
+check them in directly.
+"""
+
+load(
+    "@build_bazel_rules_swift//swift:swift.bzl",
+    "SwiftInfo",
+)
+
+def _swiftinterface_transition_impl(_settings, attr):
+    # If the `.swiftinterface` file is requested, apply the setting that causes
+    # the rule to generate it.
+    return {
+        "@build_bazel_rules_swift//swift:emit_swiftinterface": attr.swiftinterface != None,
+    }
+
+_swiftinterface_transition = transition(
+    implementation = _swiftinterface_transition_impl,
+    inputs = [],
+    outputs = ["@build_bazel_rules_swift//swift:emit_swiftinterface"],
+)
+
+def _copy_file(actions, source, destination):
+    """Copies the source file to the destination file.
+
+    Args:
+        actions: The object used to register actions.
+        source: A `File` representing the file to be copied.
+        destination: A `File` representing the destination of the copy.
+    """
+    args = actions.args()
+    args.add(source)
+    args.add(destination)
+
+    actions.run_shell(
+        arguments = [args],
+        command = """\
+set -e
+mkdir -p "$(dirname "$2")"
+cp "$1" "$2"
+""",
+        inputs = [source],
+        outputs = [destination],
+    )
+
+def _swift_library_artifact_collector_impl(ctx):
+    target = ctx.attr.target[0]
+    swift_info = target[SwiftInfo]
+
+    if ctx.outputs.static_library:
+        linker_inputs = target[CcInfo].linking_context.linker_inputs.to_list()
+        lib_to_link = linker_inputs[0].libraries[0]
+        _copy_file(
+            ctx.actions,
+            # based on build config one (but not both) of these will be present
+            source = lib_to_link.static_library or lib_to_link.pic_static_library,
+            destination = ctx.outputs.static_library,
+        )
+    if ctx.outputs.swiftdoc:
+        _copy_file(
+            ctx.actions,
+            source = swift_info.direct_modules[0].swift.swiftdoc,
+            destination = ctx.outputs.swiftdoc,
+        )
+    if ctx.outputs.swiftinterface:
+        _copy_file(
+            ctx.actions,
+            source = swift_info.direct_modules[0].swift.swiftinterface,
+            destination = ctx.outputs.swiftinterface,
+        )
+    if ctx.outputs.swiftmodule:
+        _copy_file(
+            ctx.actions,
+            source = swift_info.direct_modules[0].swift.swiftmodule,
+            destination = ctx.outputs.swiftmodule,
+        )
+    return []
+
+swift_library_artifact_collector = rule(
+    attrs = {
+        "static_library": attr.output(mandatory = False),
+        "swiftdoc": attr.output(mandatory = False),
+        "swiftinterface": attr.output(mandatory = False),
+        "swiftmodule": attr.output(mandatory = False),
+        "target": attr.label(
+            cfg = _swiftinterface_transition,
+            providers = [[CcInfo, SwiftInfo]],
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    implementation = _swift_library_artifact_collector_impl,
+)


### PR DESCRIPTION
(cherry picked from commit 47b464853d7a78cd387a095ebfeb61bf6f132410)
