### PR TITLE
Move check for LLVM toolchain outside of repository_rule

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -237,11 +237,11 @@ def _create_linux_toolchain(repository_ctx):
     Args:
       repository_ctx: The repository rule context.
     """
-    cc = repository_ctx.os.environ.get("CC") or ""
-    if "clang" not in cc:
-        fail("ERROR: rules_swift uses Bazel's CROSSTOOL to link, but Swift " +
-             "requires that the driver used is clang. Please set `CC=clang` " +
-             "in your environment before invoking Bazel.")
+    # cc = repository_ctx.os.environ.get("C_COMPILER") or ""
+    # if "clang" not in cc:
+    #     fail("ERROR: rules_swift uses Bazel's CROSSTOOL to link, but Swift " +
+    #          "requires that the driver used is clang. Please set `CC=clang` " +
+    #          "in your environment before invoking Bazel.")
 
     path_to_swiftc = repository_ctx.which("swiftc")
     if not path_to_swiftc:

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -237,12 +237,6 @@ def _create_linux_toolchain(repository_ctx):
     Args:
       repository_ctx: The repository rule context.
     """
-    # cc = repository_ctx.os.environ.get("C_COMPILER") or ""
-    # if "clang" not in cc:
-    #     fail("ERROR: rules_swift uses Bazel's CROSSTOOL to link, but Swift " +
-    #          "requires that the driver used is clang. Please set `CC=clang` " +
-    #          "in your environment before invoking Bazel.")
-
     path_to_swiftc = repository_ctx.which("swiftc")
     if not path_to_swiftc:
         fail("No 'swiftc' executable found in $PATH")

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -266,6 +266,11 @@ def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
 
+    if cc_toolchain.compiler != "clang":
+        fail("The configured Bazel CC toolchain is not LLVM, but Swift requires clang. " +
+             "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
+             "before invoking Bazel, or configure a Bazel LLVM CC toolchain.")
+
     if ctx.attr.os == "windows":
         swift_linkopts_cc_info = _swift_windows_linkopts_cc_info(
             ctx.attr.arch,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -267,7 +267,7 @@ def _swift_toolchain_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
 
     if cc_toolchain.compiler != "clang":
-        fail("The configured Bazel CC toolchain is not LLVM, but Swift requires clang. " +
+        fail("Swift requires the configured CC toolchain to be LLVM (clang). " +
              "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
              "before invoking Bazel, or configure a Bazel LLVM CC toolchain.")
 


### PR DESCRIPTION
Checking `CC=clang` in the implementation of the `repository_rule` doesn't work when using `--incompatible_enable_cc_toolchain_resolution` (for example when using https://github.com/grailbio/bazel-toolchain to bring a hermetic LLVM toolchain).

Moving the check for LLVM the `repository_rule` to the Swift toolchain impl used by all `rule`s instead solves this issue.

I tested that the check (the failure message) is triggered on Linux with:
- only `gcc` installed
- a LLVM toolchain configured in `WORKSPACE` but without `--incompatible_enable_cc_toolchain_resolution`

TODO (maybe?):
- [ ] Add a CI job, or modify a CI job to test the case with a LLVM toolchain?

Fixes #991