### PR TITLE
Disable apple tests on all linux CI jobs

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,10 +24,12 @@ x_defaults:
       - "--action_env=PATH"
     build_targets:
       - "//examples/..."
+      - "-//examples/apple/..."
     test_flags: *linux_flags
     test_targets:
       - "//examples/..."
       - "//test/..."
+      - "-//examples/apple/..."
   windows_common: &windows_common
     platform: windows
     build_flags:
@@ -79,13 +81,6 @@ tasks:
       - "mkdir $SWIFT_HOME"
       - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
     <<: *linux_common
-    build_targets:
-      - "//examples/..."
-      - "-//examples/apple/..."
-    test_targets:
-      - "//examples/..."
-      - "//test/..."
-      - "-//examples/apple/..."
 
   ubuntu2004_latest:
     name: "Current LTS"


### PR DESCRIPTION
There's a hole in bazel where target_compatible_with isn't enough https://github.com/bazelbuild/rules_swift/issues/1093
