### PR TITLE
Lock buildifier for now

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -124,4 +124,4 @@ tasks:
     test_targets:
     - "doc/..."
 
-buildifier: latest
+buildifier: 6.3.2


### PR DESCRIPTION
Hoping the upstream branch takes the import default change to reduce
conflicts
