### PR TITLE
Revert "Added target name to output path to support multiple builds of same module"

### DIFF
--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -23,7 +23,6 @@ load(
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE",
@@ -59,17 +58,11 @@ def ensure_swiftmodule_is_embedded(
         action_name = swift_action_names.MODULEWRAP,
         swift_toolchain = swift_toolchain,
     ):
-        add_target_name_to_output_path = is_feature_enabled(
-            feature_configuration = feature_configuration,
-            feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-        )
-
         # For ELF-format binaries, we need to invoke a Swift modulewrap action
         # to wrap the .swiftmodule file in a .o file that gets propagated to the
         # linker.
         modulewrap_obj = derived_files.modulewrap_object(
             actions,
-            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = label.name,
         )
         _register_modulewrap_action(

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -17,28 +17,11 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":utils.bzl", "owner_relative_path")
 
-def _default_path(ctx, basename):
-    target_name = ctx.label.name
-    return paths.join(target_name, basename)
-
-def _declare_file(actions, add_target_name_to_output_path, target_name, basename):
-    if add_target_name_to_output_path:
-        return actions.declare_file(paths.join(target_name, basename))
-    else:
-        return actions.declare_file(basename)
-
-def _declare_directory(actions, add_target_name_to_output_path, target_name, directory):
-    if add_target_name_to_output_path:
-        return actions.declare_directory("{}_{}".format(target_name, directory))
-    else:
-        return actions.declare_directory(directory)
-
-def _ast(actions, add_target_name_to_output_path, target_name, src):
+def _ast(actions, target_name, src):
     """Declares a file for an ast file during compilation.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -46,91 +29,63 @@ def _ast(actions, add_target_name_to_output_path, target_name, src):
         The declared `File` where the given src's AST will be dumped to.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
+    return actions.declare_file(
         paths.join(dirname, "{}.ast".format(basename)),
     )
 
-def _autolink_flags(actions, add_target_name_to_output_path, target_name):
+def _autolink_flags(actions, target_name):
     """Declares the response file into which autolink flags will be extracted.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.autolink".format(target_name),
-    )
+    return actions.declare_file("{}.autolink".format(target_name))
 
-def _executable(actions, add_target_name_to_output_path, target_name):
+def _executable(actions, target_name):
     """Declares a file for the executable created by a binary or test rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        target_name,
-    )
+    return actions.declare_file(target_name)
 
-def _indexstore_directory(actions, add_target_name_to_output_path, target_name):
+def _indexstore_directory(actions, target_name):
     """Declares a directory in which the compiler's indexstore will be written.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_directory(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.indexstore".format(target_name),
-    )
+    return actions.declare_directory("{}.indexstore".format(target_name))
 
-def _symbol_graph_directory(actions, add_target_name_to_output_path, target_name):
+def _symbol_graph_directory(actions, target_name):
     """Declares a directory in which the compiler's symbol graph will be written.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_directory(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.symbolgraph".format(target_name),
-    )
+    return actions.declare_directory("{}.symbolgraph".format(target_name))
 
-def _intermediate_bc_file(actions, add_target_name_to_output_path, target_name, src):
+def _intermediate_bc_file(actions, target_name, src):
     """Declares a file for an intermediate llvm bc file during compilation.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -138,10 +93,7 @@ def _intermediate_bc_file(actions, add_target_name_to_output_path, target_name, 
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
+    return actions.declare_file(
         paths.join(dirname, "{}.bc".format(basename)),
     )
 
@@ -166,7 +118,7 @@ def _intermediate_frontend_file_path(target_name, src):
 
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
 
-def _intermediate_object_file(actions, add_target_name_to_output_path, target_name, src):
+def _intermediate_object_file(actions, target_name, src):
     """Declares a file for an intermediate object file during compilation.
 
     These files are produced when the compiler is invoked with multiple frontend
@@ -176,7 +128,6 @@ def _intermediate_object_file(actions, add_target_name_to_output_path, target_na
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -184,14 +135,11 @@ def _intermediate_object_file(actions, add_target_name_to_output_path, target_na
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
+    return actions.declare_file(
         paths.join(dirname, "{}.o".format(basename)),
     )
 
-def _module_map(actions, add_target_name_to_output_path, target_name):
+def _module_map(actions, target_name):
     """Declares the module map for a target.
 
     These module maps are used when generating a Swift-compatible module map for
@@ -200,82 +148,36 @@ def _module_map(actions, add_target_name_to_output_path, target_name):
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swift.modulemap".format(target_name),
-    )
+    return actions.declare_file("{}.swift.modulemap".format(target_name))
 
-def _modulewrap_object(actions, add_target_name_to_output_path, target_name):
+def _modulewrap_object(actions, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.modulewrap.o".format(target_name),
-    )
+    return actions.declare_file("{}.modulewrap.o".format(target_name))
 
-def _declare_validated_generated_header(actions, add_target_name_to_output_path, target_name, generated_header_name):
-    """Validates and declares the explicitly named generated header.
-
-    If the file does not have a `.h` extension, the build will fail.
-
-    Args:
-        actions: The context's `actions` object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: Executable target name.
-        generated_header_name: The desired name of the generated header.
-
-    Returns:
-        A `File` that should be used as the output for the generated header.
-    """
-    extension = paths.split_extension(generated_header_name)[1]
-    if extension != ".h":
-        fail(
-            "The generated header for a Swift module must have a '.h' " +
-            "extension (got '{}').".format(generated_header_name),
-        )
-
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        generated_header_name,
-    )
-
-def _precompiled_module(actions, add_target_name_to_output_path, target_name):
+def _precompiled_module(actions, target_name):
     """Declares the precompiled module for a C/Objective-C target.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swift.pcm".format(target_name),
-    )
+    return actions.declare_file("{}.swift.pcm".format(target_name))
 
 def _reexport_modules_src(actions, target_name):
     """Declares a source file used to re-export other Swift modules.
@@ -287,34 +189,26 @@ def _reexport_modules_src(actions, target_name):
     Returns:
         The declared `File`.
     """
-
     return actions.declare_file("{}_exports.swift".format(target_name))
 
-def _static_archive(actions, add_target_name_to_output_path, alwayslink, link_name, target_name):
+def _static_archive(actions, alwayslink, link_name):
     """Declares a file for the static archive created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         alwayslink: Indicates whether the object files in the library should
             always be always be linked into any binaries that depend on it, even
             if some contain no symbols referenced by the binary.
         link_name: The name of the library being built, without a `lib` prefix
             or file extension.
-        target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
     extension = "lo" if alwayslink else "a"
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "lib{}.{}".format(link_name, extension),
-    )
+    return actions.declare_file("lib{}.{}".format(link_name, extension))
 
-def _swiftc_output_file_map(actions, add_target_name_to_output_path, target_name):
+def _swiftc_output_file_map(actions, target_name):
     """Declares a file for the output file map for a compilation action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -323,20 +217,14 @@ def _swiftc_output_file_map(actions, add_target_name_to_output_path, target_name
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.output_file_map.json".format(target_name),
-    )
+    return actions.declare_file("{}.output_file_map.json".format(target_name))
 
-def _swiftc_derived_output_file_map(actions, add_target_name_to_output_path, target_name):
+def _swiftc_derived_output_file_map(actions, target_name):
     """Declares a file for the output file map for a swiftmodule only action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -345,96 +233,64 @@ def _swiftc_derived_output_file_map(actions, add_target_name_to_output_path, tar
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
+    return actions.declare_file(
         "{}.derived_output_file_map.json".format(target_name),
     )
 
-def _swiftdoc(actions, add_target_name_to_output_path, target_name, module_name):
+def _swiftdoc(actions, module_name):
     """Declares a file for the Swift doc file created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swiftdoc".format(module_name),
-    )
+    return actions.declare_file("{}.swiftdoc".format(module_name))
 
-def _swiftinterface(actions, add_target_name_to_output_path, target_name, module_name):
+def _swiftinterface(actions, module_name):
     """Declares a file for the Swift interface created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swiftinterface".format(module_name),
-    )
+    return actions.declare_file("{}.swiftinterface".format(module_name))
 
-def _swiftmodule(actions, add_target_name_to_output_path, target_name, module_name):
+def _swiftmodule(actions, module_name):
     """Declares a file for the Swift module created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swiftmodule".format(module_name),
-    )
+    return actions.declare_file("{}.swiftmodule".format(module_name))
 
-def _swiftsourceinfo(actions, add_target_name_to_output_path, target_name, module_name):
+def _swiftsourceinfo(actions, module_name):
     """Declares a file for the Swift sourceinfo created by a compilation rule.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: The name of the target being built.
         module_name: The name of the module being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swiftsourceinfo".format(module_name),
-    )
+    return actions.declare_file("{}.swiftsourceinfo".format(module_name))
 
-def _vfsoverlay(actions, add_target_name_to_output_path, target_name):
+def _vfsoverlay(actions, target_name):
     """Declares a file for the VFS overlay for a compilation action.
 
     The VFS overlay is YAML-formatted file that allows us to place the
@@ -443,20 +299,14 @@ def _vfsoverlay(actions, add_target_name_to_output_path, target_name):
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.vfsoverlay.yaml".format(target_name),
-    )
+    return actions.declare_file("{}.vfsoverlay.yaml".format(target_name))
 
-def _whole_module_object_file(actions, add_target_name_to_output_path, target_name):
+def _whole_module_object_file(actions, target_name):
     """Declares a file for object files created with whole module optimization.
 
     This is the output of a compile action when whole module optimization is
@@ -465,36 +315,24 @@ def _whole_module_object_file(actions, add_target_name_to_output_path, target_na
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.o".format(target_name),
-    )
+    return actions.declare_file("{}.o".format(target_name))
 
-def _xctest_runner_script(actions, add_target_name_to_output_path, target_name):
+def _xctest_runner_script(actions, target_name):
     """Declares a file for the script that runs an `.xctest` bundle on Darwin.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.test-runner.sh".format(target_name),
-    )
+    return actions.declare_file("{}.test-runner.sh".format(target_name))
 
 derived_files = struct(
     ast = _ast,
@@ -505,7 +343,6 @@ derived_files = struct(
     intermediate_object_file = _intermediate_object_file,
     module_map = _module_map,
     modulewrap_object = _modulewrap_object,
-    path = _default_path,
     precompiled_module = _precompiled_module,
     reexport_modules_src = _reexport_modules_src,
     static_archive = _static_archive,
@@ -519,5 +356,4 @@ derived_files = struct(
     vfsoverlay = _vfsoverlay,
     whole_module_object_file = _whole_module_object_file,
     xctest_runner_script = _xctest_runner_script,
-    generated_header = _declare_validated_generated_header,
 )

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -334,7 +334,3 @@ SWIFT_FEATURE_OBJC_LINK_FLAGS = "swift.objc_link_flag"
 # A private feature that is set by the toolchain if the given toolchain wants
 # all Swift compilations to always be linked.
 SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE = "swift._force_alwayslink_true"
-
-# A feature that adds target_name in output path to support building
-# multiple frameworks with different target name, but same module name.
-SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT = "swift.add_target_name_to_output"

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -26,7 +26,6 @@ load(":derived_files.bzl", "derived_files")
 load(":features.bzl", "get_cc_feature_configuration", "is_feature_enabled")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_LLD_GC_WORKAROUND",
     "SWIFT_FEATURE_OBJC_LINK_FLAGS",
     "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
@@ -126,13 +125,8 @@ def create_linking_context_from_compilation_outputs(
             action_name = swift_action_names.AUTOLINK_EXTRACT,
             swift_toolchain = swift_toolchain,
         ):
-            add_target_name_to_output_path = is_feature_enabled(
-                feature_configuration = feature_configuration,
-                feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-            )
             autolink_file = derived_files.autolink_flags(
                 actions = actions,
-                add_target_name_to_output_path = add_target_name_to_output_path,
                 target_name = label.name,
             )
             register_autolink_extract_action(

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -17,10 +17,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
-load(
-    ":feature_names.bzl",
-    "SWIFT_FEATURE_BUNDLED_XCTESTS",
-)
+load(":feature_names.bzl", "SWIFT_FEATURE_BUNDLED_XCTESTS")
 load(":linking.bzl", "register_link_binary_action")
 load(":providers.bzl", "SwiftToolchainInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
@@ -325,7 +322,6 @@ def _create_xctest_runner(name, actions, executable, xctest_runner_template):
     """
     xctest_runner = derived_files.xctest_runner_script(
         actions = actions,
-        add_target_name_to_output_path = False,
         target_name = name,
     )
 
@@ -349,7 +345,7 @@ def _swift_binary_impl(ctx):
 
     _, linking_outputs, providers = _swift_linking_rule_impl(
         ctx,
-        binary_path = derived_files.path(ctx, ctx.label.name),
+        binary_path = ctx.label.name,
         feature_configuration = feature_configuration,
         swift_toolchain = swift_toolchain,
     )

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -19,7 +19,6 @@ load(":compiling.bzl", "derive_module_name", "precompile_clang_module")
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
 )
@@ -252,13 +251,8 @@ def _generate_module_map(
     else:
         private_headers = compilation_context.direct_private_headers
 
-    add_target_name_to_output_path = is_feature_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-    )
     module_map_file = derived_files.module_map(
         actions = actions,
-        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = target.label.name,
     )
 

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -16,14 +16,7 @@
 
 load(
     "@build_bazel_rules_swift//test/rules:provider_test.bzl",
-    "make_provider_test_rule",
     "provider_test",
-)
-
-private_deps_provider_test = make_provider_test_rule(
-    config_settings = {
-        "//command_line_option:features": ["swift.add_target_name_to_output"],
-    },
 )
 
 def ast_file_test_suite(name):
@@ -44,32 +37,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
     )
 
-    private_deps_provider_test(
-        name = "{}_with_no_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
-    )
-
     provider_test(
         name = "{}_with_deps".format(name),
         expected_files = [
             "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -88,32 +59,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
     )
 
-    private_deps_provider_test(
-        name = "{}_with_private_swift_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
-    )
-
     provider_test(
         name = "{}_with_private_cc_deps".format(name),
         expected_files = [
             "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_private_cc_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -126,18 +75,6 @@ def ast_file_test_suite(name):
         expected_files = [
             "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
             "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/multiple_files",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_multiple_swift_files_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -10,16 +10,6 @@ load(
 )
 
 default_test = make_action_command_line_test_rule()
-
-# Test with enabled `swift.add_target_name_to_output` feature
-default_with_target_name_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.add_target_name_to_output",
-        ],
-    },
-)
-
 default_opt_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:compilation_mode": "opt",
@@ -68,30 +58,10 @@ vfsoverlay_test = make_action_command_line_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-vfsoverlay_with_target_name_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.vfsoverlay",
-            "swift.add_target_name_to_output",
-        ],
-    },
-)
-
 explicit_swift_module_map_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.use_explicit_swift_module_map",
-        ],
-    },
-)
-
-# Test with enabled `swift.add_target_name_to_output` feature
-explicit_swift_module_map_with_target_name_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.use_explicit_swift_module_map",
-            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -117,18 +87,6 @@ def features_test_suite(name):
         expected_argv = [
             "-emit-object",
             "-I$(BIN_DIR)/test/fixtures/basic",
-            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
-        ],
-        mnemonic = "SwiftCompile",
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
-    )
-
-    default_with_target_name_test(
-        name = "{}_default_with_target_name_test".format(name),
-        tags = [name],
-        expected_argv = [
-            "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic/first",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -211,21 +169,6 @@ def features_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
-    vfsoverlay_with_target_name_test(
-        name = "{}_vfsoverlay_with_target_name_test".format(name),
-        tags = [name],
-        expected_argv = [
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
-            "-I/__build_bazel_rules_swift/swiftmodules",
-        ],
-        not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic",
-            "-explicit-swift-module-map-file",
-        ],
-        mnemonic = "SwiftCompile",
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
-    )
-
     explicit_swift_module_map_test(
         name = "{}_explicit_swift_module_map_test".format(name),
         tags = [name],
@@ -234,21 +177,6 @@ def features_test_suite(name):
         ],
         not_expected_argv = [
             "-I$(BIN_DIR)/test/fixtures/basic",
-            "-I/__build_bazel_rules_swift/swiftmodules",
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
-        ],
-        mnemonic = "SwiftCompile",
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
-    )
-
-    explicit_swift_module_map_with_target_name_test(
-        name = "{}_explicit_swift_module_map_with_target_name_test".format(name),
-        tags = [name],
-        expected_argv = [
-            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/basic/second.swift-explicit-module-map.json",
-        ],
-        not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic/second",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
         ],

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -20,14 +20,7 @@ load(
 )
 load(
     "@build_bazel_rules_swift//test/rules:provider_test.bzl",
-    "make_provider_test_rule",
     "provider_test",
-)
-
-private_deps_with_target_name_test = make_provider_test_rule(
-    config_settings = {
-        "//command_line_option:features": ["swift.add_target_name_to_output"],
-    },
 )
 
 def generated_header_test_suite(name):
@@ -43,18 +36,6 @@ def generated_header_test_suite(name):
         name = "{}_automatically_named_header_is_rule_output".format(name),
         expected_files = [
             "test/fixtures/generated_header/auto_header-Swift.h",
-            "*",
-        ],
-        field = "files",
-        provider = "DefaultInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:auto_header",
-    )
-
-    private_deps_with_target_name_test(
-        name = "{}_automatically_named_header_is_rule_output_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/generated_header/auto_header/auto_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -92,19 +73,6 @@ def generated_header_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:explicit_header",
     )
 
-    private_deps_with_target_name_test(
-        name = "{}_explicit_header_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/generated_header/explicit_header/SomeOtherName.h",
-            "-test/fixtures/generated_header/explicit_header-Swift.h",
-            "*",
-        ],
-        field = "files",
-        provider = "DefaultInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:explicit_header",
-    )
-
     # Verify that the build fails to analyze if an invalid extension is used.
     analysis_failure_test(
         name = "{}_invalid_extension".format(name),
@@ -118,18 +86,6 @@ def generated_header_test_suite(name):
         name = "{}_valid_path_separator".format(name),
         expected_files = [
             "test/fixtures/generated_header/Valid/Separator.h",
-            "*",
-        ],
-        field = "files",
-        provider = "DefaultInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:valid_path_separator",
-    )
-
-    private_deps_with_target_name_test(
-        name = "{}_valid_path_separator_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/generated_header/valid_path_separator/Valid/Separator.h",
             "*",
         ],
         field = "files",

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -20,29 +20,10 @@ load(
     "output_file_map_test",
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_target_name_test = make_output_file_map_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.add_target_name_to_output",
-        ],
-    },
-)
-
 output_file_map_embed_bitcode_test = make_output_file_map_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.emit_bc",
-        ],
-    },
-)
-
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_target_name_embed_bitcode_test = make_output_file_map_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.emit_bc",
-            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -54,19 +35,6 @@ output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
         ],
         "//command_line_option:features": [
             "swift.emit_bc",
-        ],
-    },
-)
-
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_embed_target_name_bitcode_wmo_test = make_output_file_map_test_rule(
-    config_settings = {
-        "//command_line_option:swiftcopt": [
-            "-whole-module-optimization",
-        ],
-        "//command_line_option:features": [
-            "swift.emit_bc",
-            "swift.add_target_name_to_output",
         ],
     },
 )
@@ -89,17 +57,6 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_target_name_test(
-        name = "{}_target_name_default".format(name),
-        expected_mapping = {
-            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
     # In Xcode13, the bitcode file needs to be in the output file map
     # (https://github.com/bazelbuild/rules_swift/issues/682).
     output_file_map_embed_bitcode_test(
@@ -113,17 +70,6 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_target_name_embed_bitcode_test(
-        name = "{}_target_name_emit_bc".format(name),
-        expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
     output_file_map_embed_bitcode_wmo_test(
         name = "{}_emit_bc_wmo".format(name),
         expected_mapping = {
@@ -131,17 +77,6 @@ def output_file_map_test_suite(name):
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
-    output_file_map_embed_target_name_bitcode_wmo_test(
-        name = "{}_target_name_emit_bc_wmo".format(name),
-        expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -27,16 +27,6 @@ private_deps_provider_test = make_provider_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-private_deps_provider_target_name_test = make_provider_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.supports_private_deps",
-            "swift.add_target_name_to_output",
-        ],
-    },
-)
-
 def private_deps_test_suite(name):
     """Test suite for propagation behavior of `swift_library.private_deps`.
 
@@ -106,18 +96,6 @@ def private_deps_test_suite(name):
         expected_files = [
             "/test/fixtures/private_deps/public_cc.swift.modulemap",
             "-/test/fixtures/private_deps/private_cc.swift.modulemap",
-        ],
-        field = "transitive_modules.clang!.module_map!",
-        provider = "SwiftInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
-    )
-
-    private_deps_provider_target_name_test(
-        name = "{}_client_cc_deps_modulemaps_target_name".format(name),
-        expected_files = [
-            "/test/fixtures/private_deps/public_cc/public_cc.swift.modulemap",
-            "-/test/fixtures/private_deps/public_cc/private_cc.swift.modulemap",
         ],
         field = "transitive_modules.clang!.module_map!",
         provider = "SwiftInfo",


### PR DESCRIPTION
Reverts bazelbuild/rules_swift#1082

This changes the behavior without enabling the feature in some cases. Specifically I found this in swiftlint where the output path of this target https://github.com/realm/SwiftLint/blob/b281a8d33a958a6c70c3ef18d4182378f337fd3a/BUILD#L81 ends up being `bazel-bin/swiftlint/swiftlint` instead of `bazel-bin/swiftlint` even without enabling this feature.