### PR TITLE
Remove grep_includes

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -211,7 +211,6 @@ def create_linking_context_from_compilation_outputs(
         additional_inputs = additional_inputs,
         disallow_static_libraries = False,
         disallow_dynamic_library = True,
-        grep_includes = None,
     )
 
 def new_objc_provider(
@@ -327,7 +326,6 @@ def register_link_binary_action(
         cc_feature_configuration,
         compilation_outputs,
         deps,
-        grep_includes,  # buildifier: disable=unused-variable
         name,
         output_type,
         owner,
@@ -349,7 +347,6 @@ def register_link_binary_action(
             files that will be passed to the linker.
         deps: A list of targets representing additional libraries that will be
             passed to the linker.
-        grep_includes: Used internally only.
         name: The name of the target being linked, which is used to derive the
             output artifact.
         output_type: A string indicating the output type; "executable" or

--- a/swift/internal/swift_binary_test.bzl
+++ b/swift/internal/swift_binary_test.bzl
@@ -91,13 +91,6 @@ into the binary. Possible values are:
                 ),
                 providers = [[CcInfo]],
             ),
-            # TODO(b/119082664): Used internally only.
-            "_grep_includes": attr.label(
-                allow_single_file = True,
-                cfg = "exec",
-                default = Label("@bazel_tools//tools/cpp:grep-includes"),
-                executable = True,
-            ),
         },
     )
 
@@ -274,7 +267,6 @@ def _swift_linking_rule_impl(
         # This is already collected from `linking_context`.
         compilation_outputs = None,
         deps = ctx.attr.deps + extra_link_deps,
-        grep_includes = ctx.file._grep_includes,
         name = binary_path,
         output_type = "executable",
         owner = ctx.label,


### PR DESCRIPTION
This was removed from bazel in https://github.com/bazelbuild/bazel//commit/ca8b39895bda7a48d7765b97ff9491794cb34edc
