### PR TITLE
Add platform mappings

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,8 +56,10 @@ tasks:
     <<: *mac_common
     build_flags:
       - "--enable_bzlmod"
+      - "--platform_mappings=platform_mappings_bzlmod"
     test_flags:
       - "--enable_bzlmod"
+      - "--platform_mappings=platform_mappings_bzlmod"
 
   macos_last_green:
     name: "Last Green Bazel"

--- a/platform_mappings
+++ b/platform_mappings
@@ -1,0 +1,120 @@
+platforms:
+  @build_bazel_apple_support//platforms:macos_x86_64
+    --cpu=darwin_x86_64
+
+  @build_bazel_apple_support//platforms:macos_arm64
+    --cpu=darwin_arm64
+
+  @build_bazel_apple_support//platforms:darwin_arm64e
+    --cpu=darwin_arm64e
+
+  @build_bazel_apple_support//platforms:ios_i386
+    --cpu=ios_i386
+
+  @build_bazel_apple_support//platforms:ios_x86_64
+    --cpu=ios_x86_64
+
+  @build_bazel_apple_support//platforms:ios_sim_arm64
+    --cpu=ios_sim_arm64
+
+  @build_bazel_apple_support//platforms:ios_armv7
+    --cpu=ios_armv7
+
+  @build_bazel_apple_support//platforms:ios_arm64
+    --cpu=ios_arm64
+
+  @build_bazel_apple_support//platforms:ios_arm64e
+    --cpu=ios_arm64e
+
+  @build_bazel_apple_support//platforms:tvos_x86_64
+    --cpu=tvos_x86_64
+
+  @build_bazel_apple_support//platforms:tvos_sim_arm64
+    --cpu=tvos_sim_arm64
+
+  @build_bazel_apple_support//platforms:tvos_arm64
+    --cpu=tvos_arm64
+
+  @build_bazel_apple_support//platforms:watchos_i386
+    --cpu=watchos_i386
+
+  @build_bazel_apple_support//platforms:watchos_x86_64
+    --cpu=watchos_x86_64
+
+  @build_bazel_apple_support//platforms:watchos_arm64
+    --cpu=watchos_arm64
+
+  @build_bazel_apple_support//platforms:watchos_armv7k
+    --cpu=watchos_armv7k
+
+  @build_bazel_apple_support//platforms:watchos_arm64_32
+    --cpu=watchos_arm64_32
+
+flags:
+  --cpu=darwin_x86_64
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:macos_x86_64
+
+  --cpu=darwin_arm64
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:macos_arm64
+
+  --cpu=darwin_arm64e
+  --apple_platform_type=macos
+    @build_bazel_apple_support//platforms:darwin_arm64e
+
+  --cpu=ios_i386
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_i386
+
+  --cpu=ios_x86_64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_x86_64
+
+  --cpu=ios_sim_arm64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_sim_arm64
+
+  --cpu=ios_armv7
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_armv7
+
+  --cpu=ios_arm64
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_arm64
+
+  --cpu=ios_arm64e
+  --apple_platform_type=ios
+    @build_bazel_apple_support//platforms:ios_arm64e
+
+  --cpu=tvos_x86_64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_x86_64
+
+  --cpu=tvos_sim_arm64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_sim_arm64
+
+  --cpu=tvos_arm64
+  --apple_platform_type=tvos
+    @build_bazel_apple_support//platforms:tvos_arm64
+
+  --cpu=watchos_i386
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_i386
+
+  --cpu=watchos_x86_64
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_x86_64
+
+  --cpu=watchos_arm64
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_arm64
+
+  --cpu=watchos_armv7k
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_armv7k
+
+  --cpu=watchos_arm64_32
+  --apple_platform_type=watchos
+    @build_bazel_apple_support//platforms:watchos_arm64_32

--- a/platform_mappings_bzlmod
+++ b/platform_mappings_bzlmod
@@ -1,120 +1,120 @@
 platforms:
-  @@apple_support~1.9.0//platforms:macos_x86_64
+  @apple_support~1.9.0//platforms:macos_x86_64
     --cpu=darwin_x86_64
 
-  @@apple_support~1.9.0//platforms:macos_arm64
+  @apple_support~1.9.0//platforms:macos_arm64
     --cpu=darwin_arm64
 
-  @@apple_support~1.9.0//platforms:darwin_arm64e
+  @apple_support~1.9.0//platforms:darwin_arm64e
     --cpu=darwin_arm64e
 
-  @@apple_support~1.9.0//platforms:ios_i386
+  @apple_support~1.9.0//platforms:ios_i386
     --cpu=ios_i386
 
-  @@apple_support~1.9.0//platforms:ios_x86_64
+  @apple_support~1.9.0//platforms:ios_x86_64
     --cpu=ios_x86_64
 
-  @@apple_support~1.9.0//platforms:ios_sim_arm64
+  @apple_support~1.9.0//platforms:ios_sim_arm64
     --cpu=ios_sim_arm64
 
-  @@apple_support~1.9.0//platforms:ios_armv7
+  @apple_support~1.9.0//platforms:ios_armv7
     --cpu=ios_armv7
 
-  @@apple_support~1.9.0//platforms:ios_arm64
+  @apple_support~1.9.0//platforms:ios_arm64
     --cpu=ios_arm64
 
-  @@apple_support~1.9.0//platforms:ios_arm64e
+  @apple_support~1.9.0//platforms:ios_arm64e
     --cpu=ios_arm64e
 
-  @@apple_support~1.9.0//platforms:tvos_x86_64
+  @apple_support~1.9.0//platforms:tvos_x86_64
     --cpu=tvos_x86_64
 
-  @@apple_support~1.9.0//platforms:tvos_sim_arm64
+  @apple_support~1.9.0//platforms:tvos_sim_arm64
     --cpu=tvos_sim_arm64
 
-  @@apple_support~1.9.0//platforms:tvos_arm64
+  @apple_support~1.9.0//platforms:tvos_arm64
     --cpu=tvos_arm64
 
-  @@apple_support~1.9.0//platforms:watchos_i386
+  @apple_support~1.9.0//platforms:watchos_i386
     --cpu=watchos_i386
 
-  @@apple_support~1.9.0//platforms:watchos_x86_64
+  @apple_support~1.9.0//platforms:watchos_x86_64
     --cpu=watchos_x86_64
 
-  @@apple_support~1.9.0//platforms:watchos_arm64
+  @apple_support~1.9.0//platforms:watchos_arm64
     --cpu=watchos_arm64
 
-  @@apple_support~1.9.0//platforms:watchos_armv7k
+  @apple_support~1.9.0//platforms:watchos_armv7k
     --cpu=watchos_armv7k
 
-  @@apple_support~1.9.0//platforms:watchos_arm64_32
+  @apple_support~1.9.0//platforms:watchos_arm64_32
     --cpu=watchos_arm64_32
 
 flags:
   --cpu=darwin_x86_64
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:macos_x86_64
+    @apple_support~1.9.0//platforms:macos_x86_64
 
   --cpu=darwin_arm64
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:macos_arm64
+    @apple_support~1.9.0//platforms:macos_arm64
 
   --cpu=darwin_arm64e
   --apple_platform_type=macos
-    @@apple_support~1.9.0//platforms:darwin_arm64e
+    @apple_support~1.9.0//platforms:darwin_arm64e
 
   --cpu=ios_i386
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_i386
+    @apple_support~1.9.0//platforms:ios_i386
 
   --cpu=ios_x86_64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_x86_64
+    @apple_support~1.9.0//platforms:ios_x86_64
 
   --cpu=ios_sim_arm64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_sim_arm64
+    @apple_support~1.9.0//platforms:ios_sim_arm64
 
   --cpu=ios_armv7
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_armv7
+    @apple_support~1.9.0//platforms:ios_armv7
 
   --cpu=ios_arm64
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_arm64
+    @apple_support~1.9.0//platforms:ios_arm64
 
   --cpu=ios_arm64e
   --apple_platform_type=ios
-    @@apple_support~1.9.0//platforms:ios_arm64e
+    @apple_support~1.9.0//platforms:ios_arm64e
 
   --cpu=tvos_x86_64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_x86_64
+    @apple_support~1.9.0//platforms:tvos_x86_64
 
   --cpu=tvos_sim_arm64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_sim_arm64
+    @apple_support~1.9.0//platforms:tvos_sim_arm64
 
   --cpu=tvos_arm64
   --apple_platform_type=tvos
-    @@apple_support~1.9.0//platforms:tvos_arm64
+    @apple_support~1.9.0//platforms:tvos_arm64
 
   --cpu=watchos_i386
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_i386
+    @apple_support~1.9.0//platforms:watchos_i386
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_x86_64
+    @apple_support~1.9.0//platforms:watchos_x86_64
 
   --cpu=watchos_arm64
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_arm64
+    @apple_support~1.9.0//platforms:watchos_arm64
 
   --cpu=watchos_armv7k
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_armv7k
+    @apple_support~1.9.0//platforms:watchos_armv7k
 
   --cpu=watchos_arm64_32
   --apple_platform_type=watchos
-    @@apple_support~1.9.0//platforms:watchos_arm64_32
+    @apple_support~1.9.0//platforms:watchos_arm64_32

--- a/platform_mappings_bzlmod
+++ b/platform_mappings_bzlmod
@@ -1,120 +1,120 @@
 platforms:
-  @apple_support~1.9.0//platforms:macos_x86_64
+  @@apple_support~1.9.0//platforms:macos_x86_64
     --cpu=darwin_x86_64
 
-  @apple_support~1.9.0//platforms:macos_arm64
+  @@apple_support~1.9.0//platforms:macos_arm64
     --cpu=darwin_arm64
 
-  @apple_support~1.9.0//platforms:darwin_arm64e
+  @@apple_support~1.9.0//platforms:darwin_arm64e
     --cpu=darwin_arm64e
 
-  @apple_support~1.9.0//platforms:ios_i386
+  @@apple_support~1.9.0//platforms:ios_i386
     --cpu=ios_i386
 
-  @apple_support~1.9.0//platforms:ios_x86_64
+  @@apple_support~1.9.0//platforms:ios_x86_64
     --cpu=ios_x86_64
 
-  @apple_support~1.9.0//platforms:ios_sim_arm64
+  @@apple_support~1.9.0//platforms:ios_sim_arm64
     --cpu=ios_sim_arm64
 
-  @apple_support~1.9.0//platforms:ios_armv7
+  @@apple_support~1.9.0//platforms:ios_armv7
     --cpu=ios_armv7
 
-  @apple_support~1.9.0//platforms:ios_arm64
+  @@apple_support~1.9.0//platforms:ios_arm64
     --cpu=ios_arm64
 
-  @apple_support~1.9.0//platforms:ios_arm64e
+  @@apple_support~1.9.0//platforms:ios_arm64e
     --cpu=ios_arm64e
 
-  @apple_support~1.9.0//platforms:tvos_x86_64
+  @@apple_support~1.9.0//platforms:tvos_x86_64
     --cpu=tvos_x86_64
 
-  @apple_support~1.9.0//platforms:tvos_sim_arm64
+  @@apple_support~1.9.0//platforms:tvos_sim_arm64
     --cpu=tvos_sim_arm64
 
-  @apple_support~1.9.0//platforms:tvos_arm64
+  @@apple_support~1.9.0//platforms:tvos_arm64
     --cpu=tvos_arm64
 
-  @apple_support~1.9.0//platforms:watchos_i386
+  @@apple_support~1.9.0//platforms:watchos_i386
     --cpu=watchos_i386
 
-  @apple_support~1.9.0//platforms:watchos_x86_64
+  @@apple_support~1.9.0//platforms:watchos_x86_64
     --cpu=watchos_x86_64
 
-  @apple_support~1.9.0//platforms:watchos_arm64
+  @@apple_support~1.9.0//platforms:watchos_arm64
     --cpu=watchos_arm64
 
-  @apple_support~1.9.0//platforms:watchos_armv7k
+  @@apple_support~1.9.0//platforms:watchos_armv7k
     --cpu=watchos_armv7k
 
-  @apple_support~1.9.0//platforms:watchos_arm64_32
+  @@apple_support~1.9.0//platforms:watchos_arm64_32
     --cpu=watchos_arm64_32
 
 flags:
   --cpu=darwin_x86_64
   --apple_platform_type=macos
-    @apple_support~1.9.0//platforms:macos_x86_64
+    @@apple_support~1.9.0//platforms:macos_x86_64
 
   --cpu=darwin_arm64
   --apple_platform_type=macos
-    @apple_support~1.9.0//platforms:macos_arm64
+    @@apple_support~1.9.0//platforms:macos_arm64
 
   --cpu=darwin_arm64e
   --apple_platform_type=macos
-    @apple_support~1.9.0//platforms:darwin_arm64e
+    @@apple_support~1.9.0//platforms:darwin_arm64e
 
   --cpu=ios_i386
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_i386
+    @@apple_support~1.9.0//platforms:ios_i386
 
   --cpu=ios_x86_64
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_x86_64
+    @@apple_support~1.9.0//platforms:ios_x86_64
 
   --cpu=ios_sim_arm64
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_sim_arm64
+    @@apple_support~1.9.0//platforms:ios_sim_arm64
 
   --cpu=ios_armv7
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_armv7
+    @@apple_support~1.9.0//platforms:ios_armv7
 
   --cpu=ios_arm64
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_arm64
+    @@apple_support~1.9.0//platforms:ios_arm64
 
   --cpu=ios_arm64e
   --apple_platform_type=ios
-    @apple_support~1.9.0//platforms:ios_arm64e
+    @@apple_support~1.9.0//platforms:ios_arm64e
 
   --cpu=tvos_x86_64
   --apple_platform_type=tvos
-    @apple_support~1.9.0//platforms:tvos_x86_64
+    @@apple_support~1.9.0//platforms:tvos_x86_64
 
   --cpu=tvos_sim_arm64
   --apple_platform_type=tvos
-    @apple_support~1.9.0//platforms:tvos_sim_arm64
+    @@apple_support~1.9.0//platforms:tvos_sim_arm64
 
   --cpu=tvos_arm64
   --apple_platform_type=tvos
-    @apple_support~1.9.0//platforms:tvos_arm64
+    @@apple_support~1.9.0//platforms:tvos_arm64
 
   --cpu=watchos_i386
   --apple_platform_type=watchos
-    @apple_support~1.9.0//platforms:watchos_i386
+    @@apple_support~1.9.0//platforms:watchos_i386
 
   --cpu=watchos_x86_64
   --apple_platform_type=watchos
-    @apple_support~1.9.0//platforms:watchos_x86_64
+    @@apple_support~1.9.0//platforms:watchos_x86_64
 
   --cpu=watchos_arm64
   --apple_platform_type=watchos
-    @apple_support~1.9.0//platforms:watchos_arm64
+    @@apple_support~1.9.0//platforms:watchos_arm64
 
   --cpu=watchos_armv7k
   --apple_platform_type=watchos
-    @apple_support~1.9.0//platforms:watchos_armv7k
+    @@apple_support~1.9.0//platforms:watchos_armv7k
 
   --cpu=watchos_arm64_32
   --apple_platform_type=watchos
-    @apple_support~1.9.0//platforms:watchos_arm64_32
+    @@apple_support~1.9.0//platforms:watchos_arm64_32

--- a/platform_mappings_bzlmod
+++ b/platform_mappings_bzlmod
@@ -1,0 +1,120 @@
+platforms:
+  @apple_support~1.9.0//platforms:macos_x86_64
+    --cpu=darwin_x86_64
+
+  @apple_support~1.9.0//platforms:macos_arm64
+    --cpu=darwin_arm64
+
+  @apple_support~1.9.0//platforms:darwin_arm64e
+    --cpu=darwin_arm64e
+
+  @apple_support~1.9.0//platforms:ios_i386
+    --cpu=ios_i386
+
+  @apple_support~1.9.0//platforms:ios_x86_64
+    --cpu=ios_x86_64
+
+  @apple_support~1.9.0//platforms:ios_sim_arm64
+    --cpu=ios_sim_arm64
+
+  @apple_support~1.9.0//platforms:ios_armv7
+    --cpu=ios_armv7
+
+  @apple_support~1.9.0//platforms:ios_arm64
+    --cpu=ios_arm64
+
+  @apple_support~1.9.0//platforms:ios_arm64e
+    --cpu=ios_arm64e
+
+  @apple_support~1.9.0//platforms:tvos_x86_64
+    --cpu=tvos_x86_64
+
+  @apple_support~1.9.0//platforms:tvos_sim_arm64
+    --cpu=tvos_sim_arm64
+
+  @apple_support~1.9.0//platforms:tvos_arm64
+    --cpu=tvos_arm64
+
+  @apple_support~1.9.0//platforms:watchos_i386
+    --cpu=watchos_i386
+
+  @apple_support~1.9.0//platforms:watchos_x86_64
+    --cpu=watchos_x86_64
+
+  @apple_support~1.9.0//platforms:watchos_arm64
+    --cpu=watchos_arm64
+
+  @apple_support~1.9.0//platforms:watchos_armv7k
+    --cpu=watchos_armv7k
+
+  @apple_support~1.9.0//platforms:watchos_arm64_32
+    --cpu=watchos_arm64_32
+
+flags:
+  --cpu=darwin_x86_64
+  --apple_platform_type=macos
+    @apple_support~1.9.0//platforms:macos_x86_64
+
+  --cpu=darwin_arm64
+  --apple_platform_type=macos
+    @apple_support~1.9.0//platforms:macos_arm64
+
+  --cpu=darwin_arm64e
+  --apple_platform_type=macos
+    @apple_support~1.9.0//platforms:darwin_arm64e
+
+  --cpu=ios_i386
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_i386
+
+  --cpu=ios_x86_64
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_x86_64
+
+  --cpu=ios_sim_arm64
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_sim_arm64
+
+  --cpu=ios_armv7
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_armv7
+
+  --cpu=ios_arm64
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_arm64
+
+  --cpu=ios_arm64e
+  --apple_platform_type=ios
+    @apple_support~1.9.0//platforms:ios_arm64e
+
+  --cpu=tvos_x86_64
+  --apple_platform_type=tvos
+    @apple_support~1.9.0//platforms:tvos_x86_64
+
+  --cpu=tvos_sim_arm64
+  --apple_platform_type=tvos
+    @apple_support~1.9.0//platforms:tvos_sim_arm64
+
+  --cpu=tvos_arm64
+  --apple_platform_type=tvos
+    @apple_support~1.9.0//platforms:tvos_arm64
+
+  --cpu=watchos_i386
+  --apple_platform_type=watchos
+    @apple_support~1.9.0//platforms:watchos_i386
+
+  --cpu=watchos_x86_64
+  --apple_platform_type=watchos
+    @apple_support~1.9.0//platforms:watchos_x86_64
+
+  --cpu=watchos_arm64
+  --apple_platform_type=watchos
+    @apple_support~1.9.0//platforms:watchos_arm64
+
+  --cpu=watchos_armv7k
+  --apple_platform_type=watchos
+    @apple_support~1.9.0//platforms:watchos_armv7k
+
+  --cpu=watchos_arm64_32
+  --apple_platform_type=watchos
+    @apple_support~1.9.0//platforms:watchos_arm64_32


### PR DESCRIPTION
Replace https://github.com/bazelbuild/rules_swift/pull/1102 with support for bzlmod
