### PR TITLE
Add support for universal compiler plugins

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -19,6 +19,7 @@ _DOC_SRCS = {
         "swift_binary",
         "swift_c_module",
         "swift_compiler_plugin",
+        "universal_swift_compiler_plugin",
         "swift_feature_allowlist",
         "swift_grpc_library",
         "swift_import",

--- a/examples/xplatform/macros/BUILD
+++ b/examples/xplatform/macros/BUILD
@@ -1,5 +1,5 @@
 load("//swift:swift.bzl", "swift_binary", "swift_library", "swift_test")
-load("//swift:swift_compiler_plugin.bzl", "swift_compiler_plugin")
+load("//swift:swift_compiler_plugin.bzl", "swift_compiler_plugin", "universal_swift_compiler_plugin")
 
 licenses(["notice"])
 
@@ -13,6 +13,13 @@ swift_library(
     srcs = ["Stringify.swift"],
     module_name = "Stringify",
     plugins = [":stringify_macro"],
+)
+
+swift_library(
+    name = "stringify_universal",
+    srcs = ["Stringify.swift"],
+    module_name = "StringifyUniversal",
+    plugins = [":stringify_macro_universal"],
 )
 
 swift_compiler_plugin(
@@ -34,10 +41,21 @@ swift_compiler_plugin(
     ],
 )
 
+universal_swift_compiler_plugin(
+    name = "stringify_macro_universal",
+    plugin = ":stringify_macro",
+)
+
 swift_binary(
     name = "stringify_client",
     srcs = ["StringifyClient.swift"],
     deps = [":stringify"],
+)
+
+swift_binary(
+    name = "stringify_universal_client",
+    srcs = ["StringifyUniversalClient.swift"],
+    deps = [":stringify_universal"],
 )
 
 swift_test(

--- a/examples/xplatform/macros/StringifyUniversalClient.swift
+++ b/examples/xplatform/macros/StringifyUniversalClient.swift
@@ -1,0 +1,22 @@
+// Copyright 2023 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import StringifyUniversal
+
+@main
+struct Main {
+  static func main() {
+    print(#stringify(1 + 2))
+  }
+}

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -42,6 +42,9 @@ bzl_library(
         "//swift/internal:swift_common",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
+        "@build_bazel_apple_support//lib:apple_support",
+        "@build_bazel_apple_support//lib:lipo",
+        "@build_bazel_apple_support//lib:transitions",
     ],
 )
 

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -54,6 +54,7 @@ load(
 load(
     "@build_bazel_rules_swift//swift:swift_compiler_plugin.bzl",
     _swift_compiler_plugin = "swift_compiler_plugin",
+    _universal_swift_compiler_plugin = "universal_swift_compiler_plugin",
 )
 load(
     "@build_bazel_rules_swift//swift/internal:swift_feature_allowlist.bzl",
@@ -101,6 +102,7 @@ swift_common = _swift_common
 swift_binary = _swift_binary
 swift_c_module = _swift_c_module
 swift_compiler_plugin = _swift_compiler_plugin
+universal_swift_compiler_plugin = _universal_swift_compiler_plugin
 swift_feature_allowlist = _swift_feature_allowlist
 swift_grpc_library = _swift_grpc_library
 swift_import = _swift_import

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -290,14 +290,13 @@ def _universal_swift_compiler_plugin_impl(ctx):
         module_name = plugin[SwiftCompilerPluginInfo].module_names.to_list()[0]
         swift_infos.append(plugin[SwiftCompilerPluginInfo].swift_info)
 
-    output_group_info1 = ctx.split_attr.plugin.values()[0][OutputGroupInfo]
-    output_group_info2 = ctx.split_attr.plugin.values()[1][OutputGroupInfo]
+    first_output_group_info = ctx.split_attr.plugin.values()[0][OutputGroupInfo]
     combined_output_group_info = {}
-    for key in output_group_info1:
-        combined_output_group_info[key] = depset(transitive = [
-            output_group_info1[key],
-            output_group_info2[key],
-        ])
+    for key in first_output_group_info:
+        all_values = []
+        for plugin in ctx.split_attr.plugin.values():
+            all_values.append(plugin[OutputGroupInfo][key])
+        combined_output_group_info[key] = depset(transitive = all_values)
 
     transitive_runfiles = [
         plugin[DefaultInfo].default_runfiles

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -340,4 +340,39 @@ universal_swift_compiler_plugin = rule(
     executable = True,
     fragments = ["cpp", "apple"],
     implementation = _universal_swift_compiler_plugin_impl,
+    doc = """\
+Wraps an existing `swift_compiler_plugin` target to produce a universal binary.
+
+This is useful to allow sharing of caches between Intel and Apple Silicon Macs
+at the cost of building everything twice.
+
+Example:
+
+```bzl
+# The actual macro code, using SwiftSyntax, as usual.
+swift_compiler_plugin(
+    name = "Macros",
+    srcs = glob(["Macros/*.swift"]),
+    deps = [
+        "@SwiftSyntax",
+        "@SwiftSyntax//:SwiftCompilerPlugin",
+        "@SwiftSyntax//:SwiftSyntaxMacros",
+    ],
+)
+
+# Wrap your compiler plugin in this universal shim.
+universal_swift_compiler_plugin(
+    name = "Macros.universal",
+    plugin = ":Macros",
+)
+
+# The library that defines the macro hook for use in your project, this
+# references the universal_swift_compiler_plugin.
+swift_library(
+    name = "MacroLibrary",
+    srcs = glob(["MacroLibrary/*.swift"]),
+    plugins = [":Macros.universal"],
+)
+```
+""",
 )

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -14,8 +14,9 @@
 
 """Implementation of the `swift_compiler_plugin` rule."""
 
-load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
+load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
+load("@build_bazel_apple_support//lib:transitions.bzl", "macos_universal_transition")
 load(
     "@build_bazel_rules_swift//swift/internal:compiling.bzl",
     "output_groups_from_other_compilation_outputs",
@@ -257,35 +258,17 @@ swift_library(
     implementation = _swift_compiler_plugin_impl,
 )
 
-def _macos_universal_transition_impl(settings, _attr):
-    # Create a split transition from any macOS cpu to a list of all macOS cpus
-    # if settings["//command_line_option:cpu"].startswith("darwin"):
-    return [
-        {"//command_line_option:cpu": "darwin_x86_64"},
-        {"//command_line_option:cpu": "darwin_arm64"},
-    ]
-
-# else:
-#     return settings
-
-macos_universal_transition = transition(
-    implementation = _macos_universal_transition_impl,
-    inputs = ["//command_line_option:cpu"],
-    outputs = ["//command_line_option:cpu"],
-)
-
-def _abc(ctx):
+def _universal_swift_compiler_plugin_impl(ctx):
     inputs = [
-        binary.files.to_list()[0]
-        for binary in ctx.split_attr.plugin.values()
+        plugin.files.to_list()[0]
+        for plugin in ctx.split_attr.plugin.values()
     ]
 
     if not inputs:
-        fail("Target (%s) `binary` label ('%s') does not provide any " +
-             "file for universal binary" % (ctx.attr.name, ctx.attr.binary))
+        fail("Target (%s) `plugin` label ('%s') does not provide any " +
+             "file for universal binary" % (ctx.attr.name, ctx.attr.plugin))
 
     output = ctx.actions.declare_file(ctx.label.name)
-
     if len(inputs) > 1:
         lipo.create(
             actions = ctx.actions,
@@ -294,53 +277,52 @@ def _abc(ctx):
             output = output,
             xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig],
         )
-
     else:
-        # FIXME prboably linux
-        fail("nio")
+        ctx.actions.symlink(target_file = inputs[0], output = output)
 
     cc_infos = []
-    swift_infos = []
+    direct_swift_modules = []
     module_name = None
+    swift_infos = []
     for plugin in ctx.split_attr.plugin.values():
         cc_infos.append(plugin[SwiftCompilerPluginInfo].cc_info)
+        direct_swift_modules.extend(plugin[SwiftCompilerPluginInfo].swift_info.direct_modules)
         module_name = plugin[SwiftCompilerPluginInfo].module_names.to_list()[0]
         swift_infos.append(plugin[SwiftCompilerPluginInfo].swift_info)
+
+    output_group_info1 = ctx.split_attr.plugin.values()[0][OutputGroupInfo]
+    output_group_info2 = ctx.split_attr.plugin.values()[1][OutputGroupInfo]
+    combined_output_group_info = {}
+    for key in output_group_info1:
+        combined_output_group_info[key] = depset(transitive = [
+            output_group_info1[key],
+            output_group_info2[key],
+        ])
+
+    transitive_runfiles = [
+        plugin[DefaultInfo].default_runfiles
+        for plugin in ctx.split_attr.plugin.values()
+    ]
 
     return [
         DefaultInfo(
             executable = output,
             files = depset([output]),
-            runfiles = ctx.runfiles(
-                collect_data = True,
-                collect_default = True,
-                # files = ctx.files.data,
-            ),
+            runfiles = ctx.runfiles().merge_all(transitive_runfiles),
         ),
-        # OutputGroupInfo(**output_groups), TODO
+        OutputGroupInfo(**combined_output_group_info),
         SwiftCompilerPluginInfo(
             cc_info = cc_common.merge_cc_infos(cc_infos = cc_infos),
             executable = output,
             module_names = depset([module_name]),
-            # swift_info = swift_common.create_swift_info(direct_swift_infos = swift_infos),
+            swift_info = swift_common.create_swift_info(
+                modules = direct_swift_modules,
+                swift_infos = swift_infos,
+            ),
         ),
-
-        # SwiftCompilerPluginInfo(
-        #     cc_info = CcInfo(
-        #         compilation_context = module_context.clang.compilation_context,
-        #         linking_context = linking_context,
-        #     ),
-        #     executable = binary_linking_outputs.executable,
-        #     module_names = depset([module_name]),
-        #     swift_info = swift_common.create_swift_info(
-        #         modules = [module_context],
-        #     ),
-        # ),
     ]
 
 universal_swift_compiler_plugin = rule(
-    # universal_swift_compiler_plugin = rule(
-    # cfg = macos_universal_transition,
     attrs = dicts.add(
         apple_support.action_required_attrs(),
         {
@@ -348,6 +330,7 @@ universal_swift_compiler_plugin = rule(
                 cfg = macos_universal_transition,
                 doc = "Target to generate a 'fat' binary from.",
                 mandatory = True,
+                providers = [SwiftCompilerPluginInfo],
             ),
             "_allowlist_function_transition": attr.label(
                 default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
@@ -356,5 +339,5 @@ universal_swift_compiler_plugin = rule(
     ),
     executable = True,
     fragments = ["cpp", "apple"],
-    implementation = _abc,
+    implementation = _universal_swift_compiler_plugin_impl,
 )


### PR DESCRIPTION
This is useful if you populate caches using fat binaries so that they
can be shared between aarch64 and x86_64 macs
