### PR TITLE
Add macros support for Linux

### DIFF
--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -301,7 +301,7 @@ bool SwiftRunner::ProcessArgument(
       } else if (StripPrefix("-macro-expansion-dir=", new_arg)) {
         changed = true;
         std::filesystem::create_directories(new_arg);
-        job_env_["TMPDIR"] = new_arg;
+        job_env_["TMPDIR"] = std::filesystem::absolute(new_arg);
       } else if (new_arg == "-ephemeral-module-cache") {
         // Create a temporary directory to hold the module cache, which will be
         // deleted after compilation is finished.

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -301,7 +301,18 @@ bool SwiftRunner::ProcessArgument(
       } else if (StripPrefix("-macro-expansion-dir=", new_arg)) {
         changed = true;
         std::filesystem::create_directories(new_arg);
-        job_env_["TMPDIR"] = std::filesystem::absolute(new_arg);
+#if __APPLE__
+        job_env_["TMPDIR"] = new_arg;
+#else
+        // TEMPDIR is read by C++ but not Swift. Swift requires the temprorary
+        // directory to be an absolute path and otherwise fails (or ignores it
+        // silently on macOS) so we need to set one that Swift does not read.
+        // C++ prioritizes TMPDIR over TEMPDIR so we need to wipe out the other
+        // one. The downside is that anything else reading TMPDIR will not use
+        // the one potentially set by the user.
+        job_env_["TEMPDIR"] = new_arg;
+        job_env_.erase("TMPDIR");
+#endif
       } else if (new_arg == "-ephemeral-module-cache") {
         // Create a temporary directory to hold the module cache, which will be
         // deleted after compilation is finished.


### PR DESCRIPTION
This uses Swift's builtin feature detection to check what flags are
available. This probably means previous toolchains where macros weren't
complete would return true for this, but that's probably fine.

This also requires absolutizing TMPDIR since that is validated in a case
on Linux and errors otherwise. Hoping this doesn't cause issues.
