### PR TITLE
Fix fetching env on windows

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -28,9 +28,9 @@
 #include <Windows.h>
 
 extern "C" {
-  extern char **_environ;
+  extern wchar_t **_wenviron;
 }
-#define environ _environ
+#define environ _wenviron
 #else
 extern "C" {
   extern char **environ;
@@ -39,7 +39,7 @@ extern "C" {
 
 std::map<std::string, std::string> GetCurrentEnvironment() {
   std::map<std::string, std::string> result;
-  char **envp = environ;
+  auto envp = environ;
   for (int i = 0; envp[i] != nullptr; ++i) {
     std::string envString(envp[i]);
     size_t equalsPos = envString.find('=');

--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -26,10 +26,7 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-
-extern "C" {
-  extern char **_environ;
-}
+#include <stdlib.h>
 #define environ _environ
 #else
 extern "C" {

--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -24,14 +24,35 @@
 #include <vector>
 
 #if defined(_WIN32)
-
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
-// TODO: Implement once windows supports macros
-std::map<std::string, std::string> GetCurrentEnvironment() {
-  return {};
+extern "C" {
+  extern char **_environ;
 }
+#define environ _environ
+#else
+extern "C" {
+  extern char **environ;
+}
+#endif
+
+std::map<std::string, std::string> GetCurrentEnvironment() {
+  std::map<std::string, std::string> result;
+  char **envp = environ;
+  for (int i = 0; envp[i] != nullptr; ++i) {
+    std::string envString(envp[i]);
+    size_t equalsPos = envString.find('=');
+    if (equalsPos != std::string::npos) {
+        std::string key = envString.substr(0, equalsPos);
+        std::string value = envString.substr(equalsPos + 1);
+        result[key] = value;
+    }
+  }
+  return result;
+}
+
+#if defined(_WIN32)
 
 namespace {
 class WindowsIORedirector {
@@ -240,26 +261,6 @@ int RunSubProcess(const std::vector<std::string> &args,
 #include <cstring>
 #include <filesystem>
 #include <memory>
-
-extern "C" {
-  extern char **environ;
-}
-
-std::map<std::string, std::string> GetCurrentEnvironment() {
-  std::map<std::string, std::string> result;
-  char **envp = environ;
-  for (int i = 0; envp[i] != nullptr; ++i) {
-    std::string envString(envp[i]);
-    size_t equalsPos = envString.find('=');
-    if (equalsPos != std::string::npos) {
-        std::string key = envString.substr(0, equalsPos);
-        std::string value = envString.substr(equalsPos + 1);
-        result[key] = value;
-    }
-  }
-  return result;
-}
-
 
 namespace {
 

--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -28,9 +28,9 @@
 #include <Windows.h>
 
 extern "C" {
-  extern wchar_t **_wenviron;
+  extern char **_environ;
 }
-#define environ _wenviron
+#define environ _environ
 #else
 extern "C" {
   extern char **environ;
@@ -39,7 +39,7 @@ extern "C" {
 
 std::map<std::string, std::string> GetCurrentEnvironment() {
   std::map<std::string, std::string> result;
-  auto envp = environ;
+  char **envp = environ;
   for (int i = 0; envp[i] != nullptr; ++i) {
     std::string envString(envp[i]);
     size_t equalsPos = envString.find('=');


### PR DESCRIPTION
Turns out there is _environ. This isn't all of this support, we also have to process the env before exec'ing the process