### PR TITLE
Configure LLVM cc_toolchain included with Swift releases

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
     "build_bazel_rules_swift_index_import",
+    "build_bazel_rules_swift_local_cc_config",
     "build_bazel_rules_swift_local_config",
     "com_github_apple_swift_log",
     "com_github_apple_swift_nio",

--- a/README.md
+++ b/README.md
@@ -65,17 +65,6 @@ also ensure that the Swift compiler is available on your system path.
 Copy the `WORKSPACE` snippet from [the releases
 page](https://github.com/bazelbuild/rules_swift/releases).
 
-### 3. Additional configuration (Linux only)
-
-The `swift_binary` and `swift_test` rules expect to use `clang` as the driver
-for linking, and they query the Bazel C++ API and CROSSTOOL to determine which
-arguments should be passed to the linker. By default, the C++ toolchain used by
-Bazel is `gcc`, so Swift users on Linux need to override this by setting the
-environment variable `CC=clang` when invoking Bazel.
-
-This step is not necessary for macOS users because the Xcode toolchain always
-uses `clang`.
-
 ## Building with Custom Toolchains
 
 **macOS hosts:** You can build with a custom Swift toolchain (downloaded

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -110,7 +110,7 @@ into the binary. Possible values are:
             # Do not add references; temporary attribute for C++ toolchain
             # Starlark migration.
             "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+                default = Label("@build_bazel_rules_swift_local_cc_config//:toolchain"),
             ),
             # A late-bound attribute denoting the value of the `--custom_malloc`
             # command line flag (or None if the flag is not provided).

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -172,7 +172,7 @@ The `.swiftmodule` file provided to Swift targets that depend on this target.
                 mandatory = False,
             ),
             "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+                default = Label("@build_bazel_rules_swift_local_cc_config//:toolchain"),
                 doc = """\
 The C++ toolchain from which linking flags and other tools needed by the Swift
 toolchain (such as `clang`) will be retrieved.

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -274,11 +274,6 @@ def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    if "clang" not in cc_toolchain.compiler:
-        fail("Swift requires the configured CC toolchain to be LLVM (clang). " +
-             "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
-             "before invoking Bazel, or configure a Bazel LLVM CC toolchain.")
-
     if ctx.attr.os == "windows":
         swift_linkopts_cc_info = _swift_windows_linkopts_cc_info(
             ctx.attr.arch,
@@ -450,7 +445,7 @@ configuration options that are applied to targets on a per-package basis.
                 allow_single_file = True,
             ),
             "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+                default = Label("@build_bazel_rules_swift_local_cc_config//:toolchain"),
                 doc = """\
 The C++ toolchain from which other tools needed by the Swift toolchain (such as
 `clang` and `ar`) will be retrieved.

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -800,7 +800,7 @@ configuration options that are applied to targets on a per-package basis.
                 providers = [[SwiftPackageConfigurationInfo]],
             ),
             "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+                default = Label("@build_bazel_rules_swift_local_cc_config//:toolchain"),
                 doc = """\
 The C++ toolchain from which linking flags and other tools needed by the Swift
 toolchain (such as `clang`) will be retrieved.

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -18,6 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "@build_bazel_rules_swift//swift/internal:swift_autoconfiguration.bzl",
     "swift_autoconfiguration",
+    "swift_cc_autoconfiguration",
 )
 
 def _maybe(repo_rule, name, **kwargs):
@@ -189,6 +190,11 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         canonical_id = "index-import-5.8",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"],
         sha256 = "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",
+    )
+
+    _maybe(
+        swift_cc_autoconfiguration,
+        name = "build_bazel_rules_swift_local_cc_config",
     )
 
     _maybe(


### PR DESCRIPTION
On Linux, and to some extent on macOS, Swift ships with its own version of `clang`.

Our problem: we have a tree with a lot of targets for different platforms, and we need to make sure that Swift built binaries are using the Apple-shipped `clang` if we decide to configure another default C++ toolchain for the rest of the build.

This is currently not possible, because `rules_swift` assumes the use of `@bazel_tools//tools/cpp:toolchain_type` for its `cc_toolchain`.

- On macOS, this PR is essentially doing nothing, as we can alias `@local_config_apple_cc//:toolchain`
- On Linux, it's a little bit more involved, as you need to run CC toolchain detection on the `clang` provided by Apple from https://www.swift.org/download/. Fortunately, the relevant functions are part of the public API of `@bazel_tools`.
- On Windows, we do the same as on Linux, except we use the Windows functions from `@bazel_tools`.

This means that we can remove the check for `CC=clang` entirely and leave this choice to the user (which they might need if they have native code that only compiles with clang for example). It is also a prerequisite for downloading Swift toolchains (except on macOS) directly in Bazel, which should now be possible.