### PR TITLE
Enable use_default_shell_env everywhere

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -19,6 +19,8 @@ load("@bazel_skylib//lib:types.bzl", "types")
 load(":features.bzl", "are_all_features_enabled")
 load(":toolchain_config.bzl", "swift_toolchain_config")
 
+USE_DEFAULT_SHELL_ENV = not hasattr(apple_common, "apple_crosstool_transition")
+
 # The names of actions currently supported by the Swift build rules.
 swift_action_names = struct(
     # Extracts a linker input file containing libraries to link from a compiled
@@ -269,5 +271,6 @@ def run_toolchain_action(
         ),
         mnemonic = mnemonic if mnemonic else action_name,
         tools = depset(tools, transitive = [tool_config.tool_inputs]),
+        use_default_shell_env = USE_DEFAULT_SHELL_ENV,
         **kwargs
     )

--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -19,6 +19,8 @@ load("@bazel_skylib//lib:types.bzl", "types")
 load(":features.bzl", "are_all_features_enabled")
 load(":toolchain_config.bzl", "swift_toolchain_config")
 
+# This is a proxy for being on bazel 7.x which has
+# --incompatible_merge_fixed_and_default_shell_env enabled by default
 USE_DEFAULT_SHELL_ENV = not hasattr(apple_common, "apple_crosstool_transition")
 
 # The names of actions currently supported by the Swift build rules.

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -37,6 +37,7 @@ load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(":transitions.bzl", "proto_compiler_transition")
 load(":utils.bzl", "compact", "get_providers")
+load(":actions.bzl", "USE_DEFAULT_SHELL_ENV")
 
 def _register_grpcswift_generate_action(
         label,
@@ -187,6 +188,7 @@ def _register_grpcswift_generate_action(
         mnemonic = "ProtocGenSwiftGRPC",
         outputs = generated_files,
         progress_message = "Generating Swift sources for %{label}",
+        use_default_shell_env = USE_DEFAULT_SHELL_ENV,
     )
 
     return generated_files

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -38,6 +38,7 @@ load(
 load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "get_providers")
+load(":actions.bzl", "USE_DEFAULT_SHELL_ENV")
 
 # The paths of proto files bundled with the runtime. This is mainly the well
 # known type protos, but also includes descriptor.proto to make generation of
@@ -234,6 +235,7 @@ def _register_pbswift_generate_action(
             protoc_executable,
             protoc_plugin_executable,
         ],
+        use_default_shell_env = USE_DEFAULT_SHELL_ENV,
     )
 
     return generated_files


### PR DESCRIPTION
Now that bazel 7.x has
https://bazel.build/reference/command-line-reference#flag--incompatible_merge_fixed_and_default_shell_env
enabled by default, we can set `use_default_shell_env = True` moving
forward. This makes actions respect `--action_env=FOO` which can be
useful for things like `TOOLCHAINS`, `ZERO_AR_DATE`, `TMPDIR`, etc.
Previously these were ignored.
