### PR TITLE
Fix "name 'visibility' is not defined" error on Bazel 5

### DIFF
--- a/swift/module_name.bzl
+++ b/swift/module_name.bzl
@@ -16,8 +16,6 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 
-visibility("public")
-
 def derive_swift_module_name(*args):
     """Returns a derived module name from the given build label.
 


### PR DESCRIPTION
Fixes this error

```
(12:06:33) ERROR: Skipping '@build_bazel_rules_swift//examples/xplatform/xctest': error loading package '@build_bazel_rules_swift//examples/xplatform/xctest': at /private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/build_bazel_rules_swift/swift/swift.bzl:55:5: at /private/var/tmp/_bazel_jesses/06c990151bb0d0bcaaf7ea85520191a3/external/build_bazel_rules_swift/swift/swift_compiler_plugin.bzl:51:6: compilation of module 'swift/module_name.bzl' failed
```

