### PR TITLE
Add SwiftGRPCInfo provider

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -10,6 +10,7 @@ _DOC_SRCS = {
         "swift_usage_aspect",
     ],
     "providers": [
+        "SwiftGRPCInfo",
         "SwiftInfo",
         "SwiftToolchainInfo",
         "SwiftProtoInfo",

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -7,10 +7,30 @@ with the Swift build rules as needed.
 
 On this page:
 
+  * [SwiftGRPCInfo](#SwiftGRPCInfo)
   * [SwiftInfo](#SwiftInfo)
   * [SwiftToolchainInfo](#SwiftToolchainInfo)
   * [SwiftProtoInfo](#SwiftProtoInfo)
   * [SwiftUsageInfo](#SwiftUsageInfo)
+
+<a id="SwiftGRPCInfo"></a>
+
+## SwiftGRPCInfo
+
+<pre>
+SwiftGRPCInfo(<a href="#SwiftGRPCInfo-flavor">flavor</a>, <a href="#SwiftGRPCInfo-direct_pbgrpc_files">direct_pbgrpc_files</a>)
+</pre>
+
+Propagates Swift-specific information about a `swift_grpc_library`.
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="SwiftGRPCInfo-flavor"></a>flavor |  The flavor of GRPC that was generated. E.g. server, client, or client_stubs.    |
+| <a id="SwiftGRPCInfo-direct_pbgrpc_files"></a>direct_pbgrpc_files |  `Depset` of `File`s. The Swift source files (`.grpc.swift`) generated from the `.proto` files in direct dependencies.    |
+
 
 <a id="SwiftInfo"></a>
 
@@ -41,7 +61,7 @@ has reasonable defaults for any fields not explicitly set.
 ## SwiftProtoInfo
 
 <pre>
-SwiftProtoInfo(<a href="#SwiftProtoInfo-module_mappings">module_mappings</a>, <a href="#SwiftProtoInfo-pbswift_files">pbswift_files</a>)
+SwiftProtoInfo(<a href="#SwiftProtoInfo-module_mappings">module_mappings</a>, <a href="#SwiftProtoInfo-pbswift_files">pbswift_files</a>, <a href="#SwiftProtoInfo-direct_pbswift_files">direct_pbswift_files</a>)
 </pre>
 
 Propagates Swift-specific information about a `proto_library`.
@@ -53,6 +73,7 @@ Propagates Swift-specific information about a `proto_library`.
 | :------------- | :------------- |
 | <a id="SwiftProtoInfo-module_mappings"></a>module_mappings |  `Sequence` of `struct`s. Each struct contains `module_name` and `proto_file_paths` fields that denote the transitive mappings from `.proto` files to Swift modules. This allows messages that reference messages in other libraries to import those modules in generated code.    |
 | <a id="SwiftProtoInfo-pbswift_files"></a>pbswift_files |  `Depset` of `File`s. The transitive Swift source files (`.pb.swift`) generated from the `.proto` files.    |
+| <a id="SwiftProtoInfo-direct_pbswift_files"></a>direct_pbswift_files |  `list` of `File`s. The Swift source files (`.pb.swift`) generated from the `.proto` files in direct dependencies.    |
 
 
 <a id="SwiftToolchainInfo"></a>

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -62,6 +62,19 @@ the allowlist.
     },
 )
 
+SwiftGRPCInfo = provider(
+    doc = "Propagates Swift-specific information about a `swift_grpc_library`.",
+    fields = {
+        "flavor": """\
+The flavor of GRPC that was generated. E.g. server, client, or client_stubs.
+""",
+        "direct_pbgrpc_files": """\
+`Depset` of `File`s. The Swift source files (`.grpc.swift`) generated
+from the `.proto` files in direct dependencies.
+""",
+    },
+)
+
 SwiftInfo = provider(
     doc = """\
 Contains information about the compiled artifacts of a Swift module.
@@ -120,6 +133,10 @@ libraries to import those modules in generated code.
         "pbswift_files": """\
 `Depset` of `File`s. The transitive Swift source files (`.pb.swift`) generated
 from the `.proto` files.
+""",
+        "direct_pbswift_files": """\
+`list` of `File`s. The Swift source files (`.pb.swift`) generated
+from the `.proto` files in direct dependencies.
 """,
     },
 )

--- a/swift/internal/swift_grpc_library.bzl
+++ b/swift/internal/swift_grpc_library.bzl
@@ -33,7 +33,13 @@ load(
     "proto_import_path",
     "register_module_mapping_write_action",
 )
-load(":providers.bzl", "SwiftInfo", "SwiftProtoInfo", "SwiftToolchainInfo")
+load(
+    ":providers.bzl",
+    "SwiftGRPCInfo",
+    "SwiftInfo",
+    "SwiftProtoInfo",
+    "SwiftToolchainInfo",
+)
 load(":swift_common.bzl", "swift_common")
 load(":transitions.bzl", "proto_compiler_transition")
 load(":utils.bzl", "compact", "get_providers")
@@ -334,6 +340,10 @@ def _swift_grpc_library_impl(ctx):
             linking_context = linking_context,
         ),
         deps[0][SwiftProtoInfo],
+        SwiftGRPCInfo(
+            flavor = ctx.attr.flavor,
+            direct_pbgrpc_files = generated_files,
+        ),
         swift_common.create_swift_info(
             modules = [module_context],
             swift_infos = get_providers(compile_deps, SwiftInfo),

--- a/swift/internal/swift_protoc_gen_aspect.bzl
+++ b/swift/internal/swift_protoc_gen_aspect.bzl
@@ -260,6 +260,7 @@ def _build_swift_proto_info_provider(
         An instance of `SwiftProtoInfo`.
     """
     return SwiftProtoInfo(
+        direct_pbswift_files = pbswift_files,
         module_mappings = transitive_module_mappings,
         pbswift_files = depset(
             direct = pbswift_files,

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -29,6 +29,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 load(
     "@build_bazel_rules_swift//swift/internal:providers.bzl",
+    _SwiftGRPCInfo = "SwiftGRPCInfo",
     _SwiftInfo = "SwiftInfo",
     _SwiftProtoInfo = "SwiftProtoInfo",
     _SwiftToolchainInfo = "SwiftToolchainInfo",
@@ -90,6 +91,7 @@ load(
 )
 
 # Re-export providers.
+SwiftGRPCInfo = _SwiftGRPCInfo
 SwiftInfo = _SwiftInfo
 SwiftProtoInfo = _SwiftProtoInfo
 SwiftToolchainInfo = _SwiftToolchainInfo


### PR DESCRIPTION
Hi folks! I'm working on a tool to copy generated .pb.swift and .grpc.swift files out of the Bazel build tree into my repo. These files aren't used directly, they're just meant for reference / easy lookup / non-Xcode editor support (VSCode).

Currently, getting this information from GRPC targets is a pain, and they don't differentiate the providers based on flavor. Also in the case of the existing SwiftProtoInfo you get a depset of *all* of the transitive, generated pbswift files, not just those for direct dependencies. And the SwiftProtoInfo doesn't include the GRPC files at all.

This change is purely additive so it should not break anyone. It introduces a new SwiftGRPCInfo provider returned from the swift_grpc_library rule which exposes the flavor and direct_grpc_files generated by the target. I also added an analogous  direct_pbswift_files field to the SwiftProtoInfo provider. These are just flat lists of the generated .pb.swift and .grpc.swift files respectively for direct (proto) deps of those targets. 