### PR TITLE
Support clang fuzzy matches in compiler

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -123,6 +123,8 @@ tasks:
     name: "Doc tests"
     bazel: last_green
     platform: ubuntu2004
+    test_flags:
+    - "--enable_bzlmod=false"
     test_targets:
     - "doc/..."
 

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -110,7 +110,6 @@ write_file(
         header_template = file + "_header.vm",
         input = "//swift:swift.bzl",
         symbol_names = symbols,
-        tags = ["no-sandbox"],  # https://github.com/bazelbuild/stardoc/issues/112
         deps = ["//swift"],
     )
     for [

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -272,7 +272,7 @@ def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cpp_toolchain(ctx)
 
-    if cc_toolchain.compiler != "clang":
+    if "clang" not in cc_toolchain.compiler:
         fail("Swift requires the configured CC toolchain to be LLVM (clang). " +
              "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
              "before invoking Bazel, or configure a Bazel LLVM CC toolchain.")


### PR DESCRIPTION
This was the case before https://github.com/bazelbuild/rules_swift/commit/df485c2b62f83e2024c60ce322f8b4e2671d516b as well. This matters for windows where the compiler is `clang-cl`
