### PR TITLE
Update `xctest_runner` to fail if it doesn't execute any tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -15,6 +15,7 @@ load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
 load(":pch_output_dir_tests.bzl", "pch_output_dir_test_suite")
 load(":explicit_modules_test.bzl", "explicit_modules_test_suite")
+load(":xctest_runner_tests.bzl", "xctest_runner_test_suite")
 load(":bzl_test.bzl", "bzl_test")
 
 licenses(["notice"])
@@ -50,6 +51,8 @@ split_derived_files_test_suite(name = "split_derived_files")
 pch_output_dir_test_suite(name = "pch_output_dir_settings")
 
 explicit_modules_test_suite(name = "explicit_modules")
+
+xctest_runner_test_suite(name = "xctest_runner")
 
 test_suite(
     name = "all_tests",

--- a/test/fixtures/xctest_runner/BUILD
+++ b/test/fixtures/xctest_runner/BUILD
@@ -1,0 +1,28 @@
+load("//swift:swift.bzl", "swift_test")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+
+package(
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+###############################################################################
+# Fixtures for testing xctest_runner outputs
+
+swift_test(
+    name = "PassingUnitTests",
+    srcs = ["PassingUnitTests.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_test(
+    name = "FailingUnitTests",
+    srcs = ["FailingUnitTests.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_test(
+    name = "EmptyUnitTests",
+    tags = FIXTURE_TAGS,
+)

--- a/test/fixtures/xctest_runner/FailingUnitTests.swift
+++ b/test/fixtures/xctest_runner/FailingUnitTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class FailingUnitTests: XCTestCase {
+  func testFail() {
+    XCTAssertEqual(0, 1, "should fail")
+  }
+}

--- a/test/fixtures/xctest_runner/PassingUnitTests.swift
+++ b/test/fixtures/xctest_runner/PassingUnitTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+final class PassingUnitTests: XCTestCase {
+  func testPass() {
+    let result = 1 + 1
+    XCTAssertEqual(result, 2, "should pass")
+  }
+
+  func testSrcdirSet() {
+    XCTAssertNotNil(ProcessInfo.processInfo.environment["TEST_SRCDIR"])
+  }
+
+  func testUndeclaredOutputsSet() {
+    XCTAssertNotNil(ProcessInfo.processInfo.environment["TEST_UNDECLARED_OUTPUTS_DIR"])
+  }
+}

--- a/test/rules/BUILD
+++ b/test/rules/BUILD
@@ -13,3 +13,5 @@ bzl_library(
         "@bazel_skylib//lib:unittest",
     ],
 )
+
+exports_files(["swift_shell_runner.sh.template"])

--- a/test/rules/swift_shell_runner.sh.template
+++ b/test/rules/swift_shell_runner.sh.template
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=;
+# --- end runfiles.bash initialization v3 ---
+
+set -euxo pipefail
+
+# inputs
+executable="%executable%"
+expected_return_code="%expected_return_code%"
+expected_logs=%expected_logs%
+not_expected_logs=%expected_logs%
+
+# execute the target under test while recording its outputs and return code
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+readonly testlog="$tmp_dir/test.log"
+
+return_code=0
+$(rlocation "$executable") 2>&1 | tee -i "$testlog" || return_code=$?
+
+# verify expected return code
+if [[ "$return_code" -ne $expected_return_code ]]; then
+  echo "Fail: return code was $return_code but expected $expected_return_code"
+  exit 1
+fi
+
+# verify the presence of expected logs
+for expected in "${expected_logs[@]}"
+do
+  if ! grep --quiet --regexp "$expected" "$testlog"; then
+    echo "Fail: didn't find expected log: $expected"
+    exit 1
+  fi
+done
+
+# verify the absence of unexpected logs
+for unexpected in "${not_expected_logs[@]}"
+do
+  if ! grep --quiet --invert-match --regexp "$unexpected" "$testlog"; then
+    echo "Fail: found unexpected log: $unexpected"
+    exit 1
+  fi
+done

--- a/test/rules/swift_shell_test.bzl
+++ b/test/rules/swift_shell_test.bzl
@@ -1,0 +1,80 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test rule for verifying output of Swift binaries."""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+def _swift_shell_test_impl(ctx):
+    """Implementation of the swift_shell_test rule."""
+
+    test_executable = ctx.attr.target_under_test.files_to_run.executable
+
+    runfiles = ctx.runfiles(
+        files = [test_executable],
+    ).merge_all([
+        ctx.attr.target_under_test.default_runfiles,
+        ctx.attr._tool.default_runfiles,
+    ])
+
+    output_script = ctx.actions.declare_file("{}_test_script".format(ctx.label.name))
+    ctx.actions.expand_template(
+        template = ctx.file._runner_template,
+        output = output_script,
+        substitutions = {
+            "%executable%": ctx.workspace_name + "/" + test_executable.short_path,
+            "%expected_return_code%": str(ctx.attr.expected_return_code),
+            "%expected_logs%": shell.array_literal(ctx.attr.expected_logs),
+            "%not_expected_logs%": shell.array_literal(ctx.attr.not_expected_logs),
+        },
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = output_script,
+            runfiles = runfiles,
+        ),
+        ctx.attr.target_under_test[OutputGroupInfo],
+    ]
+
+swift_shell_test = rule(
+    implementation = _swift_shell_test_impl,
+    attrs = {
+        "expected_return_code": attr.int(
+            doc = "The expected return code from the target under test",
+        ),
+        "expected_logs": attr.string_list(
+            mandatory = False,
+            doc = "Logs that are expected to be emitted",
+        ),
+        "not_expected_logs": attr.string_list(
+            mandatory = False,
+            doc = "Logs that are not expected to be emitted",
+        ),
+        "target_under_test": attr.label(
+            mandatory = True,
+            doc = "The Swift binary whose outputs to test.",
+            providers = [DefaultInfo],
+        ),
+        "_tool": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+        "_runner_template": attr.label(
+            allow_single_file = True,
+            default = "@build_bazel_rules_swift//test/rules:swift_shell_runner.sh.template",
+        ),
+    },
+    test = True,
+)

--- a/test/xctest_runner_tests.bzl
+++ b/test/xctest_runner_tests.bzl
@@ -1,0 +1,55 @@
+"""Tests for derived files related command line flags under various configs."""
+
+load(
+    "@build_bazel_rules_swift//test/rules:swift_shell_test.bzl",
+    "swift_shell_test",
+)
+
+def xctest_runner_test_suite(name):
+    """Test suite for xctest runner.
+
+    Args:
+      name: the base name to be used in things created by this macro
+    """
+    swift_shell_test(
+        name = "{}_pass".format(name),
+        expected_return_code = 0,
+        expected_logs = [
+            "Test Suite 'PassingUnitTests' passed",
+            "Test Suite 'PassingUnitTests.xctest' passed",
+            "Executed 3 tests, with 0 failures",
+        ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/xctest_runner:PassingUnitTests",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    swift_shell_test(
+        name = "{}_fail".format(name),
+        expected_return_code = 1,
+        expected_logs = [
+            "Test Suite 'FailingUnitTests' failed",
+            "Test Suite 'FailingUnitTests.xctest' failed",
+            "Executed 1 test, with 1 failure",
+        ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/xctest_runner:FailingUnitTests",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    swift_shell_test(
+        name = "{}_no_tests".format(name),
+        expected_return_code = 1,
+        expected_logs = [
+            "Executed 0 tests, with 0 failures",
+            "error: no tests were executed",
+        ],
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/xctest_runner:EmptyUnitTests",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = [name],
+    )

--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -24,6 +24,7 @@ set -euo pipefail
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 readonly profraw="$tmp_dir/coverage.profraw"
+readonly testlog="$tmp_dir/test.log"
 
 # Foo.xctest/Contents/MacOS/Foo -> Foo.xctest
 executable_path="%executable%"
@@ -55,10 +56,19 @@ fi
 exit_status=0
 xctest=$(xcrun -f xctest)
 test_filter=${TESTBRIDGE_TEST_ONLY:-All}
-DYLD_INSERT_LIBRARIES=$sanitizer_dyld_env LLVM_PROFILE_FILE="$profraw" $xctest -XCTest "$test_filter" "$bundle_path" || exit_status=$?
+DYLD_INSERT_LIBRARIES=$sanitizer_dyld_env LLVM_PROFILE_FILE="$profraw" $xctest -XCTest "$test_filter" "$bundle_path" \
+  2>&1 | tee -i "$testlog" \
+  || exit_status=$?
 
 if [[ "$exit_status" -ne 0 ]]; then
   exit "$exit_status"
+fi
+
+# Fail when bundle executes nothing
+test_target_execution_count=$(grep -e "Executed [[:digit:]]\{1,\} tests*," "$testlog" | tail -n1)
+if echo "$test_target_execution_count" | grep -q -e "Executed 0 tests, with 0 failures"; then
+  echo "error: no tests were executed, is the test bundle empty?" >&2
+  exit 1
 fi
 
 if [[ "${COVERAGE:-}" -ne 1 ]]; then


### PR DESCRIPTION
Ports https://github.com/bazelbuild/rules_apple/pull/1978 into `rules_swift`.

- Updates the `xctest_runner` to fail if it doesn't execute any tests
- Adds tests for basic runner usage
- Adds tests for empty bundle cases