### PR TITLE
Add support for importing swift_binary

### DIFF
--- a/examples/xplatform/hello_world/BUILD
+++ b/examples/xplatform/hello_world/BUILD
@@ -1,8 +1,15 @@
-load("//swift:swift.bzl", "swift_binary")
+load("//swift:swift.bzl", "swift_binary", "swift_test")
 
 licenses(["notice"])
 
 swift_binary(
     name = "hello_world",
     srcs = ["main.swift"],
+    module_name = "HelloWorld",
+)
+
+swift_test(
+    name = "hello_world_test",
+    srcs = ["main_test.swift"],
+    deps = [":hello_world"],
 )

--- a/examples/xplatform/hello_world/main.swift
+++ b/examples/xplatform/hello_world/main.swift
@@ -12,4 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-print("Hello, world!")
+public enum HelloWorldGreetings {
+    public static let greeting = "Hello, world!"
+}
+
+print(HelloWorldGreetings.greeting)

--- a/examples/xplatform/hello_world/main_test.swift
+++ b/examples/xplatform/hello_world/main_test.swift
@@ -1,0 +1,10 @@
+import XCTest
+
+@testable import HelloWorld
+
+final class HelloWorldTests: XCTestCase {
+
+    func testGreeting() {
+        XCTAssertEqual(HelloWorldGreetings.greeting, "Hello, world!")
+    }
+}


### PR DESCRIPTION
Currently when attempting to use `swift_binary` within the `deps` of a `swift_test` the module is not importable, for example:

BUILD:

```bzl
load("//swift:swift.bzl", "swift_binary", "swift_test")

swift_binary(
    name = "hello_world",
    srcs = ["main.swift"],
    module_name = "HelloWorld",
)

swift_test(
    name = "hello_world_test",
    srcs = ["main_test.swift"],
    deps = [":hello_world"],
)
```

Error:

```
examples/xplatform/hello_world/main_test.swift:3:18: error: no such module 'HelloWorld'
@testable import HelloWorld
                 ^
error: fatalError
```

Importing the library of a Swift binary is a common pattern in Swift Package Manager, and given `swift_binary` is unlike the Apple packaging rules in that it allows `srcs`, one could conceivably want to test (or use these sources in another module) without needing to split the target up into a `swift_library` and `swift_binary`. 

See [this issue](https://github.com/cgrindel/rules_swift_package_manager/issues/752) for a real use case where breaking it up into `swift_library` and `swift_test` pair complicates things. 

This PR adds support for being able to `import` the underlying library of a `swift_binary` target.