### PR TITLE
Replace --swiftcopt with starlark flag

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,13 +1,9 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load(
-    "@bazel_skylib//rules:common_settings.bzl",
-    "bool_flag",
-    "bool_setting",
-)
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
 load(
     "//swift/internal:build_settings.bzl",
-    "accumulating_string_list_flag",
     "per_module_swiftcopt_flag",
+    "repeatable_string_flag",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -89,7 +85,7 @@ filegroup(
 # Additional Swift compiler flags that will be applied to all `SwiftCompile`
 # actions in non-execution configurations (but not module interface compile
 # actions or Clang module compile actions).
-accumulating_string_list_flag(
+repeatable_string_flag(
     name = "copt",
     build_setting_default = [],
     visibility = ["//visibility:public"],
@@ -98,7 +94,7 @@ accumulating_string_list_flag(
 # Additional Swift compiler flags that will be applied to all `SwiftCompile`
 # actions in execution configurations (but not module interface compile
 # actions or Clang module compile actions).
-accumulating_string_list_flag(
+repeatable_string_flag(
     name = "exec_copt",
     build_setting_default = [],
     visibility = ["//visibility:public"],

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,7 +1,12 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
+load(
+    "@bazel_skylib//rules:common_settings.bzl",
+    "bool_flag",
+    "bool_setting",
+)
 load(
     "//swift/internal:build_settings.bzl",
+    "accumulating_string_list_flag",
     "per_module_swiftcopt_flag",
 )
 
@@ -79,6 +84,24 @@ filegroup(
     visibility = [
         "//:__pkg__",
     ],
+)
+
+# Additional Swift compiler flags that will be applied to all `SwiftCompile`
+# actions in non-execution configurations (but not module interface compile
+# actions or Clang module compile actions).
+accumulating_string_list_flag(
+    name = "copt",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
+)
+
+# Additional Swift compiler flags that will be applied to all `SwiftCompile`
+# actions in execution configurations (but not module interface compile
+# actions or Clang module compile actions).
+accumulating_string_list_flag(
+    name = "exec_copt",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
 )
 
 # User settable flag that specifies additional Swift copts on a per-swiftmodule basis.

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -424,6 +424,7 @@ bzl_library(
 bzl_library(
     name = "build_settings",
     srcs = ["build_settings.bzl"],
+    deps = ["@bazel_skylib//rules:common_settings"],
 )
 
 # Indirection needed to prevent using `objc_library` outside of macOS

--- a/swift/internal/build_settings.bzl
+++ b/swift/internal/build_settings.bzl
@@ -16,6 +16,23 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
+def _repeatable_string_flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+repeatable_string_flag = rule(
+    build_setting = config.string_list(
+        flag = True,
+        repeatable = True,
+    ),
+    doc = """\
+A string-valued flag that can occur on the command line multiple times, used for
+flags like `copt`. This allows flags to be stacked in `--config`s (rather than
+overwriting previous occurrences) and also makes no assumption about the values
+of the flags (comma-splitting does not occur).
+""",
+    implementation = _repeatable_string_flag_impl,
+)
+
 PerModuleSwiftCoptSettingInfo = provider(
     doc = "A provider for the parsed per-swiftmodule swift copts.",
     fields = {
@@ -84,16 +101,4 @@ the list is expected to be of the form: <//target-package:name>=<copts> where
 copts is a colon separated list of Swift copts.
 """,
     implementation = _per_module_swiftcopt_flag_impl,
-)
-
-def _accumulating_string_list_flag_impl(ctx):
-    return [BuildSettingInfo(value = ctx.build_setting_value)]
-
-accumulating_string_list_flag = rule(
-    build_setting = config.string_list(
-        flag = True,
-        repeatable = True,
-    ),
-    doc = "A string list-typed build setting that can be set on the command line and accumulates values.",
-    implementation = _accumulating_string_list_flag_impl,
 )

--- a/swift/internal/build_settings.bzl
+++ b/swift/internal/build_settings.bzl
@@ -14,6 +14,8 @@
 
 """Custom build settings rules for Swift rules."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
 PerModuleSwiftCoptSettingInfo = provider(
     doc = "A provider for the parsed per-swiftmodule swift copts.",
     fields = {
@@ -82,4 +84,16 @@ the list is expected to be of the form: <//target-package:name>=<copts> where
 copts is a colon separated list of Swift copts.
 """,
     implementation = _per_module_swiftcopt_flag_impl,
+)
+
+def _accumulating_string_list_flag_impl(ctx):
+    return [BuildSettingInfo(value = ctx.build_setting_value)]
+
+accumulating_string_list_flag = rule(
+    build_setting = config.string_list(
+        flag = True,
+        repeatable = True,
+    ),
+    doc = "A string list-typed build setting that can be set on the command line and accumulates values.",
+    implementation = _accumulating_string_list_flag_impl,
 )

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -21,6 +21,7 @@ toolchain, see `swift.bzl`.
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
@@ -292,11 +293,19 @@ def _swift_toolchain_impl(ctx):
             toolchain_root,
         )
 
+    # TODO: b/312204041 - Remove the use of the `swift` fragment once we've
+    # migrated the `--swiftcopt` flag via `--flag_alias`.
+    swiftcopts = list(ctx.fragments.swift.copts())
+    if "-exec-" in ctx.bin_dir.path:
+        swiftcopts.extend(ctx.attr._exec_copts[BuildSettingInfo].value)
+    else:
+        swiftcopts.extend(ctx.attr._copts[BuildSettingInfo].value)
+
     # Combine build mode features, autoconfigured features, and required
     # features.
     requested_features = (
         features_for_build_modes(ctx) +
-        features_from_swiftcopts(swiftcopts = ctx.fragments.swift.copts())
+        features_from_swiftcopts(swiftcopts = swiftcopts)
     )
     requested_features.extend([
         SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
@@ -330,7 +339,7 @@ def _swift_toolchain_impl(ctx):
         arch = ctx.attr.arch,
         sdkroot = ctx.attr.sdkroot,
         xctest_version = ctx.attr.xctest_version,
-        additional_swiftc_copts = ctx.fragments.swift.copts(),
+        additional_swiftc_copts = swiftcopts,
     )
 
     if ctx.attr.os == "windows":
@@ -441,6 +450,20 @@ configuration options that are applied to targets on a per-package basis.
                 doc = """\
 The C++ toolchain from which other tools needed by the Swift toolchain (such as
 `clang` and `ar`) will be retrieved.
+""",
+            ),
+            "_copts": attr.label(
+                default = Label("@build_bazel_rules_swift//swift:copt"),
+                doc = """\
+The label of the `string_list` containing additional flags that should be passed
+to the compiler.
+""",
+            ),
+            "_exec_copts": attr.label(
+                default = Label("@build_bazel_rules_swift//swift:exec_copt"),
+                doc = """\
+The label of the `string_list` containing additional flags that should be passed
+to the compiler for exec transition builds.
 """,
             ),
             "_worker": attr.label(


### PR DESCRIPTION
The Swift configuration fragment is being removed from bazel, this adds
the starlark flags necessary to replace the functionality. This differs
from the upstream solution since google doesn't have a need to support a
--host_swiftcopt replacement

(cherry picked from commit 8be724720ee6d1b73c52851106cf95b3cf158b3f)
