### PR TITLE
Disable builtin C++ toolchain in BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -26,3 +26,4 @@ tasks:
     platform: macos
     build_targets:
     - "@rules_swift//examples/apple/..."
+    - "--repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"


### PR DESCRIPTION
Now that the BCR uses bzlmod the builtin toolchain is preferred which
doesn't work for us. This wouldn't be an issue if the tests in the bcr
ran within this repo