### PR TITLE
Add swift.treat_warnings_as_errors feature

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -62,6 +62,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_SYSTEM_MODULE",
+    "SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS",
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
@@ -525,6 +526,19 @@ def compile_action_configs(
                 swift_toolchain_config.add_arg("-enable-testing"),
             ],
             features = [SWIFT_FEATURE_ENABLE_TESTING],
+        ),
+
+        # Enable warnings-as-errors if requested.
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg("-warnings-as-errors"),
+            ],
+            features = [SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS],
         ),
 
         # Set Developer Framework search paths

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -336,3 +336,6 @@ SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE = "swift._force_alwayslink_true"
 # 5.9 and above). Users should never manually enable, disable, or query this
 # feature.
 SWIFT_FEATURE__SUPPORTS_MACROS = "swift._supports_macros"
+
+# Pass -warnings-as-errors to the compiler.
+SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS = "swift.treat_warnings_as_errors"


### PR DESCRIPTION
This makes it easier for you to negate this feature and not have to
worry about command line flag ordering
