### PR TITLE
Add support for removed swift fragment

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
     repo_name = "build_bazel_rules_swift",
 )
 
+bazel_dep(name = "bazel_features", version = "1.2.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.0.2")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     repo_name = "build_bazel_rules_swift",
 )
 
-bazel_dep(name = "bazel_features", version = "1.2.0")
+bazel_dep(name = "bazel_features", version = "1.3.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.0.2")

--- a/swift/extras.bzl
+++ b/swift/extras.bzl
@@ -16,6 +16,7 @@
 dependencies of the Swift rules.
 """
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 load(
     "@rules_proto//proto:repositories.bzl",
@@ -37,3 +38,5 @@ def swift_rules_extra_dependencies():
     rules_proto_dependencies()
 
     rules_proto_toolchains()
+
+    bazel_features_deps()

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -293,9 +293,12 @@ def _swift_toolchain_impl(ctx):
             toolchain_root,
         )
 
-    # TODO: b/312204041 - Remove the use of the `swift` fragment once we've
-    # migrated the `--swiftcopt` flag via `--flag_alias`.
-    swiftcopts = list(ctx.fragments.swift.copts())
+    # TODO: Remove once we drop bazel 7.x support
+    if hasattr(ctx.fragments, "swift"):
+        swiftcopts = list(ctx.fragments.swift.copts())
+    else:
+        swiftcopts = []
+
     if "-exec-" in ctx.bin_dir.path:
         swiftcopts.extend(ctx.attr._exec_copts[BuildSettingInfo].value)
     else:
@@ -505,7 +508,7 @@ The version of XCTest that the toolchain packages.
         },
     ),
     doc = "Represents a Swift compiler toolchain.",
-    fragments = ["swift"],
+    fragments = [] if bazel_features.cc.swift_fragment_removed else ["swift"],
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     incompatible_use_toolchain_transition = True,
     implementation = _swift_toolchain_impl,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -19,6 +19,7 @@ toolchain package. If you are looking for rules to build Swift code using this
 toolchain, see `swift.bzl`.
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")

--- a/swift/internal/target_triples.bzl
+++ b/swift/internal/target_triples.bzl
@@ -130,8 +130,6 @@ def _parse(triple_string):
             it was present. This component may be `None`.
     """
     components = triple_string.split("-")
-    if len(components) < 3:
-        fail("Invalid target triple: {}, this likely means you're using the wrong CC toolchain, make sure you include apple_support in your project".format(triple_string))
     return _make(
         cpu = components[0],
         vendor = components[1],

--- a/swift/internal/target_triples.bzl
+++ b/swift/internal/target_triples.bzl
@@ -130,6 +130,8 @@ def _parse(triple_string):
             it was present. This component may be `None`.
     """
     components = triple_string.split("-")
+    if len(components) < 3:
+        fail("Invalid target triple: {}, this likely means you're using the wrong CC toolchain, make sure you include apple_support in your project".format(triple_string))
     return _make(
         cpu = components[0],
         vendor = components[1],

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -19,12 +19,12 @@ toolchain package. If you are looking for rules to build Swift code using this
 toolchain, see `swift.bzl`.
 """
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load("@bazel_features//:features.bzl", "bazel_features")
 load(":actions.bzl", "swift_action_names")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
 load(":compiling.bzl", "compile_action_configs", "features_from_swiftcopts")

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -81,6 +81,14 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
             build_file = "@build_bazel_rules_swift//third_party:com_github_nlohmann_json/BUILD.overlay",
         )
 
+        _maybe(
+            http_archive,
+            name = "bazel_features",
+            sha256 = "b8789c83c893d7ef3041d3f2795774936b27ff61701a705df52fd41d6ddbf692",
+            strip_prefix = "bazel_features-1.2.0",
+            url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.2.0/bazel_features-v1.2.0.tar.gz",
+        )
+
     _maybe(
         http_archive,
         name = "com_github_apple_swift_protobuf",

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -84,9 +84,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         _maybe(
             http_archive,
             name = "bazel_features",
-            sha256 = "b8789c83c893d7ef3041d3f2795774936b27ff61701a705df52fd41d6ddbf692",
-            strip_prefix = "bazel_features-1.2.0",
-            url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.2.0/bazel_features-v1.2.0.tar.gz",
+            sha256 = "53182a68f172a2af4ad37051f82201e222bc19f7a40825b877da3ff4c922b9e0",
+            strip_prefix = "bazel_features-1.3.0",
+            url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.3.0/bazel_features-v1.3.0.tar.gz",
         )
 
     _maybe(

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -30,7 +30,7 @@ output_file_map_embed_bitcode_test = make_output_file_map_test_rule(
 
 output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
     config_settings = {
-        "//command_line_option:swiftcopt": [
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [

--- a/test/split_derived_files_tests.bzl
+++ b/test/split_derived_files_tests.bzl
@@ -27,7 +27,7 @@ split_swiftmodule_provider_test = make_provider_test_rule(
 )
 split_swiftmodule_wmo_test = make_action_command_line_test_rule(
     config_settings = {
-        "//command_line_option:swiftcopt": [
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [
@@ -37,7 +37,7 @@ split_swiftmodule_wmo_test = make_action_command_line_test_rule(
 )
 split_swiftmodule_wmo_provider_test = make_provider_test_rule(
     config_settings = {
-        "//command_line_option:swiftcopt": [
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [
@@ -47,7 +47,7 @@ split_swiftmodule_wmo_provider_test = make_provider_test_rule(
 )
 split_swiftmodule_skip_function_bodies_test = make_action_command_line_test_rule(
     config_settings = {
-        "//command_line_option:swiftcopt": [
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [
@@ -74,7 +74,7 @@ split_swiftmodule_bitcode_test = make_action_command_line_test_rule(
 )
 split_swiftmodule_copts_test = make_action_command_line_test_rule(
     config_settings = {
-        "//command_line_option:swiftcopt": [
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-DHELLO",
         ],
         "//command_line_option:objccopt": [


### PR DESCRIPTION
The swift fragment was removed at bazel HEAD and replaced by our custom
starlark flag for copts in rules swift. This requires a version check
that we're relying on bazel_features for if we want to be 100% accurate.

Fixes https://github.com/bazelbuild/rules_swift/issues/1148
