### PR TITLE
Switch hasattr with our version check

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -295,7 +295,7 @@ def _swift_toolchain_impl(ctx):
         )
 
     # TODO: Remove once we drop bazel 7.x support
-    if hasattr(ctx.fragments, "swift"):
+    if bazel_features.cc.swift_fragment_removed:
         swiftcopts = list(ctx.fragments.swift.copts())
     else:
         swiftcopts = []

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -562,7 +562,7 @@ def _xcode_swift_toolchain_impl(ctx):
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
     # TODO: Remove once we drop bazel 7.x support
-    if hasattr(ctx.fragments, "swift"):
+    if bazel_features.cc.swift_fragment_removed:
         swiftcopts = list(ctx.fragments.swift.copts())
     else:
         swiftcopts = []


### PR DESCRIPTION
If you mix hasattr with version checks you get the wrong behavior on
old dev builds, because in the case of fragments when it was supported
`ctx.fragments.swift` always existed, you just couldn't access it
without declaring the dependency, so on old commit releases they are
treated as not having this feature, even when the fragment API is still
there.
