### PR TITLE
Add `swift_library_group` rule

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -27,6 +27,7 @@ _DOC_SRCS = {
         "swift_grpc_library",
         "swift_import",
         "swift_library",
+        "swift_library_group",
         "swift_module_alias",
         "swift_package_configuration",
         "swift_proto_library",

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -394,7 +394,11 @@ swift_library_group(<a href="#swift_library_group-name">name</a>, <a href="#swif
 </pre>
 
 Groups Swift compatible libraries (e.g. `swift_library` and `objc_library`).
-Can be used anywhere a `swift_library` can be used.
+The target can be used anywhere a `swift_library` can be used. It behaves
+similar to source-less `{cc,obj}_library` targets.
+
+Unlike `swift_module_alias`, a new module isn't created for this target, you
+need to import the grouped libraries directly.
 
 **ATTRIBUTES**
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -23,6 +23,7 @@ On this page:
   * [swift_grpc_library](#swift_grpc_library)
   * [swift_import](#swift_import)
   * [swift_library](#swift_library)
+  * [swift_library_group](#swift_library_group)
   * [swift_module_alias](#swift_module_alias)
   * [swift_package_configuration](#swift_package_configuration)
   * [swift_proto_library](#swift_proto_library)
@@ -382,6 +383,26 @@ Compiles and links Swift code into a static library and Swift module.
 | <a id="swift_library-plugins"></a>plugins |  A list of `swift_compiler_plugin` targets that should be loaded by the compiler when compiling this module and any modules that directly depend on it.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="swift_library-private_deps"></a>private_deps |  A list of targets that are implementation-only dependencies of the target being built. Libraries/linker flags from these dependencies will be propagated to dependent for linking, but artifacts/flags required for compilation (such as .swiftmodule files, C headers, and search paths) will not be propagated.<br><br>Allowed kinds of dependencies are:<br><br>*   `swift_c_module`, `swift_import` and `swift_library` (or anything     propagating `SwiftInfo`)<br><br>*   `cc_library` (or anything propagating `CcInfo`)<br><br>Additionally, on platforms that support Objective-C interop, `objc_library` targets (or anything propagating the `apple_common.Objc` provider) are allowed as dependencies. On platforms that do not support Objective-C interop (such as Linux), those dependencies will be **ignored.**   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="swift_library-swiftc_inputs"></a>swiftc_inputs |  Additional files that are referenced using `$(location ...)` in attributes that support location expansion.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+
+
+<a id="swift_library_group"></a>
+
+## swift_library_group
+
+<pre>
+swift_library_group(<a href="#swift_library_group-name">name</a>, <a href="#swift_library_group-deps">deps</a>)
+</pre>
+
+Groups Swift compatible libraries (e.g. `swift_library` and `objc_library`).
+Can be used anywhere a `swift_library` can be used.
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="swift_library_group-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="swift_library_group-deps"></a>deps |  A list of targets that should be included in the group.<br><br>Allowed kinds of dependencies are:<br><br>*   `swift_c_module`, `swift_import` and `swift_library` (or anything     propagating `SwiftInfo`)<br><br>*   `cc_library` (or anything propagating `CcInfo`)<br><br>Additionally, on platforms that support Objective-C interop, `objc_library` targets (or anything propagating the `apple_common.Objc` provider) are allowed as dependencies. On platforms that do not support Objective-C interop (such as Linux), those dependencies will be **ignored.**   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="swift_module_alias"></a>

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -57,6 +57,7 @@ bzl_library(
         "//swift/internal:swift_grpc_library",
         "//swift/internal:swift_import",
         "//swift/internal:swift_library",
+        "//swift/internal:swift_library_group",
         "//swift/internal:swift_module_alias",
         "//swift/internal:swift_package_configuration",
         "//swift/internal:swift_proto_library",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -246,6 +246,20 @@ bzl_library(
 )
 
 bzl_library(
+    name = "swift_library_group",
+    srcs = ["swift_library_group.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        ":attrs",
+        ":providers",
+        ":swift_clang_module_aspect",
+        ":swift_common",
+        ":utils",
+        "@bazel_skylib//lib:dicts",
+    ],
+)
+
+bzl_library(
     name = "swift_module_alias",
     srcs = ["swift_module_alias.bzl"],
     visibility = ["//swift:__subpackages__"],

--- a/swift/internal/swift_library_group.bzl
+++ b/swift/internal/swift_library_group.bzl
@@ -90,7 +90,11 @@ A list of targets that should be included in the group.
     ),
     doc = """\
 Groups Swift compatible libraries (e.g. `swift_library` and `objc_library`).
-Can be used anywhere a `swift_library` can be used.
+The target can be used anywhere a `swift_library` can be used. It behaves
+similar to source-less `{cc,obj}_library` targets.
+
+Unlike `swift_module_alias`, a new module isn't created for this target, you
+need to import the grouped libraries directly.
 """,
     implementation = _swift_library_group_impl,
 )

--- a/swift/internal/swift_library_group.bzl
+++ b/swift/internal/swift_library_group.bzl
@@ -1,0 +1,96 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `swift_library_group` rule."""
+
+load(":attrs.bzl", "swift_deps_attr", "swift_toolchain_attrs")
+load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
+load(":swift_common.bzl", "swift_common")
+load(":utils.bzl", "get_providers")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+
+def _swift_library_group_impl(ctx):
+    deps = ctx.attr.deps
+    deps_cc_infos = [
+        dep[CcInfo]
+        for dep in deps
+        if CcInfo in dep
+    ]
+    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+
+    return [
+        DefaultInfo(),
+        CcInfo(
+            compilation_context = cc_common.merge_cc_infos(
+                cc_infos = deps_cc_infos,
+            ).compilation_context,
+            linking_context = cc_common.merge_linking_contexts(
+                linking_contexts = [
+                    cc_info.linking_context
+                    for cc_info in (
+                        deps_cc_infos +
+                        swift_toolchain.implicit_deps_providers.cc_infos
+                    )
+                ] + [
+                    cc_common.create_linking_context(
+                        linker_inputs = depset(
+                            direct = [
+                                cc_common.create_linker_input(
+                                    owner = ctx.label,
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["deps"],
+        ),
+        swift_common.create_swift_info(
+            swift_infos = get_providers(deps, SwiftInfo),
+        ),
+        # Propagate an `apple_common.Objc` provider with linking info about the
+        # library so that linking with Apple Starlark APIs/rules works
+        # correctly.
+        # TODO(b/171413861): This can be removed when the Obj-C rules are
+        # migrated to use `CcLinkingContext`.
+        apple_common.new_objc_provider(
+            providers = get_providers(
+                deps,
+                apple_common.Objc,
+            ) + swift_toolchain.implicit_deps_providers.objc_infos,
+        ),
+    ]
+
+swift_library_group = rule(
+    attrs = dicts.add(
+        swift_toolchain_attrs(),
+        {
+            "deps": swift_deps_attr(
+                aspects = [swift_clang_module_aspect],
+                doc = """\
+A list of targets that should be included in the group.
+""",
+            ),
+        },
+    ),
+    doc = """\
+Groups Swift compatible libraries (e.g. `swift_library` and `objc_library`).
+Can be used anywhere a `swift_library` can be used.
+""",
+    implementation = _swift_library_group_impl,
+)

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -74,6 +74,10 @@ load(
     _swift_library = "swift_library",
 )
 load(
+    "@build_bazel_rules_swift//swift/internal:swift_library_group.bzl",
+    _swift_library_group = "swift_library_group",
+)
+load(
     "@build_bazel_rules_swift//swift/internal:swift_module_alias.bzl",
     _swift_module_alias = "swift_module_alias",
 )
@@ -109,6 +113,7 @@ swift_feature_allowlist = _swift_feature_allowlist
 swift_grpc_library = _swift_grpc_library
 swift_import = _swift_import
 swift_library = _swift_library
+swift_library_group = _swift_library_group
 swift_module_alias = _swift_module_alias
 swift_package_configuration = _swift_package_configuration
 swift_proto_library = _swift_proto_library

--- a/test/fixtures/basic/BUILD
+++ b/test/fixtures/basic/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_library")
+load("//swift:swift.bzl", "swift_library", "swift_library_group")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(
@@ -14,10 +14,16 @@ swift_library(
     tags = FIXTURE_TAGS,
 )
 
+swift_library_group(
+    name = "library_group",
+    tags = FIXTURE_TAGS,
+    deps = ["first"],
+)
+
 swift_library(
     name = "second",
     srcs = ["second.swift"],
     module_name = "second",
     tags = FIXTURE_TAGS,
-    deps = ["first"],
+    deps = ["library_group"],
 )


### PR DESCRIPTION
The `swift_library_group` rule acts as an alias for multiple other `{cc,objc,swift}_library`s. This will allow rules_swift_package_manager to properly map SPM’s library products to a target that can be added to other target’s `deps`.