### PR TITLE
Enable support for clang modules from cc_proto_library targets

### DIFF
--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -403,7 +403,7 @@ def _module_info_for_target(
     module_map_file = None
 
     # TODO: Remove once we cherry-pick the `swift_interop_hint` rule
-    if not module_name and aspect_ctx.rule.kind == "cc_library":
+    if not module_name and (aspect_ctx.rule.kind == "cc_library" or aspect_ctx.rule.kind == "cc_proto_library"):
         # For all other targets, there is no mechanism to provide a custom
         # module map, and we only generate one if the target is tagged.
         module_name = _tagged_target_module_name(


### PR DESCRIPTION
Right now the clang module aspect hardcodes the "cc_library" rule kind, meaning it does not work with "cc_proto_library" targets. I'm interested in using Swift / C++ interop to share protos with our xplat C++ layer. Ideally this shouldn't hardcode any rule kinds, but at least for now this will unblock us.