### PR TITLE
Repro changes for Swift/Objc Interop

### DIFF
--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -14,6 +14,7 @@ objc_library(
     name = "PrintStream",
     srcs = ["OIPrintStream.m"],
     hdrs = ["OIPrintStream.h"],
+    copts = ["-fmodules"],
     target_compatible_with = ["@platforms//os:macos"],
 )
 
@@ -22,12 +23,20 @@ swift_library(
     srcs = ["Printer.swift"],
     generated_header_name = "generated_header/Printer-Swift.h",
     generates_header = True,
-    deps = [":PrintStream"],
+    deps = [":PrintStream", ":Renderer"],
+)
+
+swift_library(
+    name = "Renderer",
+    srcs = ["Renderer.swift"],
+    deps = [],
+    module_name = "Renderer",
 )
 
 objc_library(
     name = "main",
     srcs = ["main.m"],
+    copts = ["-fmodules"],
     target_compatible_with = ["@platforms//os:macos"],
     deps = [":Printer"],
 )

--- a/examples/apple/objc_interop/Renderer.swift
+++ b/examples/apple/objc_interop/Renderer.swift
@@ -13,33 +13,24 @@
 // limitations under the License.
 
 import Foundation
-import examples_apple_objc_interop_PrintStream
-import Renderer
 
-@objc(OIPrinter)
-public class Printer: NSObject {
+@objc(SnapRenderer)
+public class Renderer: NSObject {
 
-  private let stream: OIPrintStream
   private let prefix: String
-  private let renderer: Renderer
 
   @objc public init(prefix: NSString) {
-    self.stream = OIPrintStream(fileHandle: .standardOutput)
     self.prefix = prefix as String
-    self.renderer = Renderer(prefix:prefix)
   }
 
-  @objc public func print(_ message: NSString) {
-    stream.print("\(prefix)\(message)")
+  @objc public func printHaHa(_ message: NSString) {
+    print("\(prefix)\(message)")
   }
 
-  @objc public func print2(_ message: NSString, renderer: Renderer) {
-    stream.print("\(prefix)\(message)")
-  }
 }
 
-extension Printer: RenderProtocol { 
-  public func render(_ name: String) {
-    stream.print(name)
-  }
+@objc(SnapRenderProtocol)
+public protocol RenderProtocol: NSObjectProtocol {
+
+    func render(_ name: String)
 }


### PR DESCRIPTION
This PR contains changes that reproduce the Swift Objc interop issue we observe in our codebase. I was able to make a repro within rules_swift example directory. 

Notes : 
 - We pass "-fmodules" copt to all `objc_library` targets in our codebase. 
 - I added a `Renderer` (`swift_library`) which defines a public protocol that conforms to `NSObjectProtocol` 
 - Imported `Renderer` from existing swift_library `Printer`. 
 - Ran command to build `main.m` : `bazelisk build examples/apple/objc_interop:main -s --disk_cache=""`

Expected outcome : 
Compilation succeeds 

Actual outcome : 
Compilation failure 
```
ERROR: /Users/ycho/Snapchat/Dev/rules_swift/examples/apple/objc_interop/BUILD:36:13: Compiling examples/apple/objc_interop/main.m failed: (Exit 1): wrapped_clang failed: error executing ObjcCompile command (from target //examples/apple/objc_interop:main) external/apple_support~1.13.0~apple_cc_configure_extension~local_config_apple_cc/wrapped_clang -target arm64-apple-macosx13.0 '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall ... (remaining 44 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from examples/apple/objc_interop/main.m:20:
bazel-out/darwin_arm64-fastbuild/bin/examples/apple/objc_interop/generated_header/Printer-Swift.h:279:9: fatal error: module 'Renderer' not found
@import Renderer;
 ~~~~~~~^~~~~~~~
1 error generated.
```

If I remove `-fmodules` copt from objc_library, I get the following error : 
```
ERROR: /Users/ycho/Snapchat/Dev/rules_swift/examples/apple/objc_interop/BUILD:36:13: Compiling examples/apple/objc_interop/main.m failed: (Exit 1): wrapped_clang failed: error executing ObjcCompile command (from target //examples/apple/objc_interop:main) external/apple_support~1.13.0~apple_cc_configure_extension~local_config_apple_cc/wrapped_clang -target arm64-apple-macosx13.0 '-D_FORTIFY_SOURCE=1' -fstack-protector -fcolor-diagnostics -Wall ... (remaining 42 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from examples/apple/objc_interop/main.m:20:
bazel-out/darwin_arm64-fastbuild/bin/examples/apple/objc_interop/generated_header/Printer-Swift.h:313:78: error: cannot find protocol declaration for 'SnapRenderProtocol'
@interface OIPrinter (SWIFT_EXTENSION(examples_apple_objc_interop_Printer)) <SnapRenderProtocol>
                                                                             ^
1 error generated.
```



