### PR TITLE
Fix docs build for proto compiler

### DIFF
--- a/proto/compilers/BUILD
+++ b/proto/compilers/BUILD
@@ -51,7 +51,7 @@ bzl_library(
     srcs = ["swift_proto_compiler_macros.bzl"],
     visibility = ["//visibility:public"],
     deps = [
-        "//swift/proto:swift_proto_compiler",
+        "//proto:swift_proto_compiler",
         "@bazel_skylib//lib:dicts",
     ],
 )


### PR DESCRIPTION
This was causing `bazel test //...` to fail since `//swift/proto` is not a package