### PR TITLE
Replace instances of to_json() method with json.encode(..)

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -3250,13 +3250,13 @@ def _declare_multiple_outputs_and_write_output_file_map(
         output_map[src.path] = struct(**src_output_map)
 
     actions.write(
-        content = struct(**output_map).to_json(),
+        content = json.encode(struct(**output_map)),
         output = output_map_file,
     )
 
     if split_derived_file_generation:
         actions.write(
-            content = struct(**derived_files_output_map).to_json(),
+            content = json.encode(struct(**derived_files_output_map)),
             output = derived_files_output_map_file,
         )
 

--- a/swift/internal/vfsoverlay.bzl
+++ b/swift/internal/vfsoverlay.bzl
@@ -56,7 +56,7 @@ def write_vfsoverlay(
 
     # The YAML specification defines it has a superset of JSON, so it is safe to
     # use the built-in `to_json` function here.
-    vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
+    vfsoverlay_yaml = json.encode(struct(**vfsoverlay_object))
 
     actions.write(
         content = vfsoverlay_yaml,


### PR DESCRIPTION
The to_json and to_proto methods on struct are deprecated and will be
removed. The "json" and "proto" builtin modules should be used instead.

This replaces instances of `foo.to_json()` with `json.encode(foo)`.