### PR TITLE
Disable deprecated gRPC build target on BCR

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -24,6 +24,7 @@ tasks:
     - "--action_env=PATH"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
+    - "-@rules_swift//examples/xplatform/deprecated_grpc/..." # TODO: Fix grpc on Linux
     - "-@rules_swift//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
   verify_targets_macos:
     name: Verify build targets


### PR DESCRIPTION
Similar to:

https://github.com/bazelbuild/rules_swift/blob/a20c38808cb7f1ac721bb5131c81e64f654e7536/.bcr/presubmit.yml#L27

This disables the `@rules_swift//examples/xplatform/deprecated_grpc/…` targets that were previously under the `@rules_swift//examples/xplatform/grpc/…` package to match the previous state on the BCR Linux machines.