### PR TITLE
Remove unnecessary uses of `ctx.resolve_tools`.

### DIFF
--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -246,6 +246,9 @@ def run_toolchain_action(
     else:
         executable = tool_config.executable
 
+    if tool_config.tools:
+        tools.extend(tool_config.tools)
+
     # If the tool configuration has any required arguments, add those first.
     if tool_config.args:
         args.add_all(tool_config.args)
@@ -266,13 +269,12 @@ def run_toolchain_action(
         env = tool_config.env,
         executable = executable,
         execution_requirements = execution_requirements,
-        input_manifests = tool_config.tool_input_manifests,
         inputs = depset(
             action_inputs.inputs,
             transitive = action_inputs.transitive_inputs,
         ),
         mnemonic = mnemonic if mnemonic else action_name,
-        tools = depset(tools, transitive = [tool_config.tool_inputs]),
+        tools = tools,
         use_default_shell_env = USE_DEFAULT_SHELL_ENV,
         **kwargs
     )

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -82,7 +82,8 @@ def _all_tool_configs(
             flags.
         use_module_wrap: If True, the compile action should embed the
             swiftmodule into the final image.
-        additional_tools: Any extra tool inputs to pass to each driver config
+        additional_tools: A list of extra tools to pass to each driver config,
+            in a format suitable for the `tools` argument to `ctx.actions.run`.
         tool_executable_suffix: The suffix for executable tools to use (e.g.
             `.exe` on Windows).
 
@@ -91,12 +92,10 @@ def _all_tool_configs(
     """
     _swift_driver_tool_config = swift_toolchain_config.driver_tool_config
 
-    tool_inputs = depset(additional_tools)
-
     compile_tool_config = _swift_driver_tool_config(
         driver_mode = "swiftc",
         swift_executable = swift_executable,
-        tool_inputs = tool_inputs,
+        tools = additional_tools,
         toolchain_root = toolchain_root,
         tool_executable_suffix = tool_executable_suffix,
         use_param_file = use_param_file,
@@ -114,7 +113,7 @@ def _all_tool_configs(
         configs[swift_action_names.AUTOLINK_EXTRACT] = _swift_driver_tool_config(
             driver_mode = "swift-autolink-extract",
             swift_executable = swift_executable,
-            tool_inputs = tool_inputs,
+            tools = additional_tools,
             toolchain_root = toolchain_root,
             tool_executable_suffix = tool_executable_suffix,
             worker_mode = "wrap",
@@ -126,7 +125,7 @@ def _all_tool_configs(
             args = ["-modulewrap"],
             driver_mode = "swift",
             swift_executable = swift_executable,
-            tool_inputs = tool_inputs,
+            tools = additional_tools,
             toolchain_root = toolchain_root,
             tool_executable_suffix = tool_executable_suffix,
             worker_mode = "wrap",

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -43,8 +43,7 @@ _ToolConfigInfo = provider(
         "env",
         "executable",
         "execution_requirements",
-        "tool_input_manifests",
-        "tool_inputs",
+        "tools",
         "use_param_file",
         "worker_mode",
     ],
@@ -300,8 +299,7 @@ def _tool_config(
         args = [],
         env = {},
         execution_requirements = {},
-        tool_input_manifests = [],
-        tool_inputs = depset(),
+        tools = [],
         use_param_file = False,
         worker_mode = None):
     """Returns a new Swift toolchain tool configuration.
@@ -316,14 +314,8 @@ def _tool_config(
             invoking actions using this tool.
         execution_requirements: A dictionary of execution requirements that
             should be passed when creating actions with this tool.
-        tool_input_manifests: A list of input runfiles metadata for tools that
-            should be passed into the `input_manifests` argument of the
-            `ctx.actions.run` call that registers actions using this tool (see
-            also Bazel's `ctx.resolve_tools`).
-        tool_inputs: A `depset` of additional inputs for tools that should be
-            passed into the `tools` argument of the `ctx.actions.run` call that
-            registers actions using this tool (see also Bazel's
-            `ctx.resolve_tools`).
+        tools: A list of additional tools to pass to spawned actions, in a
+            format suitable for the `tools` argument to `ctx.actions.run`.
         use_param_file: If True, actions invoked using this tool will have their
             arguments written to a param file.
         worker_mode: A string, or `None`, describing how the tool is invoked
@@ -343,8 +335,7 @@ def _tool_config(
         env = env,
         executable = executable,
         execution_requirements = execution_requirements,
-        tool_input_manifests = tool_input_manifests,
-        tool_inputs = tool_inputs,
+        tools = tools,
         use_param_file = use_param_file,
         worker_mode = _validate_worker_mode(worker_mode),
     )

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -356,44 +356,6 @@ def owner_relative_path(file):
     else:
         return paths.relativize(file.short_path, package)
 
-def resolve_optional_tool(ctx, *, target):
-    """Resolves a tool and returns a `struct` describing its inputs.
-
-    This function uses `ctx.resolve_tools` which allows an executable and any of
-    its required runfiles to be propagated correctly across the target boundary.
-
-    Args:
-        ctx: The rule or aspect context.
-        target: The `Target` representing the tool whose inputs should be
-            resolved. This may be `None`, in which case the returned `struct`
-            will be valid but its fields will be appropriately empty.
-
-    Returns:
-        A `struct` containing three fields:
-
-        *   `executable`: The `File` representing the tool's executable (or
-            `None` if `target` was `None`).
-        *   `input_manifests`: A list of input manifests that should be passed
-            as `tool_input_manifests` when configuring the tool in the
-            toolchain (or the empty list if `target` was `None`.)
-        *   `inputs`: A `depset` of `File`s that should be passed as
-            `tool_inputs` when configuring the tool in the toolchain (or the
-            empty `depset` if `target` was `None`.)
-    """
-    if target:
-        executable = target[DefaultInfo].files_to_run.executable
-        inputs, input_manifests = ctx.resolve_tools(tools = [target])
-    else:
-        executable = None
-        input_manifests = []
-        inputs = depset()
-
-    return struct(
-        executable = executable,
-        input_manifests = input_manifests,
-        inputs = inputs,
-    )
-
 def struct_fields(s):
     """Returns a dictionary containing the fields in the struct `s`.
 


### PR DESCRIPTION
We'd like to retire this API, which is redundant with the `executable` and `tools` arguments to `ctx.actions.run|run_shell`.