### PR TITLE
Disable Swift compiler sandboxing in Xcode 15.3+ to fix nested sandboxing

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -83,6 +83,7 @@ load(
     "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
+    "SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
@@ -562,6 +563,19 @@ def compile_action_configs(
                 swift_toolchain_config.add_arg("-warnings-as-errors"),
             ],
             features = [SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS],
+        ),
+
+        # Disable Swift sandbox.
+        swift_toolchain_config.action_config(
+            actions = [
+                swift_action_names.COMPILE,
+                swift_action_names.DERIVE_FILES,
+                swift_action_names.DUMP_AST,
+            ],
+            configurators = [
+                swift_toolchain_config.add_arg("-disable-sandbox"),
+            ],
+            features = [SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX],
         ),
 
         # Set Developer Framework search paths

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -45,6 +45,7 @@ load(
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
+    "SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE_DISABLE_SYSTEM_INDEX",
     "SWIFT_FEATURE_EMIT_BC",
     "SWIFT_FEATURE_EMIT_C_MODULE",
@@ -83,7 +84,6 @@ load(
     "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
-    "SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
@@ -575,7 +575,7 @@ def compile_action_configs(
             configurators = [
                 swift_toolchain_config.add_arg("-disable-sandbox"),
             ],
-            features = [SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX],
+            features = [SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX],
         ),
 
         # Set Developer Framework search paths

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -341,6 +341,10 @@ SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE = "swift._force_alwayslink_true"
 # feature.
 SWIFT_FEATURE__SUPPORTS_MACROS = "swift._supports_macros"
 
+# Disables Swift sandbox which prevents issues with nested sandboxing when Swift code contains system-provided macros.
+# If enabled '#Preview' macro provided by SwiftUI fails to build and probably other system-provided macros.
+SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX = "swift._disable_swift_sandbox"
+
 # Pass -warnings-as-errors to the compiler.
 SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS = "swift.treat_warnings_as_errors"
 

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -343,6 +343,7 @@ SWIFT_FEATURE__SUPPORTS_MACROS = "swift._supports_macros"
 
 # Disables Swift sandbox which prevents issues with nested sandboxing when Swift code contains system-provided macros.
 # If enabled '#Preview' macro provided by SwiftUI fails to build and probably other system-provided macros.
+# Enabled by default for Swift 5.10+ on macOS.
 SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX = "swift._disable_swift_sandbox"
 
 # Pass -warnings-as-errors to the compiler.

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -344,7 +344,7 @@ SWIFT_FEATURE__SUPPORTS_MACROS = "swift._supports_macros"
 # Disables Swift sandbox which prevents issues with nested sandboxing when Swift code contains system-provided macros.
 # If enabled '#Preview' macro provided by SwiftUI fails to build and probably other system-provided macros.
 # Enabled by default for Swift 5.10+ on macOS.
-SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX = "swift._disable_swift_sandbox"
+SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX = "swift.disable_swift_sandbox"
 
 # Pass -warnings-as-errors to the compiler.
 SWIFT_FEATURE_TREAT_WARNINGS_AS_ERRORS = "swift.treat_warnings_as_errors"

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -50,6 +50,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
+    "SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
     "SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
@@ -639,6 +640,9 @@ def _xcode_swift_toolchain_impl(ctx):
     if _is_xcode_at_least_version(xcode_config, "15.0"):
         requested_features.append(SWIFT_FEATURE__SUPPORTS_MACROS)
         requested_features.append(SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION)
+
+    if _is_xcode_at_least_version(xcode_config, "15.3"):
+        requested_features.append(SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX)
 
     env = _xcode_env(target_triple = target_triple, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -35,6 +35,7 @@ load(
     "SWIFT_FEATURE_COVERAGE",
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
+    "SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE_EMIT_SWIFTDOC",
     "SWIFT_FEATURE_EMIT_SWIFTSOURCEINFO",
     "SWIFT_FEATURE_ENABLE_BATCH_MODE",
@@ -50,7 +51,6 @@ load(
     "SWIFT_FEATURE_SUPPORTS_SYSTEM_MODULE_FLAG",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_USE_RESPONSE_FILES",
-    "SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
     "SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
@@ -642,7 +642,7 @@ def _xcode_swift_toolchain_impl(ctx):
         requested_features.append(SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION)
 
     if _is_xcode_at_least_version(xcode_config, "15.3"):
-        requested_features.append(SWIFT_FEATURE__DISABLE_SWIFT_SANDBOX)
+        requested_features.append(SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX)
 
     env = _xcode_env(target_triple = target_triple, xcode_config = xcode_config)
     execution_requirements = xcode_config.execution_info()

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -60,6 +60,14 @@ use_global_index_store_index_while_building_test = make_action_command_line_test
     },
 )
 
+disable_swift_sandbox_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.disable_swift_sandbox",
+        ],
+    },
+)
+
 vfsoverlay_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
@@ -173,6 +181,17 @@ def features_test_suite(name):
         tags = [name],
         expected_argv = [
             "-Xwrapped-swift=-global-index-store-import-path=bazel-out/_global_index_store",
+        ],
+        mnemonic = "SwiftCompile",
+        target_compatible_with = ["@platforms//os:macos"],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    disable_swift_sandbox_test(
+        name = "{}_disable_swift_sandbox_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-disable-sandbox",
         ],
         mnemonic = "SwiftCompile",
         target_compatible_with = ["@platforms//os:macos"],


### PR DESCRIPTION
This should solve https://github.com/bazelbuild/rules_swift/issues/1202
 and #1204

> There were issues with Swift compiler plugins (incl. macros) and nested sandboxes on macOS with Swift 5.9 that have been fixed with 5.10:
> swift: [apple/swift#70079](https://github.com/apple/swift/pull/70079)
> swift-driver: [apple/swift-driver#1493](https://github.com/apple/swift-driver/pull/1493)
> swift-package-manager: [apple/swift-package-manager#7167](https://github.com/apple/swift-package-manager/pull/7167)


I am not sure whether this flag is required on Linux too.