### PR TITLE
Infer emit-bc feature if -lto is passed

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -132,6 +132,13 @@ _WMO_FLAGS = {
     "-wmo": True,
 }
 
+# Swift command line flags that enable LTO. (This
+# dictionary is used as a set for quick lookup; the values are irrelevant.)
+_LTO_FLAGS = {
+    "-lto=llvm-thin": True,
+    "-lto=llvm-full": True,
+}
+
 def compile_action_configs(
         *,
         os = None,
@@ -1909,6 +1916,20 @@ def _is_wmo_manually_requested(user_compile_flags):
             return True
     return False
 
+def _is_LTO_requested(user_compile_flags):
+    """Returns `True` if a LTO flag is in the given list of compiler flags.
+
+    Args:
+        user_compile_flags: A list of compiler flags to scan for LTO usage.
+
+    Returns:
+        True if LTO is enabled in the given list of flags.
+    """
+    for copt in user_compile_flags:
+        if copt in _LTO_FLAGS:
+            return True
+    return False
+
 def features_from_swiftcopts(swiftcopts):
     """Returns a list of features to enable based on `--swiftcopt` flags.
 
@@ -1931,6 +1952,9 @@ def features_from_swiftcopts(swiftcopts):
         features.append(SWIFT_FEATURE__WMO_IN_SWIFTCOPTS)
     if _find_num_threads_flag_value(user_compile_flags = swiftcopts) == 0:
         features.append(SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS)
+    if _is_LTO_requested(user_compile_flags = swiftcopts):
+        features.append(SWIFT_FEATURE_EMIT_BC)
+
     return features
 
 def _index_while_building_configurator(prerequisites, args):

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -71,6 +71,14 @@ output_file_map_embed_target_name_bitcode_wmo_test = make_output_file_map_test_r
     },
 )
 
+output_file_map_lto_test = make_output_file_map_test_rule(
+    config_settings = {
+        str(Label("@build_bazel_rules_swift//swift:copt")): [
+            "-lto=llvm-thin",
+        ],
+    },
+)
+
 def output_file_map_test_suite(name):
     """Test suite for `swift_library` generating output file maps.
 
@@ -143,6 +151,17 @@ def output_file_map_test_suite(name):
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_lto_test(
+        name = "{}_lto".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
When passing `-lto=llvm-thin` or `-lto=llvm-full` to swiftc, it switches from emitting object files to bitcode files.
To include `llvm-bc` instead of `object` in the generated output-file-map, the feature `SWIFT_FEATURE_EMIT_BC` (`swift.emit_bc`) must be inferred. 
This PR implements this similar to `SWIFT_FEATURE__WMO_IN_SWIFTCOPTS`.