### PR TITLE
Add features to enable LTO

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -262,11 +262,7 @@ def compile_action_configs(
             configurators = [
                 swift_toolchain_config.add_arg("-emit-bc"),
             ],
-            features = [
-                [SWIFT_FEATURE_EMIT_BC],
-                [SWIFT_FEATURE_FULL_LTO],
-                [SWIFT_FEATURE_THIN_LTO],
-            ],
+            features = [SWIFT_FEATURE_EMIT_BC],
         ),
 
         # Add the single object file or object file map, whichever is needed.
@@ -414,7 +410,6 @@ def compile_action_configs(
                 swift_toolchain_config.add_arg("-lto=llvm-thin"),
             ],
             features = [SWIFT_FEATURE_THIN_LTO],
-            not_features = [SWIFT_FEATURE_FULL_LTO],
         ),
         swift_toolchain_config.action_config(
             actions = [swift_action_names.COMPILE],
@@ -422,7 +417,6 @@ def compile_action_configs(
                 swift_toolchain_config.add_arg("-lto=llvm-full"),
             ],
             features = [SWIFT_FEATURE_FULL_LTO],
-            not_features = [SWIFT_FEATURE_THIN_LTO],
         ),
     ]
 

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -367,3 +367,9 @@ SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT = "swift.add_target_name_to_output"
 # extraction (Swift 5.8 and above). Users should never manually enable, disable, or query this
 # feature.
 SWIFT_FEATURE__SUPPORTS_CONST_VALUE_EXTRACTION = "swift._supports_const_value_extraction"
+
+# Enable thin LTO and update output-file-map correctly
+SWIFT_FEATURE_THIN_LTO = "swift.thin_lto"
+
+# Enable full LTO and update output-file-map correctly
+SWIFT_FEATURE_FULL_LTO = "swift.full_lto"

--- a/test/compiler_arguments_tests.bzl
+++ b/test/compiler_arguments_tests.bzl
@@ -14,6 +14,22 @@ split_test = make_action_command_line_test_rule(
     },
 )
 
+thin_lto_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.thin_lto",
+        ],
+    },
+)
+
+full_lto_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.full_lto",
+        ],
+    },
+)
+
 def compiler_arguments_test_suite(name):
     """Test suite for various command line flags passed to Swift compiles.
 
@@ -67,6 +83,22 @@ def compiler_arguments_test_suite(name):
         mnemonic = "SwiftDeriveFiles",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:lib_package_name",
+    )
+
+    thin_lto_test(
+        name = "{}_thin_lto".format(name),
+        expected_argv = ["-lto=llvm-thin"],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",
+    )
+
+    full_lto_test(
+        name = "{}_full_lto".format(name),
+        expected_argv = ["-lto=llvm-full"],
+        mnemonic = "SwiftCompile",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",
     )
 
     native.test_suite(

--- a/test/fixtures/compiler_arguments/BUILD
+++ b/test/fixtures/compiler_arguments/BUILD
@@ -34,3 +34,9 @@ swift_test(
     srcs = ["empty.swift"],
     tags = FIXTURE_TAGS,
 )
+
+swift_binary(
+    name = "bin",
+    srcs = ["empty.swift"],
+    tags = FIXTURE_TAGS,
+)

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -71,6 +71,22 @@ output_file_map_embed_target_name_bitcode_wmo_test = make_output_file_map_test_r
     },
 )
 
+output_file_map_thin_lto_test = make_output_file_map_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.thin_lto",
+        ],
+    },
+)
+
+output_file_map_full_lto_test = make_output_file_map_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.full_lto",
+        ],
+    },
+)
+
 def output_file_map_test_suite(name):
     """Test suite for `swift_library` generating output file maps.
 
@@ -143,6 +159,28 @@ def output_file_map_test_suite(name):
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_thin_lto_test(
+        name = "{}_thin_lto".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_full_lto_test(
+        name = "{}_full_lto".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
Add features to enable LTO (thin and full).
When passing `-lto=`, `swiftc` switches to emit bc files and the generated output-file-map must contain a mapping for `llvm-bc` instead of `object`.