### PR TITLE
Fix `file_prefix_pwd_is_dot_` default value

### DIFF
--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -110,7 +110,8 @@ SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
     : job_env_(GetCurrentEnvironment()),
       index_import_path_(index_import_path),
       force_response_file_(force_response_file),
-      is_dump_ast_(false) {
+      is_dump_ast_(false),
+      file_prefix_pwd_is_dot_(false) {
   args_ = ProcessArguments(args);
 }
 


### PR DESCRIPTION
This value can be assigned non-zero memory if not initialied with `false`.

I noticed when building with `file_prefix_map` feature disabled that the codepath checking for `true` was still getting hit causing global index store paths to be wrong.