### PR TITLE
Add feature to propagate the generated module map

### DIFF
--- a/examples/apple/objc_interop_modulemap/BUILD
+++ b/examples/apple/objc_interop_modulemap/BUILD
@@ -1,0 +1,40 @@
+# This example tests that Swift code can be called from Objective-C code and
+# vice versa when it is linked into the existing native linking rules for Apple
+# platforms.
+
+load(
+    "//swift:swift.bzl",
+    "swift_binary",
+    "swift_library",
+)
+
+licenses(["notice"])
+
+objc_library(
+    name = "PrintStream",
+    srcs = ["OIPrintStream.m"],
+    hdrs = ["OIPrintStream.h"],
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+swift_library(
+    name = "Printer",
+    srcs = ["Printer.swift"],
+    features = ["swift.propagate_generated_module_map"],
+    generated_header_name = "generated_header/Printer-Swift.h",
+    generates_header = True,
+    deps = [":PrintStream"],
+)
+
+objc_library(
+    name = "main",
+    srcs = ["main.m"],
+    enable_modules = True,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [":Printer"],
+)
+
+swift_binary(
+    name = "objc_interop_modulemap",
+    deps = [":main"],
+)

--- a/examples/apple/objc_interop_modulemap/OIPrintStream.h
+++ b/examples/apple/objc_interop_modulemap/OIPrintStream.h
@@ -1,0 +1,24 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+/** A very contrived interface for writing strings to a file handle. */
+@interface OIPrintStream : NSObject
+
+- (nonnull instancetype)initWithFileHandle:(nonnull NSFileHandle *)fileHandle;
+
+- (void)printString:(nonnull NSString *)message;
+
+@end

--- a/examples/apple/objc_interop_modulemap/OIPrintStream.m
+++ b/examples/apple/objc_interop_modulemap/OIPrintStream.m
@@ -1,0 +1,35 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "examples/apple/objc_interop_modulemap/OIPrintStream.h"
+
+@implementation OIPrintStream {
+  NSFileHandle *_fileHandle;
+}
+
+- (instancetype)initWithFileHandle:(nonnull NSFileHandle *)fileHandle {
+  if (self = [super init]) {
+    _fileHandle = fileHandle;
+  }
+  return self;
+}
+
+- (void)printString:(nonnull NSString *)message {
+  NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
+  [_fileHandle writeData:data];
+  NSData *newline = [NSData dataWithBytes:"\n" length:1];
+  [_fileHandle writeData:newline];
+}
+
+@end

--- a/examples/apple/objc_interop_modulemap/Printer.swift
+++ b/examples/apple/objc_interop_modulemap/Printer.swift
@@ -1,0 +1,32 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import examples_apple_objc_interop_modulemap_PrintStream
+
+@objc(OIPrinter)
+public class Printer: NSObject {
+
+  private let stream: OIPrintStream
+  private let prefix: String
+
+  @objc public init(prefix: NSString) {
+    self.stream = OIPrintStream(fileHandle: .standardOutput)
+    self.prefix = prefix as String
+  }
+
+  @objc public func print(_ message: NSString) {
+    stream.print("\(prefix)\(message)")
+  }
+}

--- a/examples/apple/objc_interop_modulemap/main.m
+++ b/examples/apple/objc_interop_modulemap/main.m
@@ -1,0 +1,23 @@
+// Copyright 2018 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import examples_apple_objc_interop_modulemap_Printer;
+
+int main(int argc, char **argv) {
+  @autoreleasepool {
+    OIPrinter *printer = [[OIPrinter alloc] initWithPrefix:@"*** "];
+    [printer print:@"Hello world"];
+  }
+  return 0;
+}

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -194,7 +194,7 @@ def _intermediate_object_file(actions, add_target_name_to_output_path, target_na
         paths.join(dirname, "{}.o".format(basename)),
     )
 
-def _module_map(actions, add_target_name_to_output_path, target_name):
+def _module_map(actions, target_name):
     """Declares the module map for a target.
 
     These module maps are used when generating a Swift-compatible module map for
@@ -203,17 +203,16 @@ def _module_map(actions, add_target_name_to_output_path, target_name):
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swift.modulemap".format(target_name),
+
+    # Path is two directories deep to avoid automatic discovery by
+    # `-fimplicit-module-maps` and with non-related include paths
+    return actions.declare_file(
+        "{}_modulemap/_/module.modulemap".format(target_name),
     )
 
 def _modulewrap_object(actions, add_target_name_to_output_path, target_name):

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -142,6 +142,11 @@ SWIFT_FEATURE_NO_ASAN_VERSION_CHECK = "swift.no_asan_version_check"
 # the target is not generating a header.
 SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
 
+# If enabled, the parent directory of the generated module map is added to
+# `CcInfo.compilation_context.includes`. This allows `objc_library` to import
+# the Swift module.
+SWIFT_FEATURE_PROPAGATE_GENERATED_MODULE_MAP = "swift.propagate_generated_module_map"
+
 # If enabled, builds using the "opt" compilation mode will invoke `swiftc` with
 # the `-whole-module-optimization` flag (in addition to `-O`).
 SWIFT_FEATURE_OPT_USES_WMO = "swift.opt_uses_wmo"

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -20,7 +20,6 @@ load(":compiling.bzl", "derive_module_name", "precompile_clang_module")
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
@@ -283,11 +282,6 @@ def _generate_module_map(
     else:
         private_headers = compilation_context.direct_private_headers
 
-    add_target_name_to_output_path = is_feature_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-    )
-
     # Sort dependent module names and the headers to ensure a deterministic
     # order in the output file, in the event the compilation context would ever
     # change this on us. For files, use the execution path as the sorting key.
@@ -317,7 +311,6 @@ def _generate_module_map(
 
     module_map_file = derived_files.module_map(
         actions = actions,
-        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = target.label.name,
     )
 

--- a/test/interop_hints_tests.bzl
+++ b/test/interop_hints_tests.bzl
@@ -36,7 +36,7 @@ def interop_hints_test_suite(name = "interop_hints"):
     provider_test(
         name = "{}_hint_with_custom_module_name_builds".format(name),
         expected_files = [
-            "test/fixtures/interop_hints/cc_lib_custom_module_name.swift.modulemap",
+            "test/fixtures/interop_hints/cc_lib_custom_module_name_modulemap/_/module.modulemap",
         ],
         field = "transitive_modules.clang.module_map!",
         provider = "SwiftInfo",

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -104,8 +104,8 @@ def private_deps_test_suite(name):
     private_deps_provider_test(
         name = "{}_client_cc_deps_modulemaps".format(name),
         expected_files = [
-            "/test/fixtures/private_deps/public_cc.swift.modulemap",
-            "-/test/fixtures/private_deps/private_cc.swift.modulemap",
+            "/test/fixtures/private_deps/public_cc_modulemap/_/module.modulemap",
+            "-/test/fixtures/private_deps/private_cc_modulemap_/module.modulemap",
         ],
         field = "transitive_modules.clang!.module_map!",
         provider = "SwiftInfo",
@@ -116,8 +116,8 @@ def private_deps_test_suite(name):
     private_deps_provider_target_name_test(
         name = "{}_client_cc_deps_modulemaps_target_name".format(name),
         expected_files = [
-            "/test/fixtures/private_deps/public_cc/public_cc.swift.modulemap",
-            "-/test/fixtures/private_deps/public_cc/private_cc.swift.modulemap",
+            "/test/fixtures/private_deps/public_cc_modulemap/_/module.modulemap",
+            "-/test/fixtures/private_deps/private_cc_modulemap/_/module.modulemap",
         ],
         field = "transitive_modules.clang!.module_map!",
         provider = "SwiftInfo",


### PR DESCRIPTION
Allows `objc_library` to modularly import `swift_library` targets without having to generate a similar module map.