### PR TITLE
Bump `module.compatibility_level`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "rules_swift",
     version = "0",
     bazel_compatibility = [">=6.0.0"],
-    compatibility_level = 1,
+    compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )
 


### PR DESCRIPTION
rules_swift 2.0 will have quite a few breaking changes. Users will possibly need to perform some migrations. Dependent rulesets will possibly need to make changes as well. If dependent rulesets can support both pre-2.0 and 2.0, they can use `bazel_dep.max_compatibility_level`.