### PR TITLE
Enable `swift.add_target_name_to_output` by default

### DIFF
--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -31,6 +31,7 @@ load(":compiling.bzl", "compile_action_configs", "features_from_swiftcopts")
 load(":debugging.bzl", "modulewrap_action_configs")
 load(
     ":feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
@@ -313,6 +314,7 @@ def _swift_toolchain_impl(ctx):
         features_from_swiftcopts(swiftcopts = swiftcopts)
     )
     requested_features.extend([
+        SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
         SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
         SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
         SWIFT_FEATURE_DEBUG_PREFIX_MAP,

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -30,6 +30,7 @@ load(":attrs.bzl", "swift_toolchain_driver_attrs")
 load(":compiling.bzl", "compile_action_configs", "features_from_swiftcopts")
 load(
     ":feature_names.bzl",
+    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_BUNDLED_XCTESTS",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
     "SWIFT_FEATURE_COVERAGE",
@@ -611,6 +612,7 @@ def _xcode_swift_toolchain_impl(ctx):
     ) + features_from_swiftcopts(swiftcopts = swiftcopts)
     requested_features.extend(ctx.features)
     requested_features.extend([
+        SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
         SWIFT_FEATURE_BUNDLED_XCTESTS,
         SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
         SWIFT_FEATURE_COVERAGE_PREFIX_MAP,

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -20,9 +20,9 @@ load(
     "provider_test",
 )
 
-private_deps_provider_test = make_provider_test_rule(
+provider_without_target_name_test = make_provider_test_rule(
     config_settings = {
-        "//command_line_option:features": ["swift.add_target_name_to_output"],
+        "//command_line_option:features": ["-swift.add_target_name_to_output"],
     },
 )
 
@@ -36,7 +36,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_no_deps".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/lower_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -44,10 +44,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
     )
 
-    private_deps_provider_test(
+    provider_without_target_name_test(
         name = "{}_with_no_deps_with_target_name".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/lower_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -58,7 +58,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_deps".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -66,10 +66,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
     )
 
-    private_deps_provider_test(
+    provider_without_target_name_test(
         name = "{}_with_deps_with_target_name".format(name),
         expected_files = [
-            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
+            "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -80,7 +80,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_private_swift_deps".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_swift_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -88,10 +88,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
     )
 
-    private_deps_provider_test(
+    provider_without_target_name_test(
         name = "{}_with_private_swift_deps_with_target_name".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_swift_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -102,7 +102,7 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_private_cc_deps".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -110,10 +110,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
     )
 
-    private_deps_provider_test(
+    provider_without_target_name_test(
         name = "{}_with_private_cc_deps_with_target_name".format(name),
         expected_files = [
-            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
+            "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -124,8 +124,8 @@ def ast_file_test_suite(name):
     provider_test(
         name = "{}_with_multiple_swift_files".format(name),
         expected_files = [
-            "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
-            "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
+            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -133,11 +133,11 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/multiple_files",
     )
 
-    private_deps_provider_test(
+    provider_without_target_name_test(
         name = "{}_with_multiple_swift_files_with_target_name".format(name),
         expected_files = [
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
+            "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
+            "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -11,11 +11,10 @@ load(
 
 default_test = make_action_command_line_test_rule()
 
-# Test with enabled `swift.add_target_name_to_output` feature
-default_with_target_name_test = make_action_command_line_test_rule(
+default_without_target_name_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -76,12 +75,11 @@ vfsoverlay_test = make_action_command_line_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-vfsoverlay_with_target_name_test = make_action_command_line_test_rule(
+vfsoverlay_without_target_name_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.vfsoverlay",
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -94,12 +92,11 @@ explicit_swift_module_map_test = make_action_command_line_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-explicit_swift_module_map_with_target_name_test = make_action_command_line_test_rule(
+explicit_swift_module_map_without_target_name_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.use_explicit_swift_module_map",
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -124,19 +121,19 @@ def features_test_suite(name):
         tags = [name],
         expected_argv = [
             "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-I$(BIN_DIR)/test/fixtures/basic/first",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
-    default_with_target_name_test(
-        name = "{}_default_with_target_name_test".format(name),
+    default_without_target_name_test(
+        name = "{}_default_without_target_name_test".format(name),
         tags = [name],
         expected_argv = [
             "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic/first",
+            "-I$(BIN_DIR)/test/fixtures/basic",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -219,7 +216,7 @@ def features_test_suite(name):
         name = "{}_vfsoverlay_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
+            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
             "-I/__build_bazel_rules_swift/swiftmodules",
         ],
         not_expected_argv = [
@@ -230,11 +227,11 @@ def features_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
-    vfsoverlay_with_target_name_test(
-        name = "{}_vfsoverlay_with_target_name_test".format(name),
+    vfsoverlay_without_target_name_test(
+        name = "{}_vfsoverlay_without_target_name_test".format(name),
         tags = [name],
         expected_argv = [
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
+            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
             "-I/__build_bazel_rules_swift/swiftmodules",
         ],
         not_expected_argv = [
@@ -252,7 +249,7 @@ def features_test_suite(name):
             "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/basic/second.swift-explicit-module-map.json",
         ],
         not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-I$(BIN_DIR)/test/fixtures/basic/second",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
         ],
@@ -260,14 +257,14 @@ def features_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
-    explicit_swift_module_map_with_target_name_test(
-        name = "{}_explicit_swift_module_map_with_target_name_test".format(name),
+    explicit_swift_module_map_without_target_name_test(
+        name = "{}_explicit_swift_module_map_without_target_name_test".format(name),
         tags = [name],
         expected_argv = [
             "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/basic/second.swift-explicit-module-map.json",
         ],
         not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic/second",
+            "-I$(BIN_DIR)/test/fixtures/basic",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
         ],

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -24,9 +24,9 @@ load(
     "provider_test",
 )
 
-private_deps_with_target_name_test = make_provider_test_rule(
+private_deps_without_target_name_test = make_provider_test_rule(
     config_settings = {
-        "//command_line_option:features": ["swift.add_target_name_to_output"],
+        "//command_line_option:features": ["-swift.add_target_name_to_output"],
     },
 )
 
@@ -42,7 +42,7 @@ def generated_header_test_suite(name):
     provider_test(
         name = "{}_automatically_named_header_is_rule_output".format(name),
         expected_files = [
-            "test/fixtures/generated_header/auto_header-Swift.h",
+            "test/fixtures/generated_header/auto_header/auto_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -51,10 +51,10 @@ def generated_header_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:auto_header",
     )
 
-    private_deps_with_target_name_test(
-        name = "{}_automatically_named_header_is_rule_output_with_target_name".format(name),
+    private_deps_without_target_name_test(
+        name = "{}_automatically_named_header_is_rule_output_without_target_name".format(name),
         expected_files = [
-            "test/fixtures/generated_header/auto_header/auto_header-Swift.h",
+            "test/fixtures/generated_header/auto_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -68,7 +68,7 @@ def generated_header_test_suite(name):
     provider_test(
         name = "{}_no_header".format(name),
         expected_files = [
-            "-test/fixtures/generated_header/no_header-Swift.h",
+            "-test/fixtures/generated_header/no_header/no_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -82,8 +82,8 @@ def generated_header_test_suite(name):
     provider_test(
         name = "{}_explicit_header".format(name),
         expected_files = [
-            "test/fixtures/generated_header/SomeOtherName.h",
-            "-test/fixtures/generated_header/explicit_header-Swift.h",
+            "test/fixtures/generated_header/explicit_header/SomeOtherName.h",
+            "-test/fixtures/generated_header/explicit_header/explicit_header-Swift.h",
             "*",
         ],
         field = "files",
@@ -92,10 +92,10 @@ def generated_header_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:explicit_header",
     )
 
-    private_deps_with_target_name_test(
-        name = "{}_explicit_header_with_target_name".format(name),
+    private_deps_without_target_name_test(
+        name = "{}_explicit_header_without_target_name".format(name),
         expected_files = [
-            "test/fixtures/generated_header/explicit_header/SomeOtherName.h",
+            "test/fixtures/generated_header/SomeOtherName.h",
             "-test/fixtures/generated_header/explicit_header-Swift.h",
             "*",
         ],
@@ -117,7 +117,7 @@ def generated_header_test_suite(name):
     provider_test(
         name = "{}_valid_path_separator".format(name),
         expected_files = [
-            "test/fixtures/generated_header/Valid/Separator.h",
+            "test/fixtures/generated_header/valid_path_separator/Valid/Separator.h",
             "*",
         ],
         field = "files",
@@ -126,10 +126,10 @@ def generated_header_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/generated_header:valid_path_separator",
     )
 
-    private_deps_with_target_name_test(
-        name = "{}_valid_path_separator_with_target_name".format(name),
+    private_deps_without_target_name_test(
+        name = "{}_valid_path_separator_without_target_name".format(name),
         expected_files = [
-            "test/fixtures/generated_header/valid_path_separator/Valid/Separator.h",
+            "test/fixtures/generated_header/Valid/Separator.h",
             "*",
         ],
         field = "files",

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -31,10 +31,28 @@ explicit_swift_module_map_test = make_action_command_line_test_rule(
     },
 )
 
+explicit_swift_module_map_without_target_name_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_explicit_swift_module_map",
+            "-swift.add_target_name_to_output",
+        ],
+    },
+)
+
 vfsoverlay_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.vfsoverlay",
+        ],
+    },
+)
+
+vfsoverlay_without_target_name_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.vfsoverlay",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -69,8 +87,37 @@ def module_interface_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/module_interface:toy_module",
     )
 
+    explicit_swift_module_map_without_target_name_test(
+        name = "{}_explicit_swift_module_map_without_target_name_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-explicit-swift-module-map-file $(BIN_DIR)/test/fixtures/module_interface/ToyModule.swift-explicit-module-map.json",
+        ],
+        not_expected_argv = [
+            "-Xfrontend",
+        ],
+        mnemonic = "SwiftCompileModuleInterface",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/module_interface:toy_module",
+    )
+
     vfsoverlay_test(
         name = "{}_vfsoverlay_test".format(name),
+        tags = [name],
+        expected_argv = [
+            "-vfsoverlay$(BIN_DIR)/test/fixtures/module_interface/ToyModule/ToyModule.vfsoverlay.yaml",
+            "-I/__build_bazel_rules_swift/swiftmodules",
+        ],
+        not_expected_argv = [
+            "-I$(BIN_DIR)/test/fixtures/module_interface/toy_module",
+            "-explicit-swift-module-map-file",
+            "-Xfrontend",
+        ],
+        mnemonic = "SwiftCompileModuleInterface",
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/module_interface:toy_module",
+    )
+
+    vfsoverlay_without_target_name_test(
+        name = "{}_vfsoverlay_without_target_name_test".format(name),
         tags = [name],
         expected_argv = [
             "-vfsoverlay$(BIN_DIR)/test/fixtures/module_interface/ToyModule.vfsoverlay.yaml",

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -20,11 +20,10 @@ load(
     "output_file_map_test",
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_target_name_test = make_output_file_map_test_rule(
+output_file_map_without_target_name_test = make_output_file_map_test_rule(
     config_settings = {
         "//command_line_option:features": [
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -37,12 +36,11 @@ output_file_map_embed_bitcode_test = make_output_file_map_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_target_name_embed_bitcode_test = make_output_file_map_test_rule(
+output_file_map_without_target_name_embed_bitcode_test = make_output_file_map_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.emit_bc",
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -58,15 +56,14 @@ output_file_map_embed_bitcode_wmo_test = make_output_file_map_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-output_file_map_embed_target_name_bitcode_wmo_test = make_output_file_map_test_rule(
+output_file_map_embed_without_target_name_bitcode_wmo_test = make_output_file_map_test_rule(
     config_settings = {
         str(Label("@build_bazel_rules_swift//swift:copt")): [
             "-whole-module-optimization",
         ],
         "//command_line_option:features": [
             "swift.emit_bc",
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -97,22 +94,22 @@ def output_file_map_test_suite(name):
     output_file_map_test(
         name = "{}_default".format(name),
         expected_mapping = {
-            "object": "test/fixtures/debug_settings/simple_objs/Empty.swift.o",
+            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
             "const-values": "test/fixtures/debug_settings/simple_objs/Empty.swift.swiftconstvalues",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_target_name_test(
-        name = "{}_target_name_default".format(name),
+    output_file_map_without_target_name_test(
+        name = "{}_without_target_name_default".format(name),
         expected_mapping = {
-            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
+            "object": "test/fixtures/debug_settings/simple_objs/Empty.swift.o",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
@@ -122,21 +119,21 @@ def output_file_map_test_suite(name):
     output_file_map_embed_bitcode_test(
         name = "{}_emit_bc".format(name),
         expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
-    output_file_map_target_name_embed_bitcode_test(
-        name = "{}_target_name_emit_bc".format(name),
-        expected_mapping = {
             "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_without_target_name_embed_bitcode_test(
+        name = "{}_without_target_name_emit_bc".format(name),
+        expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
@@ -144,6 +141,17 @@ def output_file_map_test_suite(name):
     output_file_map_embed_bitcode_wmo_test(
         name = "{}_emit_bc_wmo".format(name),
         expected_mapping = {
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
+        },
+        file_entry = "test/fixtures/debug_settings/Empty.swift",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
+        tags = [name],
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    output_file_map_embed_without_target_name_bitcode_wmo_test(
+        name = "{}_without_target_name_emit_bc_wmo".format(name),
+        expected_mapping = {
             "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
@@ -152,8 +160,8 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_embed_target_name_bitcode_wmo_test(
-        name = "{}_target_name_emit_bc_wmo".format(name),
+    output_file_map_thin_lto_test(
+        name = "{}_thin_lto".format(name),
         expected_mapping = {
             "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
         },
@@ -163,24 +171,13 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_thin_lto_test(
-        name = "{}_thin_lto".format(name),
-        expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
     output_file_map_full_lto_test(
         name = "{}_full_lto".format(name),
         expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple_objs/Empty.swift.bc",
+            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
+        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )

--- a/test/private_deps_tests.bzl
+++ b/test/private_deps_tests.bzl
@@ -27,12 +27,11 @@ private_deps_provider_test = make_provider_test_rule(
     },
 )
 
-# Test with enabled `swift.add_target_name_to_output` feature
-private_deps_provider_target_name_test = make_provider_test_rule(
+private_deps_provider_without_target_name_test = make_provider_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.supports_private_deps",
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
@@ -113,7 +112,7 @@ def private_deps_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
     )
 
-    private_deps_provider_target_name_test(
+    private_deps_provider_without_target_name_test(
         name = "{}_client_cc_deps_modulemaps_target_name".format(name),
         expected_files = [
             "/test/fixtures/private_deps/public_cc_modulemap/_/module.modulemap",

--- a/test/swift_binary_linking_tests.bzl
+++ b/test/swift_binary_linking_tests.bzl
@@ -6,25 +6,25 @@ load(
     "swift_binary_linking_test",
 )
 
-swift_binary_linking_with_target_name_test = make_swift_binary_linking_test_rule(
+swift_binary_linking_without_target_name_test = make_swift_binary_linking_test_rule(
     config_settings = {
         "//command_line_option:features": [
-            "swift.add_target_name_to_output",
+            "-swift.add_target_name_to_output",
         ],
     },
 )
 
 def swift_binary_linking_test_suite(name):
-    swift_binary_linking_with_target_name_test(
-        name = "{}_with_target_name".format(name),
-        output_binary_path = "test/fixtures/linking/bin/bin",
+    swift_binary_linking_without_target_name_test(
+        name = "{}_without_target_name".format(name),
+        output_binary_path = "test/fixtures/linking/bin",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
     )
 
     swift_binary_linking_test(
         name = "{}_default".format(name),
-        output_binary_path = "test/fixtures/linking/bin",
+        output_binary_path = "test/fixtures/linking/bin/bin",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/linking:bin",
     )


### PR DESCRIPTION
Since we are releasing 2.0 with breaking changes, we should enable this by default now, and then in 3.0 we can remove the feature.