### PR TITLE
Apply `swift.add_target_name_to_output` only to outputs that need it

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -151,7 +151,8 @@ A tuple containing three elements:
 
 <pre>
 swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>,
-                                      <a href="#swift_common.compile_module_interface-module_name">module_name</a>, <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>)
+                                      <a href="#swift_common.compile_module_interface-module_name">module_name</a>, <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>,
+                                      <a href="#swift_common.compile_module_interface-target_name">target_name</a>)
 </pre>
 
 Compiles a Swift module interface.
@@ -168,6 +169,7 @@ Compiles a Swift module interface.
 | <a id="swift_common.compile_module_interface-swiftinterface_file"></a>swiftinterface_file |  The Swift module interface file to compile.   |  none |
 | <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled.   |  none |
 | <a id="swift_common.compile_module_interface-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
+| <a id="swift_common.compile_module_interface-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
 
 **RETURNS**
 

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -23,7 +23,6 @@ load(
 load(":derived_files.bzl", "derived_files")
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_FASTBUILD",
     "SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE",
@@ -59,17 +58,11 @@ def ensure_swiftmodule_is_embedded(
         action_name = swift_action_names.MODULEWRAP,
         swift_toolchain = swift_toolchain,
     ):
-        add_target_name_to_output_path = is_feature_enabled(
-            feature_configuration = feature_configuration,
-            feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-        )
-
         # For ELF-format binaries, we need to invoke a Swift modulewrap action
         # to wrap the .swiftmodule file in a .o file that gets propagated to the
         # linker.
         modulewrap_obj = derived_files.modulewrap_object(
             actions,
-            add_target_name_to_output_path = add_target_name_to_output_path,
             target_name = label.name,
         )
         _register_modulewrap_action(

--- a/swift/internal/derived_files.bzl
+++ b/swift/internal/derived_files.bzl
@@ -30,18 +30,11 @@ def _declare_file(actions, add_target_name_to_output_path, target_name, basename
     else:
         return actions.declare_file(basename)
 
-def _declare_directory(actions, add_target_name_to_output_path, target_name, directory):
-    if add_target_name_to_output_path:
-        return actions.declare_directory("{}_{}".format(target_name, directory))
-    else:
-        return actions.declare_directory(directory)
-
-def _ast(actions, add_target_name_to_output_path, target_name, src):
+def _ast(actions, target_name, src):
     """Declares a file for an ast file during compilation.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -49,91 +42,49 @@ def _ast(actions, add_target_name_to_output_path, target_name, src):
         The declared `File` where the given src's AST will be dumped to.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        paths.join(dirname, "{}.ast".format(basename)),
-    )
+    return actions.declare_file(paths.join(dirname, "{}.ast".format(basename)))
 
-def _autolink_flags(actions, add_target_name_to_output_path, target_name):
+def _autolink_flags(actions, target_name):
     """Declares the response file into which autolink flags will be extracted.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.autolink".format(target_name),
-    )
+    return actions.declare_file("{}.autolink".format(target_name))
 
-def _executable(actions, add_target_name_to_output_path, target_name):
-    """Declares a file for the executable created by a binary or test rule.
-
-    Args:
-        actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
-        target_name: The name of the target being built.
-
-    Returns:
-        The declared `File`.
-    """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        target_name,
-    )
-
-def _indexstore_directory(actions, add_target_name_to_output_path, target_name):
+def _indexstore_directory(actions, target_name):
     """Declares a directory in which the compiler's indexstore will be written.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_directory(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.indexstore".format(target_name),
-    )
+    return actions.declare_directory("{}.indexstore".format(target_name))
 
-def _symbol_graph_directory(actions, add_target_name_to_output_path, target_name):
+def _symbol_graph_directory(actions, target_name):
     """Declares a directory in which the compiler's symbol graph will be written.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_directory(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.symbolgraph".format(target_name),
-    )
+    return actions.declare_directory("{}.symbolgraph".format(target_name))
 
-def _intermediate_bc_file(actions, add_target_name_to_output_path, target_name, src):
+def _intermediate_bc_file(actions, target_name, src):
     """Declares a file for an intermediate llvm bc file during compilation.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -141,12 +92,7 @@ def _intermediate_bc_file(actions, add_target_name_to_output_path, target_name, 
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        paths.join(dirname, "{}.bc".format(basename)),
-    )
+    return actions.declare_file(paths.join(dirname, "{}.bc".format(basename)))
 
 def _intermediate_frontend_file_path(target_name, src):
     """Returns the path to the directory for intermediate compile outputs.
@@ -169,7 +115,7 @@ def _intermediate_frontend_file_path(target_name, src):
 
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
 
-def _intermediate_object_file(actions, add_target_name_to_output_path, target_name, src):
+def _intermediate_object_file(actions, target_name, src):
     """Declares a file for an intermediate object file during compilation.
 
     These files are produced when the compiler is invoked with multiple frontend
@@ -179,7 +125,6 @@ def _intermediate_object_file(actions, add_target_name_to_output_path, target_na
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
         src: A `File` representing the source file being compiled.
 
@@ -187,12 +132,7 @@ def _intermediate_object_file(actions, add_target_name_to_output_path, target_na
         The declared `File`.
     """
     dirname, basename = _intermediate_frontend_file_path(target_name, src)
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        paths.join(dirname, "{}.o".format(basename)),
-    )
+    return actions.declare_file(paths.join(dirname, "{}.o".format(basename)))
 
 def _module_map(actions, target_name):
     """Declares the module map for a target.
@@ -215,23 +155,17 @@ def _module_map(actions, target_name):
         "{}_modulemap/_/module.modulemap".format(target_name),
     )
 
-def _modulewrap_object(actions, add_target_name_to_output_path, target_name):
+def _modulewrap_object(actions, target_name):
     """Declares the object file used to wrap Swift modules for ELF binaries.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.modulewrap.o".format(target_name),
-    )
+    return actions.declare_file("{}.modulewrap.o".format(target_name))
 
 def _declare_validated_generated_header(actions, add_target_name_to_output_path, target_name, generated_header_name):
     """Validates and declares the explicitly named generated header.
@@ -261,23 +195,17 @@ def _declare_validated_generated_header(actions, add_target_name_to_output_path,
         generated_header_name,
     )
 
-def _precompiled_module(actions, add_target_name_to_output_path, target_name):
+def _precompiled_module(actions, target_name):
     """Declares the precompiled module for a C/Objective-C target.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.swift.pcm".format(target_name),
-    )
+    return actions.declare_file("{}.swift.pcm".format(target_name))
 
 def _reexport_modules_src(actions, target_name):
     """Declares a source file used to re-export other Swift modules.
@@ -316,7 +244,7 @@ def _static_archive(actions, add_target_name_to_output_path, alwayslink, link_na
         "lib{}.{}".format(link_name, extension),
     )
 
-def _swiftc_output_file_map(actions, add_target_name_to_output_path, target_name):
+def _swiftc_output_file_map(actions, target_name):
     """Declares a file for the output file map for a compilation action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -325,20 +253,14 @@ def _swiftc_output_file_map(actions, add_target_name_to_output_path, target_name
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.output_file_map.json".format(target_name),
-    )
+    return actions.declare_file("{}.output_file_map.json".format(target_name))
 
-def _swiftc_derived_output_file_map(actions, add_target_name_to_output_path, target_name):
+def _swiftc_derived_output_file_map(actions, target_name):
     """Declares a file for the output file map for a swiftmodule only action.
 
     This JSON-formatted output map file allows us to supply our own paths and
@@ -347,16 +269,12 @@ def _swiftc_derived_output_file_map(actions, add_target_name_to_output_path, tar
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
+    return actions.declare_file(
         "{}.derived_output_file_map.json".format(target_name),
     )
 
@@ -455,7 +373,7 @@ def _swiftsourceinfo(actions, add_target_name_to_output_path, target_name, modul
         "{}.swiftsourceinfo".format(module_name),
     )
 
-def _vfsoverlay(actions, add_target_name_to_output_path, target_name):
+def _vfsoverlay(actions, target_name):
     """Declares a file for the VFS overlay for a compilation action.
 
     The VFS overlay is YAML-formatted file that allows us to place the
@@ -464,20 +382,14 @@ def _vfsoverlay(actions, add_target_name_to_output_path, target_name):
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.vfsoverlay.yaml".format(target_name),
-    )
+    return actions.declare_file("{}.vfsoverlay.yaml".format(target_name))
 
-def _whole_module_object_file(actions, add_target_name_to_output_path, target_name):
+def _whole_module_object_file(actions, target_name):
     """Declares a file for object files created with whole module optimization.
 
     This is the output of a compile action when whole module optimization is
@@ -486,18 +398,12 @@ def _whole_module_object_file(actions, add_target_name_to_output_path, target_na
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.o".format(target_name),
-    )
+    return actions.declare_file("{}.o".format(target_name))
 
 def _swift_const_values_file(actions, target_name):
     """Declares a file for the Swift const values.
@@ -532,28 +438,21 @@ def _intermediate_swift_const_values_file(actions, target_name, src):
         paths.join(dirname, "{}.swiftconstvalues".format(basename)),
     )
 
-def _xctest_runner_script(actions, add_target_name_to_output_path, target_name):
+def _xctest_runner_script(actions, target_name):
     """Declares a file for the script that runs an `.xctest` bundle on Darwin.
 
     Args:
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         target_name: The name of the target being built.
 
     Returns:
         The declared `File`.
     """
-    return _declare_file(
-        actions,
-        add_target_name_to_output_path,
-        target_name,
-        "{}.test-runner.sh".format(target_name),
-    )
+    return actions.declare_file("{}.test-runner.sh".format(target_name))
 
 derived_files = struct(
     ast = _ast,
     autolink_flags = _autolink_flags,
-    executable = _executable,
     indexstore_directory = _indexstore_directory,
     intermediate_bc_file = _intermediate_bc_file,
     intermediate_object_file = _intermediate_object_file,

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -31,7 +31,6 @@ load(
 )
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_LLD_GC_WORKAROUND",
     "SWIFT_FEATURE_OBJC_LINK_FLAGS",
     "SWIFT_FEATURE__FORCE_ALWAYSLINK_TRUE",
@@ -259,13 +258,8 @@ def create_linking_context_from_compilation_outputs(
             action_name = swift_action_names.AUTOLINK_EXTRACT,
             swift_toolchain = swift_toolchain,
         ):
-            add_target_name_to_output_path = is_feature_enabled(
-                feature_configuration = feature_configuration,
-                feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-            )
             autolink_file = derived_files.autolink_flags(
                 actions = actions,
-                add_target_name_to_output_path = add_target_name_to_output_path,
                 target_name = label.name,
             )
             register_autolink_extract_action(

--- a/swift/internal/swift_binary_test_rules.bzl
+++ b/swift/internal/swift_binary_test_rules.bzl
@@ -201,14 +201,13 @@ def _swift_linking_rule_impl(
 
     return cc_compilation_outputs, linking_outputs, providers
 
-def _create_xctest_runner(name, actions, add_target_name_to_output_path, executable, xctest_runner_template):
+def _create_xctest_runner(name, actions, executable, xctest_runner_template):
     """Creates a script that will launch `xctest` with the given test bundle.
 
     Args:
         name: The name of the target being built, which will be used as the
             basename of the test runner script.
         actions: The context's actions object.
-        add_target_name_to_output_path: Add target_name in output path. More info at SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT description.
         executable: The `File` representing the executable inside the `.xctest`
             bundle that should be executed.
         xctest_runner_template: The `File` that will be used as a template to
@@ -220,7 +219,6 @@ def _create_xctest_runner(name, actions, add_target_name_to_output_path, executa
     """
     xctest_runner = derived_files.xctest_runner_script(
         actions = actions,
-        add_target_name_to_output_path = add_target_name_to_output_path,
         target_name = name,
     )
 
@@ -277,11 +275,6 @@ def _swift_test_impl(ctx):
         feature_name = SWIFT_FEATURE_BUNDLED_XCTESTS,
     )
 
-    add_target_name_to_output_path = swift_common.is_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
-    )
-
     # If we need to run the test in an .xctest bundle, the binary must have
     # Mach-O type `MH_BUNDLE` instead of `MH_EXECUTE`.
     linkopts = ["-Wl,-bundle"] if is_bundled else []
@@ -327,7 +320,6 @@ def _swift_test_impl(ctx):
         xctest_runner = _create_xctest_runner(
             name = ctx.label.name,
             actions = ctx.actions,
-            add_target_name_to_output_path = add_target_name_to_output_path,
             executable = linking_outputs.executable,
             xctest_runner_template = ctx.file._xctest_runner_template,
         )

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -83,6 +83,7 @@ def _swift_import_impl(ctx):
             swiftinterface_file = swiftinterface,
             swift_infos = swift_infos,
             swift_toolchain = swift_toolchain,
+            target_name = ctx.attr.name,
         )
         swift_outputs = [
             module_context.swift.swiftmodule,

--- a/test/BUILD
+++ b/test/BUILD
@@ -18,10 +18,10 @@ load(":pch_output_dir_tests.bzl", "pch_output_dir_test_suite")
 load(":private_deps_tests.bzl", "private_deps_test_suite")
 load(":private_swiftinterface_tests.bzl", "private_swiftinterface_test_suite")
 load(":split_derived_files_tests.bzl", "split_derived_files_test_suite")
+load(":swift_binary_linking_tests.bzl", "swift_binary_linking_test_suite")
 load(":swift_through_non_swift_tests.bzl", "swift_through_non_swift_test_suite")
 load(":utils_tests.bzl", "utils_test_suite")
 load(":xctest_runner_tests.bzl", "xctest_runner_test_suite")
-load(":swift_binary_linking_tests.bzl", "swift_binary_linking_test_suite")
 
 licenses(["notice"])
 

--- a/test/ast_file_tests.bzl
+++ b/test/ast_file_tests.bzl
@@ -14,17 +14,7 @@
 
 """Tests for `ast_file`."""
 
-load(
-    "@build_bazel_rules_swift//test/rules:provider_test.bzl",
-    "make_provider_test_rule",
-    "provider_test",
-)
-
-private_deps_provider_test = make_provider_test_rule(
-    config_settings = {
-        "//command_line_option:features": ["swift.add_target_name_to_output"],
-    },
-)
+load("@build_bazel_rules_swift//test/rules:provider_test.bzl", "provider_test")
 
 def ast_file_test_suite(name):
     """Test suite for `swift_library` dumping ast files.
@@ -44,32 +34,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
     )
 
-    private_deps_provider_test(
-        name = "{}_with_no_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/swift_through_non_swift/lower/lower_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:lower",
-    )
-
     provider_test(
         name = "{}_with_deps".format(name),
         expected_files = [
             "test/fixtures/swift_through_non_swift/upper_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/swift_through_non_swift:upper",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/swift_through_non_swift/upper/upper_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -88,32 +56,10 @@ def ast_file_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
     )
 
-    private_deps_provider_test(
-        name = "{}_with_private_swift_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/private_deps/client_swift_deps/client_swift_deps_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_swift_deps",
-    )
-
     provider_test(
         name = "{}_with_private_cc_deps".format(name),
         expected_files = [
             "test/fixtures/private_deps/client_cc_deps_objs/Empty.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/private_deps:client_cc_deps",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_private_cc_deps_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/private_deps/client_cc_deps/client_cc_deps_objs/Empty.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",
@@ -126,18 +72,6 @@ def ast_file_test_suite(name):
         expected_files = [
             "test/fixtures/multiple_files/multiple_files_objs/Empty.swift.ast",
             "test/fixtures/multiple_files/multiple_files_objs/Empty2.swift.ast",
-        ],
-        field = "swift_ast_file",
-        provider = "OutputGroupInfo",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/multiple_files",
-    )
-
-    private_deps_provider_test(
-        name = "{}_with_multiple_swift_files_with_target_name".format(name),
-        expected_files = [
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty.swift.ast",
-            "test/fixtures/multiple_files/multiple_files/multiple_files_objs/Empty2.swift.ast",
         ],
         field = "swift_ast_file",
         provider = "OutputGroupInfo",

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -230,21 +230,6 @@ def features_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
     )
 
-    vfsoverlay_with_target_name_test(
-        name = "{}_vfsoverlay_with_target_name_test".format(name),
-        tags = [name],
-        expected_argv = [
-            "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second/second.vfsoverlay.yaml",
-            "-I/__build_bazel_rules_swift/swiftmodules",
-        ],
-        not_expected_argv = [
-            "-I$(BIN_DIR)/test/fixtures/basic",
-            "-explicit-swift-module-map-file",
-        ],
-        mnemonic = "SwiftCompile",
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/basic:second",
-    )
-
     explicit_swift_module_map_test(
         name = "{}_explicit_swift_module_map_test".format(name),
         tags = [name],

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -60,7 +60,7 @@ def module_interface_test_suite(name):
         name = "{}_explicit_swift_module_map_test".format(name),
         tags = [name],
         expected_argv = [
-            "-explicit-swift-module-map-file $(BIN_DIR)/test/fixtures/module_interface/ToyModule.swift-explicit-module-map.json",
+            "-explicit-swift-module-map-file $(BIN_DIR)/test/fixtures/module_interface/toy_module.swift-explicit-module-map.json",
         ],
         not_expected_argv = [
             "-Xfrontend",
@@ -73,7 +73,7 @@ def module_interface_test_suite(name):
         name = "{}_vfsoverlay_test".format(name),
         tags = [name],
         expected_argv = [
-            "-vfsoverlay$(BIN_DIR)/test/fixtures/module_interface/ToyModule.vfsoverlay.yaml",
+            "-vfsoverlay$(BIN_DIR)/test/fixtures/module_interface/toy_module.vfsoverlay.yaml",
             "-I/__build_bazel_rules_swift/swiftmodules",
         ],
         not_expected_argv = [

--- a/test/output_file_map_tests.bzl
+++ b/test/output_file_map_tests.bzl
@@ -106,17 +106,6 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_target_name_test(
-        name = "{}_target_name_default".format(name),
-        expected_mapping = {
-            "object": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.o",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
     # In Xcode13, the bitcode file needs to be in the output file map
     # (https://github.com/bazelbuild/rules_swift/issues/682).
     output_file_map_embed_bitcode_test(
@@ -130,17 +119,6 @@ def output_file_map_test_suite(name):
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )
 
-    output_file_map_target_name_embed_bitcode_test(
-        name = "{}_target_name_emit_bc".format(name),
-        expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
     output_file_map_embed_bitcode_wmo_test(
         name = "{}_emit_bc_wmo".format(name),
         expected_mapping = {
@@ -148,17 +126,6 @@ def output_file_map_test_suite(name):
         },
         file_entry = "test/fixtures/debug_settings/Empty.swift",
         output_file_map = "test/fixtures/debug_settings/simple.output_file_map.json",
-        tags = [name],
-        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
-    )
-
-    output_file_map_embed_target_name_bitcode_wmo_test(
-        name = "{}_target_name_emit_bc_wmo".format(name),
-        expected_mapping = {
-            "llvm-bc": "test/fixtures/debug_settings/simple/simple_objs/Empty.swift.bc",
-        },
-        file_entry = "test/fixtures/debug_settings/Empty.swift",
-        output_file_map = "test/fixtures/debug_settings/simple/simple.output_file_map.json",
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
In particular, only outputs that need to have the module name as part of the filename.