### PR TITLE
Pass `compilation_contexts` and `swift_infos` instead of `deps` to `swift_common.compile`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -86,10 +86,10 @@ A new attribute dictionary that can be added to the attributes of a
 ## swift_common.compile
 
 <pre>
-swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-deps">deps</a>, <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>,
+swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-cc_infos">cc_infos</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>,
                      <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-is_test">is_test</a>, <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>,
-                     <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_deps">private_deps</a>, <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>,
-                     <a href="#swift_common.compile-target_name">target_name</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>)
+                     <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-objc_infos">objc_infos</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_swift_infos">private_swift_infos</a>, <a href="#swift_common.compile-srcs">srcs</a>,
+                     <a href="#swift_common.compile-swift_infos">swift_infos</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile-target_name">target_name</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>)
 </pre>
 
 Compiles a Swift module.
@@ -101,19 +101,21 @@ Compiles a Swift module.
 | :------------- | :------------- | :------------- |
 | <a id="swift_common.compile-actions"></a>actions |  The context's `actions` object.   |  none |
 | <a id="swift_common.compile-additional_inputs"></a>additional_inputs |  A list of `File`s representing additional input files that need to be passed to the Swift compile action because they are referenced by compiler flags.   |  `[]` |
+| <a id="swift_common.compile-cc_infos"></a>cc_infos |  A list of `CcInfo` providers that represent C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from a target's dependencies.   |  none |
 | <a id="swift_common.compile-copts"></a>copts |  A list of compiler flags that apply to the target being built. These flags, along with those from Bazel's Swift configuration fragment (i.e., `--swiftcopt` command line flags) are scanned to determine whether whole module optimization is being requested, which affects the nature of the output files.   |  `[]` |
 | <a id="swift_common.compile-defines"></a>defines |  Symbols that should be defined by passing `-D` to the compiler.   |  `[]` |
-| <a id="swift_common.compile-deps"></a>deps |  Non-private dependencies of the target being compiled. These targets are used as dependencies of both the Swift module being compiled and the Clang module for the generated header. These targets must propagate `CcInfo` or `SwiftInfo`.   |  `[]` |
 | <a id="swift_common.compile-extra_swift_infos"></a>extra_swift_infos |  Extra `SwiftInfo` providers that aren't contained by the `deps` of the target being compiled but are required for compilation.   |  `[]` |
 | <a id="swift_common.compile-feature_configuration"></a>feature_configuration |  A feature configuration obtained from `swift_common.configure_features`.   |  none |
 | <a id="swift_common.compile-generated_header_name"></a>generated_header_name |  The name of the Objective-C generated header that should be generated for this module. If omitted, no header will be generated.   |  `None` |
 | <a id="swift_common.compile-is_test"></a>is_test |  Deprecated. This argument will be removed in the next major release. Use the `include_dev_srch_paths` attribute instead. Represents if the `testonly` value of the context.   |  `None` |
 | <a id="swift_common.compile-include_dev_srch_paths"></a>include_dev_srch_paths |  A `bool` that indicates whether the developer framework search paths will be added to the compilation command.   |  `None` |
 | <a id="swift_common.compile-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `swift_common.derive_module_name` to generate a default from the target's label if needed.   |  none |
+| <a id="swift_common.compile-objc_infos"></a>objc_infos |  A list of `apple_common.ObjC` providers that represent C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from a target's dependencies.   |  none |
 | <a id="swift_common.compile-package_name"></a>package_name |  The semantic package of the name of the Swift module being compiled.   |  none |
 | <a id="swift_common.compile-plugins"></a>plugins |  A list of `SwiftCompilerPluginInfo` providers that represent plugins that should be loaded by the compiler.   |  `[]` |
-| <a id="swift_common.compile-private_deps"></a>private_deps |  Private (implementation-only) dependencies of the target being compiled. These are only used as dependencies of the Swift module, not of the Clang module for the generated header. These targets must propagate `CcInfo` or `SwiftInfo`.   |  `[]` |
+| <a id="swift_common.compile-private_swift_infos"></a>private_swift_infos |  A list of `SwiftInfo` providers from private (implementation-only) dependencies of the target being compiled. The modules defined by these providers are used as dependencies of the Swift module being compiled but not of the Clang module for the generated header.   |  `[]` |
 | <a id="swift_common.compile-srcs"></a>srcs |  The Swift source files to compile.   |  none |
+| <a id="swift_common.compile-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from non-private dependencies of the target being compiled. The modules defined by these providers are used as dependencies of both the Swift module being compiled and the Clang module for the generated header.   |  none |
 | <a id="swift_common.compile-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 | <a id="swift_common.compile-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
 | <a id="swift_common.compile-workspace_name"></a>workspace_name |  The name of the workspace for which the code is being compiled, which is used to determine unique file paths for some outputs.   |  none |
@@ -125,7 +127,9 @@ A tuple containing three elements:
   1.  A Swift module context (as returned by `swift_common.create_module`)
       that contains the Swift (and potentially C/Objective-C) compilation
       prerequisites of the compiled module. This should typically be
-      propagated by a `SwiftInfo` provider of the calling rule.
+      propagated by a `SwiftInfo` provider of the calling rule, and the
+      `CcCompilationContext` inside the Clang module substructure should
+      be propagated by the `CcInfo` provider of the calling rule.
   2.  A `CcCompilationOutputs` object (as returned by
       `cc_common.create_compilation_outputs`) that contains the compiled
       object files.

--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -49,7 +49,7 @@ load(
 )
 
 def proto_path(proto_src, proto_info):
-    """Derives the string used to import the proto. 
+    """Derives the string used to import the proto.
 
     This is the proto source path within its repository,
     adjusted by `import_prefix` and `strip_import_prefix`.
@@ -270,14 +270,16 @@ def compile_swift_protos_for_target(
     include_dev_srch_paths = include_developer_search_paths(attr)
     module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
         actions = ctx.actions,
+        cc_infos = get_providers(compiler_deps, CcInfo),
         copts = ["-parse-as-library"],
-        deps = compiler_deps,
         feature_configuration = feature_configuration,
         include_dev_srch_paths = include_dev_srch_paths,
         module_name = module_name,
+        objc_infos = get_providers(compiler_deps, apple_common.Objc),
         package_name = None,
         srcs = generated_swift_srcs,
         swift_toolchain = swift_toolchain,
+        swift_infos = get_providers(compiler_deps, SwiftInfo),
         target_name = target_label.name,
         workspace_name = ctx.workspace_name,
     )

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2767,7 +2767,6 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
                 feature_configuration = feature_configuration,
                 includes = includes,
                 public_hdrs = public_hdrs,
-                swift_infos = swift_infos,
                 swift_toolchain = swift_toolchain,
                 target_name = target_name,
             ),
@@ -2980,7 +2979,6 @@ def _create_cc_compilation_context(
         feature_configuration,
         includes,
         public_hdrs,
-        swift_infos,
         swift_toolchain,
         target_name):
     """Creates a `CcCompilationContext` to propagate for a Swift module.
@@ -3003,10 +3001,6 @@ def _create_cc_compilation_context(
             context.
         public_hdrs: Public headers that should be propagated by the new
             compilation context (for example, the module's generated header).
-        swift_infos: `SwiftInfo` providers propagated by non-private
-            dependencies of the target being compiled. The modules represented
-            by these providers are used as dependencies of both the Swift module
-            being compiled and the Clang module for the generated header.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the

--- a/swift/internal/swift_binary_test_rules.bzl
+++ b/swift/internal/swift_binary_test_rules.bzl
@@ -23,10 +23,25 @@ load(
     "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT",
     "SWIFT_FEATURE_BUNDLED_XCTESTS",
 )
-load(":linking.bzl", "binary_rule_attrs", "configure_features_for_binary", "register_link_binary_action")
-load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftToolchainInfo")
+load(
+    ":linking.bzl",
+    "binary_rule_attrs",
+    "configure_features_for_binary",
+    "register_link_binary_action",
+)
+load(
+    ":providers.bzl",
+    "SwiftCompilerPluginInfo",
+    "SwiftInfo",
+    "SwiftToolchainInfo",
+)
 load(":swift_common.bzl", "swift_common")
-load(":utils.bzl", "expand_locations", "get_providers", "include_developer_search_paths")
+load(
+    ":utils.bzl",
+    "expand_locations",
+    "get_providers",
+    "include_developer_search_paths",
+)
 
 def _maybe_parse_as_library_copts(srcs):
     """Returns a list of compiler flags depending on `main.swift`'s presence.
@@ -106,16 +121,18 @@ def _swift_linking_rule_impl(
         module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
             actions = ctx.actions,
             additional_inputs = additional_inputs,
+            cc_infos = get_providers(ctx.attr.deps, CcInfo),
             copts = copts,
             defines = ctx.attr.defines,
-            deps = ctx.attr.deps,
             extra_swift_infos = extra_swift_infos,
             feature_configuration = feature_configuration,
             include_dev_srch_paths = include_dev_srch_paths,
             module_name = module_name,
+            objc_infos = get_providers(ctx.attr.deps, apple_common.Objc),
             package_name = ctx.attr.package_name,
             plugins = get_providers(ctx.attr.plugins, SwiftCompilerPluginInfo),
             srcs = srcs,
+            swift_infos = get_providers(ctx.attr.deps, SwiftInfo),
             swift_toolchain = swift_toolchain,
             target_name = ctx.label.name,
             workspace_name = ctx.workspace_name,

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -164,6 +164,9 @@ def _swift_library_impl(ctx):
         deps = ctx.attr.deps
         private_deps = []
 
+    swift_infos = get_providers(deps, SwiftInfo)
+    private_swift_infos = get_providers(private_deps, SwiftInfo)
+
     if ctx.attr.generates_header:
         generated_header_name = (
             ctx.attr.generated_header_name or
@@ -183,17 +186,19 @@ def _swift_library_impl(ctx):
     module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
         actions = ctx.actions,
         additional_inputs = additional_inputs,
+        cc_infos = get_providers(ctx.attr.deps, CcInfo),
         copts = _maybe_parse_as_library_copts(srcs) + copts,
         defines = ctx.attr.defines,
-        deps = deps,
         feature_configuration = feature_configuration,
         generated_header_name = generated_header_name,
         include_dev_srch_paths = include_dev_srch_paths,
         module_name = module_name,
+        objc_infos = get_providers(ctx.attr.deps, apple_common.Objc),
         package_name = ctx.attr.package_name,
         plugins = get_providers(ctx.attr.plugins, SwiftCompilerPluginInfo),
-        private_deps = private_deps,
+        private_swift_infos = private_swift_infos,
         srcs = srcs,
+        swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
         workspace_name = ctx.workspace_name,
@@ -267,7 +272,7 @@ def _swift_library_impl(ctx):
             modules = [module_context],
             # Note that private_deps are explicitly omitted here; they should
             # not propagate.
-            swift_infos = get_providers(deps, SwiftInfo),
+            swift_infos = swift_infos,
         ),
     ]
 

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -55,15 +55,19 @@ def _swift_module_alias_impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
 
+    swift_infos = get_providers(deps, SwiftInfo)
+
     module_context, compilation_outputs, other_compilation_outputs = swift_common.compile(
         actions = ctx.actions,
+        cc_infos = get_providers(ctx.attr.deps, CcInfo),
         copts = ["-parse-as-library"],
-        deps = deps,
         feature_configuration = feature_configuration,
         include_dev_srch_paths = ctx.attr.testonly,
         module_name = module_name,
+        objc_infos = get_providers(ctx.attr.deps, apple_common.Objc),
         package_name = None,
         srcs = [reexport_src],
+        swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
         workspace_name = ctx.workspace_name,
@@ -110,7 +114,7 @@ def _swift_module_alias_impl(ctx):
         ),
         swift_common.create_swift_info(
             modules = [module_context],
-            swift_infos = get_providers(deps, SwiftInfo),
+            swift_infos = swift_infos,
         ),
     ]
 

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -72,13 +72,14 @@ def compact(sequence):
 
 def compilation_context_for_explicit_module_compilation(
         compilation_contexts,
-        deps):
+        swift_infos):
     """Returns a compilation context suitable for compiling an explicit module.
 
     Args:
         compilation_contexts: `CcCompilationContext`s that provide information
             about headers and include paths for the target being compiled.
-        deps: Direct dependencies of the target being compiled.
+        swift_infos: `SwiftInfo` providers propagated by direct dependencies of
+            the target being compiled.
 
     Returns:
         A `CcCompilationContext` containing information needed when compiling an
@@ -88,31 +89,23 @@ def compilation_context_for_explicit_module_compilation(
     """
     all_compilation_contexts = list(compilation_contexts)
 
-    for dep in deps:
-        if CcInfo in dep:
-            all_compilation_contexts.append(dep[CcInfo].compilation_context)
-        elif SwiftInfo in dep:
-            # TODO(b/151667396): Remove j2objc-specific knowledge.
-            # J2ObjC doesn't expose `CcInfo` directly on the `java_library`
-            # targets it processes, but we can find the compilation context that
-            # was synthesized by `swift_clang_module_aspect` within the
-            # `SwiftInfo` provider.
-            for module in dep[SwiftInfo].direct_modules:
-                clang = module.clang
-                if not clang:
-                    continue
+    for swift_info in swift_infos:
+        for module in swift_info.direct_modules:
+            clang = module.clang
+            if not clang:
+                continue
 
-                if clang.compilation_context:
-                    all_compilation_contexts.append(clang.compilation_context)
-                if clang.strict_includes:
-                    all_compilation_contexts.append(
-                        cc_common.create_compilation_context(
-                            includes = clang.strict_includes,
-                        ),
-                    )
+            if clang.compilation_context:
+                all_compilation_contexts.append(clang.compilation_context)
+            if clang.strict_includes:
+                all_compilation_contexts.append(
+                    cc_common.create_compilation_context(
+                        includes = clang.strict_includes,
+                    ),
+                )
 
-    return cc_common.merge_compilation_contexts(
-        compilation_contexts = all_compilation_contexts,
+    return merge_compilation_contexts(
+        direct_compilation_contexts = all_compilation_contexts,
     )
 
 def expand_locations(ctx, values, targets = []):

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -41,6 +41,7 @@ load(
 load(
     "@build_bazel_rules_swift//swift/internal:providers.bzl",
     "SwiftCompilerPluginInfo",
+    "SwiftInfo",
     "SwiftToolchainInfo",
 )
 load(
@@ -83,6 +84,7 @@ def _swift_compiler_plugin_impl(ctx):
     module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
         actions = ctx.actions,
         additional_inputs = ctx.files.swiftc_inputs,
+        cc_infos = get_providers(deps, CcInfo),
         copts = expand_locations(
             ctx,
             ctx.attr.copts,
@@ -100,13 +102,14 @@ def _swift_compiler_plugin_impl(ctx):
             entry_point_function_name,
         ],
         defines = ctx.attr.defines,
-        deps = deps,
         feature_configuration = feature_configuration,
         include_dev_srch_paths = ctx.attr.testonly,
         module_name = module_name,
+        objc_infos = get_providers(deps, apple_common.Objc),
         package_name = ctx.attr.package_name,
         plugins = get_providers(ctx.attr.plugins, SwiftCompilerPluginInfo),
         srcs = srcs,
+        swift_infos = get_providers(deps, SwiftInfo),
         swift_toolchain = swift_toolchain,
         target_name = ctx.label.name,
         workspace_name = ctx.workspace_name,


### PR DESCRIPTION
The choice to pass `compilation_contexts` separately was a trade-off. The compilation contexts nested inside the Clang modules aren't easily suitable for use here. We can't rely on only the direct modules' CCs because information that should still get propagated—like defines and include paths—would get lost when passing through any `objc_library` that doesn't export a module. And we don't want to process the full set of transitive modules' CCs for each compile action, as this would be a significant performance hit. The only other option considered was to propagate a copy of the CC at the top level of `SwiftInfo`, even for no-module `objc_library` targets, but there were concerns about performance here as well, and whether that context would drift from the real one.

Even with the extra argument, this change makes the compilation API more flexible by removing the assumption that compilation requirements must be expressed as `Target`s. For example, removing the assumption that dependencies propagate `SwiftInfo` directly allows the API to be used inside aspects where the `SwiftInfo` providers may need to be wrapped by a custom provider in order to avoid collisions.

PiperOrigin-RevId: 424979602
(cherry picked from commit bfcae19af93924651911e6bdc669608e9453a774)

---

Cherry-pick notes: In `swift_common.compile` we take in `cc_infos` and `objc_infos` instead of `compilation_contexts` since we still need merged linking information to support  `-disable-autolink-framework`. If we ever remove that feature, we should change `compile` to match `upstream`.