### PR TITLE
Separate `swift_binary` and `swift_test` into their own .bzl files

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -52,7 +52,7 @@ bzl_library(
     deps = [
         ":swift_compiler_plugin",
         "//swift/internal:providers",
-        "//swift/internal:swift_binary_test_rules",
+        "//swift/internal:swift_binary",
         "//swift/internal:swift_common",
         "//swift/internal:swift_extract_symbol_graph",
         "//swift/internal:swift_feature_allowlist",
@@ -63,6 +63,7 @@ bzl_library(
         "//swift/internal:swift_module_alias",
         "//swift/internal:swift_package_configuration",
         "//swift/internal:swift_symbol_graph_aspect",
+        "//swift/internal:swift_test",
         "//swift/internal:swift_usage_aspect",
     ],
 )

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -419,8 +419,23 @@ filegroup(
 )
 
 bzl_library(
-    name = "swift_binary_test_rules",
-    srcs = ["swift_binary_test_rules.bzl"],
+    name = "swift_binary",
+    srcs = ["swift_binary.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        ":compiling",
+        ":derived_files",
+        ":feature_names",
+        ":linking",
+        ":providers",
+        ":swift_common",
+        ":utils",
+    ],
+)
+
+bzl_library(
+    name = "swift_test",
+    srcs = ["swift_test.bzl"],
     visibility = ["//swift:__subpackages__"],
     deps = [
         ":compiling",

--- a/swift/internal/swift_binary.bzl
+++ b/swift/internal/swift_binary.bzl
@@ -1,0 +1,214 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `swift_binary` and `swift_test` rules."""
+
+load(":derived_files.bzl", "derived_files")
+load(":feature_names.bzl", "SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT")
+load(
+    ":linking.bzl",
+    "binary_rule_attrs",
+    "configure_features_for_binary",
+    "malloc_linking_context",
+    "register_link_binary_action",
+)
+load(":output_groups.bzl", "supplemental_compilation_output_groups")
+load(
+    ":providers.bzl",
+    "SwiftCompilerPluginInfo",
+    "SwiftInfo",
+    "SwiftToolchainInfo",
+)
+load(":swift_common.bzl", "swift_common")
+load(
+    ":utils.bzl",
+    "expand_locations",
+    "get_providers",
+    "include_developer_search_paths",
+)
+
+def _maybe_parse_as_library_copts(srcs):
+    """Returns a list of compiler flags depending on `main.swift`'s presence.
+
+    Now that the `@main` attribute exists and is becoming more common, in the
+    case there is a single file not named `main.swift`, we assume that it has a
+    `@main` annotation, in which case it needs to be parsed as a library, not
+    as if it has top level code. In the case this is the wrong assumption,
+    compilation or linking will fail.
+
+    Args:
+        srcs: A list of source files to check for the presence of `main.swift`.
+
+    Returns:
+        A list of compiler flags to add to `copts`
+    """
+    use_parse_as_library = len(srcs) == 1 and \
+                           srcs[0].basename != "main.swift"
+    return ["-parse-as-library"] if use_parse_as_library else []
+
+def _swift_binary_impl(ctx):
+    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+
+    feature_configuration = configure_features_for_binary(
+        ctx = ctx,
+        requested_features = ctx.features,
+        swift_toolchain = swift_toolchain,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    srcs = ctx.files.srcs
+    module_contexts = []
+    additional_linking_contexts = []
+    all_supplemental_outputs = []
+
+    # If the binary has sources, compile those first and collect the outputs to
+    # be passed to the linker.
+    if srcs:
+        module_name = ctx.attr.module_name
+        if not module_name:
+            module_name = swift_common.derive_module_name(ctx.label)
+
+        include_dev_srch_paths = include_developer_search_paths(ctx.attr)
+
+        module_context, cc_compilation_outputs, supplemental_outputs = swift_common.compile(
+            actions = ctx.actions,
+            additional_inputs = ctx.files.swiftc_inputs,
+            cc_infos = get_providers(ctx.attr.deps, CcInfo),
+            copts = expand_locations(
+                ctx,
+                ctx.attr.copts,
+                ctx.attr.swiftc_inputs,
+            ) + _maybe_parse_as_library_copts(srcs),
+            defines = ctx.attr.defines,
+            feature_configuration = feature_configuration,
+            include_dev_srch_paths = include_dev_srch_paths,
+            module_name = module_name,
+            objc_infos = get_providers(ctx.attr.deps, apple_common.Objc),
+            package_name = ctx.attr.package_name,
+            plugins = get_providers(ctx.attr.plugins, SwiftCompilerPluginInfo),
+            srcs = srcs,
+            swift_infos = get_providers(ctx.attr.deps, SwiftInfo),
+            swift_toolchain = swift_toolchain,
+            target_name = ctx.label.name,
+            workspace_name = ctx.workspace_name,
+        )
+        module_contexts.append(module_context)
+        all_supplemental_outputs.append(supplemental_outputs)
+
+        # Unlike `upstream`, we create a linking_context in order to support
+        # `autolink-extract`. See `a1395155c6a27d76aab5e1a93455259a0ac10b2f` and
+        # `93219a3b21390f212f5fd013e8db3654fd09814c`.
+        linking_context, _ = swift_common.create_linking_context_from_compilation_outputs(
+            actions = ctx.actions,
+            alwayslink = True,
+            compilation_outputs = cc_compilation_outputs,
+            feature_configuration = feature_configuration,
+            include_dev_srch_paths = include_dev_srch_paths,
+            label = ctx.label,
+            linking_contexts = [
+                dep[CcInfo].linking_context
+                for dep in ctx.attr.deps
+                if CcInfo in dep
+            ],
+            module_context = module_context,
+            swift_toolchain = swift_toolchain,
+        )
+        additional_linking_contexts.append(linking_context)
+    else:
+        cc_compilation_outputs = cc_common.create_compilation_outputs()
+
+    additional_linking_contexts.append(malloc_linking_context(ctx))
+
+    cc_feature_configuration = swift_common.cc_feature_configuration(
+        feature_configuration = feature_configuration,
+    )
+
+    linking_outputs = register_link_binary_action(
+        actions = ctx.actions,
+        additional_inputs = ctx.files.swiftc_inputs,
+        additional_linking_contexts = additional_linking_contexts,
+        cc_feature_configuration = cc_feature_configuration,
+        # This is already collected from `linking_context`.
+        compilation_outputs = None,
+        deps = ctx.attr.deps,
+        name = derived_files.path(
+            ctx,
+            swift_common.is_enabled(
+                feature_configuration = feature_configuration,
+                feature_name = SWIFT_FEATURE_ADD_TARGET_NAME_TO_OUTPUT,
+            ),
+            ctx.label.name,
+        ),
+        output_type = "executable",
+        owner = ctx.label,
+        stamp = ctx.attr.stamp,
+        swift_toolchain = swift_toolchain,
+        user_link_flags = expand_locations(
+            ctx,
+            ctx.attr.linkopts,
+            ctx.attr.swiftc_inputs,
+        ) + ctx.fragments.cpp.linkopts,
+    )
+
+    return [
+        DefaultInfo(
+            executable = linking_outputs.executable,
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+                files = ctx.files.data,
+            ),
+        ),
+        OutputGroupInfo(
+            **supplemental_compilation_output_groups(
+                *all_supplemental_outputs
+            )
+        ),
+        swift_common.create_swift_info(
+            modules = [
+                swift_common.create_module(
+                    name = module_context.name,
+                    compilation_context = module_context.compilation_context,
+                    # The rest of the fields are intentionally ommited, as we
+                    # only want to expose the compilation_context
+                )
+                for module_context in module_contexts
+            ],
+        ),
+    ]
+
+swift_binary = rule(
+    attrs = binary_rule_attrs(
+        additional_deps_providers = [[SwiftCompilerPluginInfo]],
+        stamp_default = -1,
+    ),
+    doc = """\
+Compiles and links Swift code into an executable binary.
+
+On Linux, this rule produces an executable binary for the desired target
+architecture.
+
+On Apple platforms, this rule produces a _single-architecture_ binary; it does
+not produce fat binaries. As such, this rule is mainly useful for creating Swift
+tools intended to run on the local build machine.
+
+If you want to create a multi-architecture binary or a bundled application,
+please use one of the platform-specific application rules in
+[rules_apple](https://github.com/bazelbuild/rules_apple) instead of
+`swift_binary`.
+""",
+    executable = True,
+    fragments = ["cpp"],
+    implementation = _swift_binary_impl,
+)

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -42,9 +42,8 @@ load(
     _SwiftUsageInfo = "SwiftUsageInfo",
 )
 load(
-    "@build_bazel_rules_swift//swift/internal:swift_binary_test_rules.bzl",
+    "@build_bazel_rules_swift//swift/internal:swift_binary.bzl",
     _swift_binary = "swift_binary",
-    _swift_test = "swift_test",
 )
 load(
     "@build_bazel_rules_swift//swift/internal:swift_clang_module_aspect.bzl",
@@ -91,6 +90,10 @@ load(
     _swift_symbol_graph_aspect = "swift_symbol_graph_aspect",
 )
 load(
+    "@build_bazel_rules_swift//swift/internal:swift_test.bzl",
+    _swift_test = "swift_test",
+)
+load(
     "@build_bazel_rules_swift//swift/internal:swift_usage_aspect.bzl",
     _swift_usage_aspect = "swift_usage_aspect",
 )
@@ -107,10 +110,10 @@ SwiftUsageInfo = _SwiftUsageInfo
 swift_common = _swift_common
 
 # Re-export rules.
-swift_extract_symbol_graph = _swift_extract_symbol_graph
 swift_binary = _swift_binary
 swift_compiler_plugin = _swift_compiler_plugin
 universal_swift_compiler_plugin = _universal_swift_compiler_plugin
+swift_extract_symbol_graph = _swift_extract_symbol_graph
 swift_feature_allowlist = _swift_feature_allowlist
 swift_import = _swift_import
 swift_interop_hint = _swift_interop_hint


### PR DESCRIPTION
The implementation of `swift_test` is becoming more complex and diverging from just a simple binary now that test discovery is supported, so it makes more sense to have these rules live in separate files and move common functionality into `linking.bzl` instead.

PiperOrigin-RevId: 430970577
(cherry picked from commit 9ab07198f2f678451ce627749d9fc90fa441d59d)