### PR TITLE
Cherry-pick `supplemental_compilation_output_groups`

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -7,7 +7,10 @@ exports_files(["copy_swift_sources.sh.tpl"])
 bzl_library(
     name = "swift_proto_utils",
     srcs = ["swift_proto_utils.bzl"],
-    deps = ["@bazel_skylib//lib:paths"],
+    deps = [
+        "//swift/internal:output_groups",
+        "@bazel_skylib//lib:paths",
+    ],
 )
 
 bzl_library(

--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -31,14 +31,14 @@ load(
 
 # buildifier: disable=bzl-visibility
 load(
-    "//swift/internal:compiling.bzl",
-    "output_groups_from_other_compilation_outputs",
+    "//swift/internal:linking.bzl",
+    "new_objc_provider",
 )
 
 # buildifier: disable=bzl-visibility
 load(
-    "//swift/internal:linking.bzl",
-    "new_objc_provider",
+    "//swift/internal:output_groups.bzl",
+    "supplemental_compilation_output_groups",
 )
 
 # buildifier: disable=bzl-visibility
@@ -268,7 +268,7 @@ def compile_swift_protos_for_target(
 
     # Compile the generated Swift source files as a module:
     include_dev_srch_paths = include_developer_search_paths(attr)
-    module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
+    module_context, cc_compilation_outputs, supplemental_outputs = swift_common.compile(
         actions = ctx.actions,
         cc_infos = get_providers(compiler_deps, CcInfo),
         copts = ["-parse-as-library"],
@@ -370,8 +370,8 @@ def compile_swift_protos_for_target(
 
     # Create the direct output group info provider:
     direct_output_group_info = OutputGroupInfo(
-        **output_groups_from_other_compilation_outputs(
-            other_compilation_outputs = other_compilation_outputs,
+        **supplemental_compilation_output_groups(
+            supplemental_outputs,
         )
     )
 

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -35,6 +35,7 @@ bzl_library(
         ":module_name",
         "//swift/internal:compiling",
         "//swift/internal:linking",
+        "//swift/internal:output_groups",
         "//swift/internal:providers",
         "//swift/internal:swift_common",
         "//swift/internal:utils",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -128,6 +128,15 @@ bzl_library(
 )
 
 bzl_library(
+    name = "output_groups",
+    srcs = ["output_groups.bzl"],
+    visibility = [
+        "//proto:__subpackages__",
+        "//swift:__subpackages__",
+    ],
+)
+
+bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
     visibility = ["//swift:__subpackages__"],
@@ -217,6 +226,7 @@ bzl_library(
         ":compiling",
         ":feature_names",
         ":linking",
+        ":output_groups",
         ":providers",
         ":swift_common",
         ":utils",
@@ -248,6 +258,7 @@ bzl_library(
         ":compiling",
         ":derived_files",
         ":linking",
+        ":output_groups",
         ":providers",
         ":swift_common",
         ":utils",
@@ -377,6 +388,7 @@ bzl_library(
         ":env_expansion",
         ":feature_names",
         ":linking",
+        ":output_groups",
         ":providers",
         ":swift_common",
         ":utils",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -3473,47 +3473,6 @@ def _declare_multiple_outputs_and_write_output_file_map(
         derived_files_output_file_map = derived_files_output_map_file,
     )
 
-def output_groups_from_other_compilation_outputs(*, other_compilation_outputs):
-    """Returns a dictionary of output groups from a Swift module context.
-
-    Args:
-        other_compilation_outputs: The value in the third element of the tuple
-            returned by `swift_common.compile`.
-
-    Returns:
-        A `dict` whose keys are the names of output groups and values are
-        `depset`s of `File`s, which can be splatted as keyword arguments to the
-        `OutputGroupInfo` constructor.
-    """
-    output_groups = {}
-
-    if other_compilation_outputs.ast_files:
-        output_groups["swift_ast_file"] = depset(
-            other_compilation_outputs.ast_files,
-        )
-
-    if other_compilation_outputs.indexstore:
-        output_groups["swift_index_store"] = depset([
-            other_compilation_outputs.indexstore,
-        ])
-
-    if other_compilation_outputs.symbol_graph:
-        output_groups["swift_symbol_graph"] = depset([
-            other_compilation_outputs.symbol_graph,
-        ])
-
-    if other_compilation_outputs.macro_expansion_directory:
-        output_groups["macro_expansions"] = depset([
-            other_compilation_outputs.macro_expansion_directory,
-        ])
-
-    if other_compilation_outputs.const_values_files:
-        output_groups["const_values"] = depset(
-            other_compilation_outputs.const_values_files,
-        )
-
-    return output_groups
-
 def swift_library_output_map(name):
     """Returns the dictionary of implicit outputs for a `swift_library`.
 

--- a/swift/internal/output_groups.bzl
+++ b/swift/internal/output_groups.bzl
@@ -1,0 +1,63 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Internal APIs used to compute output groups for compilation rules."""
+
+visibility([
+    "//proto/...",
+    "//swift/...",
+])
+
+def supplemental_compilation_output_groups(*supplemental_outputs):
+    """Computes output groups from supplemental compilation outputs.
+
+    Args:
+        *supplemental_outputs: Zero or more supplemental outputs `struct`s
+            returned from calls to `swift_common.compile`.
+
+    Returns:
+        A dictionary whose keys are output group names and whose values are
+        depsets of `File`s, which is suitable to be `**kwargs`-expanded into an
+        `OutputGroupInfo` provider.
+    """
+    ast_files = []
+    const_values_files = []
+    indexstore_files = []
+    macro_expansions_files = []
+    symbol_graph_files = []
+
+    for outputs in supplemental_outputs:
+        if outputs.ast_files:
+            ast_files.extend(outputs.ast_files)
+        if outputs.const_values_files:
+            const_values_files.extend(outputs.const_values_files)
+        if outputs.indexstore:
+            indexstore_files.append(outputs.indexstore)
+        if outputs.macro_expansion_directory:
+            macro_expansions_files.append(outputs.macro_expansion_directory)
+        if outputs.symbol_graph:
+            symbol_graph_files.append(outputs.symbol_graph)
+
+    output_groups = {}
+    if ast_files:
+        output_groups["swift_ast_file"] = depset(ast_files)
+    if const_values_files:
+        output_groups["const_values"] = depset(const_values_files)
+    if indexstore_files:
+        output_groups["swift_index_store"] = depset(indexstore_files)
+    if macro_expansions_files:
+        output_groups["macro_expansions"] = depset(macro_expansions_files)
+    if symbol_graph_files:
+        output_groups["swift_symbol_graph"] = depset(symbol_graph_files)
+    return output_groups

--- a/swift/internal/swift_binary_test_rules.bzl
+++ b/swift/internal/swift_binary_test_rules.bzl
@@ -15,7 +15,6 @@
 """Implementation of the `swift_binary` and `swift_test` rules."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
 load(":env_expansion.bzl", "expanded_env")
 load(
@@ -29,6 +28,7 @@ load(
     "configure_features_for_binary",
     "register_link_binary_action",
 )
+load(":output_groups.bzl", "supplemental_compilation_output_groups")
 load(
     ":providers.bzl",
     "SwiftCompilerPluginInfo",
@@ -118,7 +118,7 @@ def _swift_linking_rule_impl(
 
         include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 
-        module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
+        module_context, cc_compilation_outputs, supplemental_outputs = swift_common.compile(
             actions = ctx.actions,
             additional_inputs = additional_inputs,
             cc_infos = get_providers(ctx.attr.deps, CcInfo),
@@ -137,8 +137,8 @@ def _swift_linking_rule_impl(
             target_name = ctx.label.name,
             workspace_name = ctx.workspace_name,
         )
-        output_groups = output_groups_from_other_compilation_outputs(
-            other_compilation_outputs = other_compilation_outputs,
+        output_groups = supplemental_compilation_output_groups(
+            supplemental_outputs,
         )
 
         linking_context, _ = swift_common.create_linking_context_from_compilation_outputs(

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -23,11 +23,7 @@ load(
     "PerModuleSwiftCoptSettingInfo",
     "additional_per_module_swiftcopts",
 )
-load(
-    ":compiling.bzl",
-    "output_groups_from_other_compilation_outputs",
-    "swift_library_output_map",
-)
+load(":compiling.bzl", "swift_library_output_map")
 load(
     ":feature_names.bzl",
     "SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE",
@@ -36,6 +32,7 @@ load(
     "SWIFT_FEATURE_SUPPORTS_PRIVATE_DEPS",
 )
 load(":linking.bzl", "new_objc_provider")
+load(":output_groups.bzl", "supplemental_compilation_output_groups")
 load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo", "SwiftToolchainInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
@@ -183,7 +180,7 @@ def _swift_library_impl(ctx):
 
     include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 
-    module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
+    module_context, cc_compilation_outputs, supplemental_outputs = swift_common.compile(
         actions = ctx.actions,
         additional_inputs = additional_inputs,
         cc_infos = get_providers(ctx.attr.deps, CcInfo),
@@ -255,8 +252,8 @@ def _swift_library_impl(ctx):
                 files = ctx.files.data,
             ),
         ),
-        OutputGroupInfo(**output_groups_from_other_compilation_outputs(
-            other_compilation_outputs = other_compilation_outputs,
+        OutputGroupInfo(**supplemental_compilation_output_groups(
+            supplemental_outputs,
         )),
         CcInfo(
             compilation_context = module_context.clang.compilation_context,

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -15,9 +15,9 @@
 """Implementation of the `swift_module_alias` rule."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":compiling.bzl", "output_groups_from_other_compilation_outputs")
 load(":derived_files.bzl", "derived_files")
 load(":linking.bzl", "new_objc_provider")
+load(":output_groups.bzl", "supplemental_compilation_output_groups")
 load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "compact", "get_providers")
@@ -57,7 +57,7 @@ def _swift_module_alias_impl(ctx):
 
     swift_infos = get_providers(deps, SwiftInfo)
 
-    module_context, compilation_outputs, other_compilation_outputs = swift_common.compile(
+    module_context, compilation_outputs, supplemental_outputs = swift_common.compile(
         actions = ctx.actions,
         cc_infos = get_providers(ctx.attr.deps, CcInfo),
         copts = ["-parse-as-library"],
@@ -101,8 +101,8 @@ def _swift_module_alias_impl(ctx):
                 linking_output.library_to_link.static_library,
             ])),
         ),
-        OutputGroupInfo(**output_groups_from_other_compilation_outputs(
-            other_compilation_outputs = other_compilation_outputs,
+        OutputGroupInfo(**supplemental_compilation_output_groups(
+            supplemental_outputs,
         )),
         coverage_common.instrumented_files_info(
             ctx,

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -19,10 +19,6 @@ load("@build_bazel_apple_support//lib:apple_support.bzl", "apple_support")
 load("@build_bazel_apple_support//lib:lipo.bzl", "lipo")
 load("@build_bazel_apple_support//lib:transitions.bzl", "macos_universal_transition")
 load(
-    "@build_bazel_rules_swift//swift/internal:compiling.bzl",
-    "output_groups_from_other_compilation_outputs",
-)
-load(
     "@build_bazel_rules_swift//swift/internal:feature_names.bzl",
     "SWIFT_FEATURE__SUPPORTS_MACROS",
 )
@@ -37,6 +33,10 @@ load(
     "create_linking_context_from_compilation_outputs",
     "malloc_linking_context",
     "register_link_binary_action",
+)
+load(
+    "@build_bazel_rules_swift//swift/internal:output_groups.bzl",
+    "supplemental_compilation_output_groups",
 )
 load(
     "@build_bazel_rules_swift//swift/internal:providers.bzl",
@@ -81,7 +81,7 @@ def _swift_compiler_plugin_impl(ctx):
         module_name = derive_swift_module_name(ctx.label)
     entry_point_function_name = "{}_main".format(module_name)
 
-    module_context, cc_compilation_outputs, other_compilation_outputs = swift_common.compile(
+    module_context, cc_compilation_outputs, supplemental_outputs = swift_common.compile(
         actions = ctx.actions,
         additional_inputs = ctx.files.swiftc_inputs,
         cc_infos = get_providers(deps, CcInfo),
@@ -114,8 +114,8 @@ def _swift_compiler_plugin_impl(ctx):
         target_name = ctx.label.name,
         workspace_name = ctx.workspace_name,
     )
-    output_groups = output_groups_from_other_compilation_outputs(
-        other_compilation_outputs = other_compilation_outputs,
+    output_groups = supplemental_compilation_output_groups(
+        supplemental_outputs,
     )
 
     cc_feature_configuration = swift_common.cc_feature_configuration(


### PR DESCRIPTION
Partial cherry-pick of `supplemental_compilation_output_groups` from 69349eeba42ed7b7365759ba208067b4aa23854d, in order to use it in another cherry-pick.