### PR TITLE
Introduce the `swift_common.get_toolchain` helper function

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -561,6 +561,29 @@ Extracts the symbol graph from a Swift module.
 | <a id="swift_common.extract_symbol_graph-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 
 
+<a id="swift_common.get_toolchain"></a>
+
+## swift_common.get_toolchain
+
+<pre>
+swift_common.get_toolchain(<a href="#swift_common.get_toolchain-ctx">ctx</a>, <a href="#swift_common.get_toolchain-attr">attr</a>)
+</pre>
+
+Gets the Swift toolchain associated with the rule or aspect.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.get_toolchain-ctx"></a>ctx |  The rule or aspect context.   |  none |
+| <a id="swift_common.get_toolchain-attr"></a>attr |  The name of the attribute on the calling rule or aspect that should be used to retrieve the toolchain if it is not provided by the `toolchains` argument of the rule/aspect. Note that this is only supported for legacy/migration purposes and will be removed once migration to toolchains is complete.   |  `"_toolchain"` |
+
+**RETURNS**
+
+A `SwiftToolchainInfo` provider.
+
+
 <a id="swift_common.is_enabled"></a>
 
 ## swift_common.is_enabled

--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -25,7 +25,6 @@ load(
     "SwiftInfo",
     "SwiftProtoCompilerInfo",
     "SwiftProtoInfo",
-    "SwiftToolchainInfo",
     "swift_common",
 )
 
@@ -258,7 +257,7 @@ def compile_swift_protos_for_target(
         ))
 
     # Extract the swift toolchain and configure the features:
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
         requested_features = ctx.features,
@@ -303,7 +302,7 @@ def compile_swift_protos_for_target(
     )
 
     # Extract the swift toolchain and configure the features:
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
         requested_features = ctx.features,

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -177,6 +177,7 @@ bzl_library(
         ":features",
         ":module_maps",
         ":providers",
+        ":toolchain_utils",
         ":utils",
     ],
 )
@@ -193,6 +194,7 @@ bzl_library(
         ":providers",
         ":swift_clang_module_aspect",
         ":symbol_graph_extracting",
+        ":toolchain_utils",
     ],
 )
 
@@ -206,6 +208,7 @@ bzl_library(
         ":features",
         ":providers",
         ":symbol_graph_extracting",
+        ":toolchain_utils",
         ":utils",
         "@bazel_skylib//lib:dicts",
     ],
@@ -352,6 +355,12 @@ bzl_library(
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:types",
     ],
+)
+
+bzl_library(
+    name = "toolchain_utils",
+    srcs = ["toolchain_utils.bzl"],
+    visibility = ["//swift:__subpackages__"],
 )
 
 bzl_library(

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -15,7 +15,7 @@
 """Common attributes used by multiple Swift build rules."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo")
 
 def swift_common_rule_attrs(
         additional_deps_aspects = [],
@@ -390,7 +390,6 @@ def swift_toolchain_attrs(toolchain_attr_name = "_toolchain"):
     return {
         toolchain_attr_name: attr.label(
             default = Label("@build_bazel_rules_swift_local_config//:toolchain"),
-            providers = [[SwiftToolchainInfo]],
         ),
     }
 

--- a/swift/internal/swift_binary.bzl
+++ b/swift/internal/swift_binary.bzl
@@ -24,12 +24,7 @@ load(
     "register_link_binary_action",
 )
 load(":output_groups.bzl", "supplemental_compilation_output_groups")
-load(
-    ":providers.bzl",
-    "SwiftCompilerPluginInfo",
-    "SwiftInfo",
-    "SwiftToolchainInfo",
-)
+load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
 load(
     ":utils.bzl",
@@ -58,7 +53,7 @@ def _maybe_parse_as_library_copts(srcs):
     return ["-parse-as-library"] if use_parse_as_library else []
 
 def _swift_binary_impl(ctx):
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
 
     feature_configuration = configure_features_for_binary(
         ctx = ctx,

--- a/swift/internal/swift_clang_module_aspect.bzl
+++ b/swift/internal/swift_clang_module_aspect.bzl
@@ -31,11 +31,11 @@ load(":module_maps.bzl", "write_module_map")
 load(
     ":providers.bzl",
     "SwiftInfo",
-    "SwiftToolchainInfo",
     "create_clang_module",
     "create_module",
     "create_swift_info",
 )
+load(":toolchain_utils.bzl", "get_swift_toolchain")
 load(":utils.bzl", "compilation_context_for_explicit_module_compilation")
 
 _MULTIPLE_TARGET_ASPECT_ATTRS = [
@@ -838,7 +838,10 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
         ])
         unsupported_features.append(SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS)
 
-    swift_toolchain = aspect_ctx.attr._toolchain_for_aspect[SwiftToolchainInfo]
+    swift_toolchain = get_swift_toolchain(
+        aspect_ctx,
+        attr = "_toolchain_for_aspect",
+    )
     feature_configuration = configure_features(
         ctx = aspect_ctx,
         requested_features = requested_features,

--- a/swift/internal/swift_common.bzl
+++ b/swift/internal/swift_common.bzl
@@ -53,6 +53,7 @@ load(
 )
 load(":swift_clang_module_aspect.bzl", "create_swift_interop_info")
 load(":symbol_graph_extracting.bzl", "extract_symbol_graph")
+load(":toolchain_utils.bzl", "get_swift_toolchain")
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -71,6 +72,7 @@ swift_common = struct(
     create_swift_module = create_swift_module,
     derive_module_name = derive_module_name,
     extract_symbol_graph = extract_symbol_graph,
+    get_toolchain = get_swift_toolchain,
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
     precompile_clang_module = precompile_clang_module,

--- a/swift/internal/swift_import.bzl
+++ b/swift/internal/swift_import.bzl
@@ -17,7 +17,7 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":attrs.bzl", "swift_common_rule_attrs", "swift_toolchain_attrs")
 load(":linking.bzl", "new_objc_provider")
-load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "compact", "get_compilation_contexts", "get_providers")
 
@@ -43,7 +43,7 @@ def _swift_import_impl(ctx):
         fail("One or both of 'swiftinterface' and 'swiftmodule' must be " +
              "specified.")
 
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
         swift_toolchain = swift_toolchain,

--- a/swift/internal/swift_library.bzl
+++ b/swift/internal/swift_library.bzl
@@ -33,7 +33,7 @@ load(
 )
 load(":linking.bzl", "new_objc_provider")
 load(":output_groups.bzl", "supplemental_compilation_output_groups")
-load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
 load(
@@ -130,7 +130,7 @@ def _swift_library_impl(ctx):
     if not module_name:
         module_name = swift_common.derive_module_name(ctx.label)
 
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
         requested_features = ctx.features + extra_features,

--- a/swift/internal/swift_library_group.bzl
+++ b/swift/internal/swift_library_group.bzl
@@ -16,7 +16,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":attrs.bzl", "swift_deps_attr", "swift_toolchain_attrs")
-load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "get_providers")
@@ -28,7 +28,7 @@ def _swift_library_group_impl(ctx):
         for dep in deps
         if CcInfo in dep
     ]
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
 
     return [
         DefaultInfo(),

--- a/swift/internal/swift_module_alias.bzl
+++ b/swift/internal/swift_module_alias.bzl
@@ -18,7 +18,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":derived_files.bzl", "derived_files")
 load(":linking.bzl", "new_objc_provider")
 load(":output_groups.bzl", "supplemental_compilation_output_groups")
-load(":providers.bzl", "SwiftInfo", "SwiftToolchainInfo")
+load(":providers.bzl", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
 load(":utils.bzl", "compact", "get_providers")
 
@@ -47,7 +47,7 @@ def _swift_module_alias_impl(ctx):
         output = reexport_src,
     )
 
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(
         ctx = ctx,
         requested_features = ctx.features,

--- a/swift/internal/swift_symbol_graph_aspect.bzl
+++ b/swift/internal/swift_symbol_graph_aspect.bzl
@@ -18,20 +18,16 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(":attrs.bzl", "swift_toolchain_attrs")
 load(":derived_files.bzl", "derived_files")
 load(":features.bzl", "configure_features")
-load(
-    ":providers.bzl",
-    "SwiftInfo",
-    "SwiftSymbolGraphInfo",
-    "SwiftToolchainInfo",
-)
+load(":providers.bzl", "SwiftInfo", "SwiftSymbolGraphInfo")
 load(":symbol_graph_extracting.bzl", "extract_symbol_graph")
+load(":toolchain_utils.bzl", "get_swift_toolchain")
 load(":utils.bzl", "include_developer_search_paths")
 
 def _swift_symbol_graph_aspect_impl(target, aspect_ctx):
     symbol_graphs = []
 
     if SwiftInfo in target:
-        swift_toolchain = aspect_ctx.attr._toolchain[SwiftToolchainInfo]
+        swift_toolchain = get_swift_toolchain(aspect_ctx)
         feature_configuration = configure_features(
             ctx = aspect_ctx,
             swift_toolchain = swift_toolchain,

--- a/swift/internal/swift_test.bzl
+++ b/swift/internal/swift_test.bzl
@@ -34,7 +34,6 @@ load(
     "SwiftCompilerPluginInfo",
     "SwiftInfo",
     "SwiftSymbolGraphInfo",
-    "SwiftToolchainInfo",
 )
 load(":swift_common.bzl", "swift_common")
 load(":swift_symbol_graph_aspect.bzl", "test_discovery_symbol_graph_aspect")
@@ -170,7 +169,7 @@ def _generate_test_discovery_srcs(*, actions, deps, name, test_discoverer):
     return outputs
 
 def _swift_test_impl(ctx):
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
 
     feature_configuration = configure_features_for_binary(
         ctx = ctx,

--- a/swift/internal/swift_toolchain.bzl
+++ b/swift/internal/swift_toolchain.bzl
@@ -424,44 +424,51 @@ def _swift_toolchain_impl(ctx):
     # TODO(allevato): Move some of the remaining hardcoded values, like object
     # format and Obj-C interop support, to attributes so that we can remove the
     # assumptions that are only valid on Linux.
-    return [
-        SwiftToolchainInfo(
-            action_configs = all_action_configs,
-            cc_toolchain_info = cc_toolchain,
-            clang_implicit_deps_providers = (
-                collect_implicit_deps_providers([])
-            ),
-            developer_dirs = [],
-            entry_point_linkopts_provider = _entry_point_linkopts_provider,
-            feature_allowlists = [
-                target[SwiftFeatureAllowlistInfo]
-                for target in ctx.attr.feature_allowlists
-            ],
-            generated_header_module_implicit_deps_providers = (
-                collect_implicit_deps_providers([])
-            ),
-            implicit_deps_providers = collect_implicit_deps_providers(
-                [],
-                additional_cc_infos = [swift_linkopts_cc_info],
-            ),
-            package_configurations = [
-                target[SwiftPackageConfigurationInfo]
-                for target in ctx.attr.package_configurations
-            ],
-            requested_features = requested_features,
-            root_dir = toolchain_root,
-            swift_worker = ctx.attr._worker[DefaultInfo].files_to_run,
-            const_protocols_to_gather = ctx.file.const_protocols_to_gather,
-            test_configuration = struct(
-                env = env,
-                execution_requirements = {},
-            ),
-            tool_configs = all_tool_configs,
-            unsupported_features = ctx.disabled_features + [
-                SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
-                SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE,
-            ],
+    swift_toolchain_info = SwiftToolchainInfo(
+        action_configs = all_action_configs,
+        cc_toolchain_info = cc_toolchain,
+        clang_implicit_deps_providers = (
+            collect_implicit_deps_providers([])
         ),
+        developer_dirs = [],
+        entry_point_linkopts_provider = _entry_point_linkopts_provider,
+        feature_allowlists = [
+            target[SwiftFeatureAllowlistInfo]
+            for target in ctx.attr.feature_allowlists
+        ],
+        generated_header_module_implicit_deps_providers = (
+            collect_implicit_deps_providers([])
+        ),
+        implicit_deps_providers = collect_implicit_deps_providers(
+            [],
+            additional_cc_infos = [swift_linkopts_cc_info],
+        ),
+        package_configurations = [
+            target[SwiftPackageConfigurationInfo]
+            for target in ctx.attr.package_configurations
+        ],
+        requested_features = requested_features,
+        root_dir = toolchain_root,
+        swift_worker = ctx.attr._worker[DefaultInfo].files_to_run,
+        const_protocols_to_gather = ctx.file.const_protocols_to_gather,
+        test_configuration = struct(
+            env = env,
+            execution_requirements = {},
+        ),
+        tool_configs = all_tool_configs,
+        unsupported_features = ctx.disabled_features + [
+            SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
+            SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE,
+        ],
+    )
+
+    return [
+        platform_common.ToolchainInfo(
+            swift_toolchain = swift_toolchain_info,
+        ),
+        # TODO(b/205018581): Remove this legacy propagation when everything is
+        # migrated over to new-style toolchains.
+        swift_toolchain_info,
     ]
 
 swift_toolchain = rule(

--- a/swift/internal/toolchain_utils.bzl
+++ b/swift/internal/toolchain_utils.bzl
@@ -1,0 +1,44 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers used to depend on and access the Swift toolchain."""
+
+SWIFT_TOOLCHAIN_TYPE = "@build_bazel_rules_swift//toolchains:toolchain_type"
+
+def get_swift_toolchain(ctx, attr = "_toolchain"):
+    """Gets the Swift toolchain associated with the rule or aspect.
+
+    Args:
+        ctx: The rule or aspect context.
+        attr: The name of the attribute on the calling rule or aspect that
+            should be used to retrieve the toolchain if it is not provided by
+            the `toolchains` argument of the rule/aspect. Note that this is only
+            supported for legacy/migration purposes and will be removed once
+            migration to toolchains is complete.
+
+    Returns:
+        A `SwiftToolchainInfo` provider.
+    """
+    if SWIFT_TOOLCHAIN_TYPE in ctx.toolchains:
+        return ctx.toolchains[SWIFT_TOOLCHAIN_TYPE].swift_toolchain
+
+    # TODO(b/205018581): Delete this code path when migration to the new
+    # toolchain APIs is complete.
+    toolchain_target = getattr(ctx.attr, attr, None)
+    if toolchain_target and platform_common.ToolchainInfo in toolchain_target:
+        return toolchain_target[platform_common.ToolchainInfo].swift_toolchain
+
+    fail("To use `swift_common.get_toolchain`, you must declare the " +
+         "toolchain in your rule using " +
+         "`toolchains = [swift_common.toolchain_type()]`.")

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -708,45 +708,52 @@ def _xcode_swift_toolchain_impl(ctx):
             ),
         )
 
-    return [
-        SwiftToolchainInfo(
-            action_configs = all_action_configs,
-            cc_toolchain_info = cc_toolchain,
-            clang_implicit_deps_providers = collect_implicit_deps_providers(
-                ctx.attr.clang_implicit_deps,
-            ),
-            developer_dirs = swift_toolchain_developer_paths,
-            entry_point_linkopts_provider = _entry_point_linkopts_provider,
-            feature_allowlists = [
-                target[SwiftFeatureAllowlistInfo]
-                for target in ctx.attr.feature_allowlists
-            ],
-            generated_header_module_implicit_deps_providers = (
-                collect_implicit_deps_providers(
-                    ctx.attr.generated_header_module_implicit_deps,
-                )
-            ),
-            implicit_deps_providers = collect_implicit_deps_providers(
-                ctx.attr.implicit_deps + ctx.attr.clang_implicit_deps,
-                additional_cc_infos = [swift_linkopts_providers.cc_info],
-                additional_objc_infos = [swift_linkopts_providers.objc_info],
-            ),
-            package_configurations = [
-                target[SwiftPackageConfigurationInfo]
-                for target in ctx.attr.package_configurations
-            ],
-            requested_features = requested_features,
-            swift_worker = ctx.attr._worker[DefaultInfo].files_to_run,
-            const_protocols_to_gather = ctx.file.const_protocols_to_gather,
-            test_configuration = struct(
-                env = env,
-                execution_requirements = execution_requirements,
-            ),
-            tool_configs = all_tool_configs,
-            unsupported_features = ctx.disabled_features + [
-                SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
-            ],
+    swift_toolchain_info = SwiftToolchainInfo(
+        action_configs = all_action_configs,
+        cc_toolchain_info = cc_toolchain,
+        clang_implicit_deps_providers = collect_implicit_deps_providers(
+            ctx.attr.clang_implicit_deps,
         ),
+        developer_dirs = swift_toolchain_developer_paths,
+        entry_point_linkopts_provider = _entry_point_linkopts_provider,
+        feature_allowlists = [
+            target[SwiftFeatureAllowlistInfo]
+            for target in ctx.attr.feature_allowlists
+        ],
+        generated_header_module_implicit_deps_providers = (
+            collect_implicit_deps_providers(
+                ctx.attr.generated_header_module_implicit_deps,
+            )
+        ),
+        implicit_deps_providers = collect_implicit_deps_providers(
+            ctx.attr.implicit_deps + ctx.attr.clang_implicit_deps,
+            additional_cc_infos = [swift_linkopts_providers.cc_info],
+            additional_objc_infos = [swift_linkopts_providers.objc_info],
+        ),
+        package_configurations = [
+            target[SwiftPackageConfigurationInfo]
+            for target in ctx.attr.package_configurations
+        ],
+        requested_features = requested_features,
+        swift_worker = ctx.attr._worker[DefaultInfo].files_to_run,
+        const_protocols_to_gather = ctx.file.const_protocols_to_gather,
+        test_configuration = struct(
+            env = env,
+            execution_requirements = execution_requirements,
+        ),
+        tool_configs = all_tool_configs,
+        unsupported_features = ctx.disabled_features + [
+            SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
+        ],
+    )
+
+    return [
+        platform_common.ToolchainInfo(
+            swift_toolchain = swift_toolchain_info,
+        ),
+        # TODO(b/205018581): Remove this legacy propagation when everything is
+        # migrated over to new-style toolchains.
+        swift_toolchain_info,
     ]
 
 xcode_swift_toolchain = rule(

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -42,7 +42,6 @@ load(
     "@build_bazel_rules_swift//swift/internal:providers.bzl",
     "SwiftCompilerPluginInfo",
     "SwiftInfo",
-    "SwiftToolchainInfo",
 )
 load(
     "@build_bazel_rules_swift//swift/internal:swift_common.bzl",
@@ -56,7 +55,7 @@ load(
 load(":module_name.bzl", "derive_swift_module_name")
 
 def _swift_compiler_plugin_impl(ctx):
-    swift_toolchain = ctx.attr._toolchain[SwiftToolchainInfo]
+    swift_toolchain = swift_common.get_toolchain(ctx)
 
     feature_configuration = configure_features_for_binary(
         ctx = ctx,


### PR DESCRIPTION
This is change 1 of _N_ to migrate the Swift build rules to use new-style Bazel toolchains. This change:

*   Updates the toolchain configuration rules to wrap the `SwiftToolchainInfo` provider in `platform_common.ToolchainInfo`, for future use by `toolchain()` rules.
*   Funnels all toolchain access through a new `swift_toolchain.get_toolchain()` function that looks up the toolchain using `ctx.toolchains`, falling back to the implicit attribute.

Since `ctx.toolchains` isn't defined yet, the second change is a no-op but it simplifies future parts of the migration.

PiperOrigin-RevId: 439638938
(cherry picked from commit 884e54426535acb820c746ccff074546b5796402)