### PR TITLE
Add the `-Xwrapped-swift=-bazel-target-label=...` flag to pass the label of the target that spawns the worker, for future diagnostic purposes

### DIFF
--- a/swift/internal/autolinking.bzl
+++ b/swift/internal/autolinking.bzl
@@ -73,6 +73,7 @@ def register_autolink_extract_action(
     prerequisites = struct(
         autolink_file = autolink_file,
         object_files = object_files,
+        target_label = feature_configuration._label,
     )
     run_toolchain_action(
         actions = actions,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -2266,6 +2266,7 @@ def compile_module_interface(
         objc_info = None,
         source_files = [swiftinterface_file],
         swiftmodule_file = swiftmodule_file,
+        target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
         transitive_swiftmodules = transitive_swiftmodules,
         user_compile_flags = [],
@@ -2624,6 +2625,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         objc_info = merged_objc_info,
         plugins = depset(used_plugins),
         source_files = srcs,
+        target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
         transitive_swiftmodules = transitive_swiftmodules,
         user_compile_flags = copts,
@@ -2921,6 +2923,7 @@ def _precompile_clang_module(
         objc_info = apple_common.new_objc_provider(),
         pcm_file = precompiled_module,
         source_files = [module_map_file],
+        target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
     )
 

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -189,6 +189,7 @@ def _register_modulewrap_action(
     prerequisites = struct(
         object_file = object,
         swiftmodule_file = swiftmodule,
+        target_label = feature_configuration._label,
     )
     run_toolchain_action(
         actions = actions,

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -123,6 +123,10 @@ def configure_features(
         # other APIs, so they don't have to be passed manually by the callers.
         _bin_dir = ctx.bin_dir,
         _genfiles_dir = ctx.genfiles_dir,
+        # Capture the label of the calling target so that it can be passed to
+        # the worker as additional context, without requiring the user to pass
+        # it in separately.
+        _label = ctx.label,
     )
 
 def features_for_build_modes(ctx, cpp_fragment = None):

--- a/swift/internal/symbol_graph_extracting.bzl
+++ b/swift/internal/symbol_graph_extracting.bzl
@@ -127,6 +127,7 @@ def extract_symbol_graph(
         minimum_access_level = minimum_access_level,
         module_name = module_name,
         output_dir = output_dir,
+        target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
         transitive_swiftmodules = transitive_swiftmodules,
     )

--- a/swift/internal/xcode_swift_toolchain.bzl
+++ b/swift/internal/xcode_swift_toolchain.bzl
@@ -25,7 +25,7 @@ load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
-load(":actions.bzl", "swift_action_names")
+load(":actions.bzl", "swift_action_names", "target_label_action_configs")
 load(":attrs.bzl", "swift_toolchain_driver_attrs")
 load(":compiling.bzl", "compile_action_configs", "features_from_swiftcopts")
 load(
@@ -422,12 +422,14 @@ def _all_action_configs(
             ),
         )
 
+    action_configs.extend(target_label_action_configs())
     action_configs.extend(compile_action_configs(
         additional_objc_copts = additional_objc_copts,
         additional_swiftc_copts = additional_swiftc_copts,
         generated_header_rewriter = generated_header_rewriter,
     ))
     action_configs.extend(symbol_graph_action_configs())
+
     return action_configs
 
 def _all_tool_configs(

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -325,6 +325,8 @@ bool SwiftRunner::ProcessArgument(
         changed = true;
       } else if (StripPrefix("-generated-header-rewriter=", new_arg)) {
         changed = true;
+      } else if (StripPrefix("-bazel-target-label=", new_arg)) {
+        changed = true;
       } else if (StripPrefix("-global-index-store-import-path=", new_arg)) {
         changed = true;
       } else {
@@ -386,6 +388,8 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
         global_index_store_import_path_ = arg;
       } else if (StripPrefix("-generated-header-rewriter=", arg)) {
         generated_header_rewriter_path_ = arg;
+      } else if (StripPrefix("-bazel-target-label=", arg)) {
+        target_label_ = arg;
       } else if (arg == "-file-prefix-pwd-is-dot") {
         file_prefix_pwd_is_dot_ = true;
       }

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -155,6 +155,10 @@ class SwiftRunner {
   // this compilation.
   std::string generated_header_rewriter_path_;
 
+  // The Bazel target label that spawned the worker request, which can be used
+  // in custom diagnostic messages printed by the worker.
+  std::string target_label_;
+
   // The path of the output map file
   std::string output_file_map_path_;
 


### PR DESCRIPTION
PiperOrigin-RevId: 439679495
(cherry picked from commit 4cc310d33290df290b729334eb6aead6127867cf)