### PR TITLE
Temporarily disable Windows CI due to missing Swift binary

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -120,10 +120,11 @@ tasks:
       - .bazelci/update_workspace_to_deps_heads.sh
     <<: *linux_common
 
-  windows_last_green:
-    name: "Last Green Bazel"
-    bazel: last_green
-    <<: *windows_common
+  # TODO: re-enable when Windows in Bazel CI is properly configured for Swift.
+  # windows_last_green:
+  #   name: "Last Green Bazel"
+  #   bazel: last_green
+  #   <<: *windows_common
 
   doc_tests:
     name: "Doc tests"


### PR DESCRIPTION
Bazel CI Windows machines do not have Swift.exe installed and builds fail. Temporarily disable this until Windows machines are properly configured for Swift.