### PR TITLE
Update `load` statements in `rules_swift` to use the build-definition-specific files instead of the umbrella `swift.bzl`

### DIFF
--- a/examples/apple/objc_interop/BUILD
+++ b/examples/apple/objc_interop/BUILD
@@ -2,11 +2,8 @@
 # vice versa when it is linked into the existing native linking rules for Apple
 # platforms.
 
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_library",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
 
 licenses(["notice"])
 

--- a/examples/apple/objc_interop_modulemap/BUILD
+++ b/examples/apple/objc_interop_modulemap/BUILD
@@ -2,11 +2,8 @@
 # vice versa when it is linked into the existing native linking rules for Apple
 # platforms.
 
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_library",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
 
 licenses(["notice"])
 

--- a/examples/apple/test_filter/BUILD
+++ b/examples/apple/test_filter/BUILD
@@ -1,8 +1,5 @@
-load(
-    "//swift:swift.bzl",
-    "swift_library",
-    "swift_test",
-)
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_test.bzl", "swift_test")
 
 swift_library(
     name = "test_filter_lib",

--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -1,9 +1,6 @@
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_interop_hint",
-    "swift_library",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
+load("//swift:swift_library.bzl", "swift_library")
 
 licenses(["notice"])
 

--- a/examples/xplatform/custom_swift_proto_compiler/rules/custom_swift_proto_compiler.bzl
+++ b/examples/xplatform/custom_swift_proto_compiler/rules/custom_swift_proto_compiler.bzl
@@ -25,10 +25,7 @@ load(
     "SwiftProtoCompilerInfo",
     "swift_proto_common",
 )
-load(
-    "//swift:swift.bzl",
-    "SwiftInfo",
-)
+load("//swift:providers.bzl", "SwiftInfo")
 
 def _custom_swift_proto_compile(label, actions, swift_proto_compiler_info, additional_compiler_info, proto_infos, module_mappings):
     """Compiles Swift source files from `ProtoInfo` providers.

--- a/examples/xplatform/dispatch/BUILD
+++ b/examples/xplatform/dispatch/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_binary")
+load("//swift:swift_binary.bzl", "swift_binary")
 
 licenses(["notice"])
 

--- a/examples/xplatform/grpc/BUILD
+++ b/examples/xplatform/grpc/BUILD
@@ -10,11 +10,8 @@
 # 3.  Run the `echo_client` binary in the same terminal. It will send a request
 #     to this service and then print the response that it received.
 
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_test",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_test.bzl", "swift_test")
 
 licenses(["notice"])
 

--- a/examples/xplatform/hello_world/BUILD
+++ b/examples/xplatform/hello_world/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_binary")
+load("//swift:swift_binary.bzl", "swift_binary")
 
 licenses(["notice"])
 

--- a/examples/xplatform/include_dev_srch_paths/BUILD
+++ b/examples/xplatform/include_dev_srch_paths/BUILD
@@ -1,4 +1,6 @@
-load("//swift:swift.bzl", "swift_library", "swift_library_group", "swift_test")
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_library_group.bzl", "swift_library_group")
+load("//swift:swift_test.bzl", "swift_test")
 
 swift_library(
     name = "TestHelpers",

--- a/examples/xplatform/macros/BUILD
+++ b/examples/xplatform/macros/BUILD
@@ -1,5 +1,7 @@
-load("//swift:swift.bzl", "swift_binary", "swift_library", "swift_test")
+load("//swift:swift_binary.bzl", "swift_binary")
 load("//swift:swift_compiler_plugin.bzl", "swift_compiler_plugin", "universal_swift_compiler_plugin")
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_test.bzl", "swift_test")
 
 licenses(["notice"])
 

--- a/examples/xplatform/module_alias/BUILD
+++ b/examples/xplatform/module_alias/BUILD
@@ -1,4 +1,6 @@
-load("//swift:swift.bzl", "swift_binary", "swift_library", "swift_module_alias")
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_module_alias.bzl", "swift_module_alias")
 
 swift_binary(
     name = "hello_world",

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -6,10 +6,7 @@ load(
     "//proto:proto.bzl",
     "swift_proto_library",
 )
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
 
 licenses(["notice"])
 

--- a/examples/xplatform/proto_files/BUILD
+++ b/examples/xplatform/proto_files/BUILD
@@ -6,10 +6,7 @@ load(
     "//proto:proto.bzl",
     "swift_proto_library",
 )
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
 
 proto_library(
     name = "message_1_proto",

--- a/examples/xplatform/proto_glob/BUILD
+++ b/examples/xplatform/proto_glob/BUILD
@@ -6,10 +6,7 @@ load(
     "//proto:proto.bzl",
     "swift_proto_library",
 )
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
 
 proto_library(
     name = "proto_glob",

--- a/examples/xplatform/proto_library_group/BUILD
+++ b/examples/xplatform/proto_library_group/BUILD
@@ -1,8 +1,5 @@
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_test",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_test.bzl", "swift_test")
 
 swift_binary(
     name = "echo_server",

--- a/examples/xplatform/proto_path/BUILD
+++ b/examples/xplatform/proto_path/BUILD
@@ -1,7 +1,4 @@
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "proto_path_example",

--- a/examples/xplatform/swift_import/BUILD
+++ b/examples/xplatform/swift_import/BUILD
@@ -1,5 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//swift:swift.bzl", "swift_binary", "swift_import", "swift_library")
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_import.bzl", "swift_import")
+load("//swift:swift_library.bzl", "swift_library")
 load(":get_swiftmodule.bzl", "get_swiftmodule")
 
 swift_binary(

--- a/examples/xplatform/swift_import/get_swiftmodule.bzl
+++ b/examples/xplatform/swift_import/get_swiftmodule.bzl
@@ -1,6 +1,6 @@
 """Return the .swiftmodule file from a swift_library for testing"""
 
-load("//swift:swift.bzl", "SwiftInfo")
+load("//swift:providers.bzl", "SwiftInfo")
 
 def _impl(ctx):
     modules = ctx.attr.lib[SwiftInfo].direct_modules

--- a/examples/xplatform/xctest/BUILD
+++ b/examples/xplatform/xctest/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_test")
+load("//swift:swift_test.bzl", "swift_test")
 
 licenses(["notice"])
 

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -31,7 +31,7 @@ load(
     _swift_proto_library_group = "swift_proto_library_group",
 )
 load(
-    "//swift:swift.bzl",
+    "//swift:providers.bzl",
     _SwiftProtoCompilerInfo = "SwiftProtoCompilerInfo",
     _SwiftProtoInfo = "SwiftProtoInfo",
 )

--- a/proto/swift_proto_compiler.bzl
+++ b/proto/swift_proto_compiler.bzl
@@ -28,11 +28,7 @@ load(
     "//proto:swift_proto_utils.bzl",
     "register_module_mapping_write_action",
 )
-load(
-    "//swift:swift.bzl",
-    "SwiftInfo",
-    "SwiftProtoCompilerInfo",
-)
+load("//swift:providers.bzl", "SwiftInfo", "SwiftProtoCompilerInfo")
 
 def _swift_proto_compile(label, actions, swift_proto_compiler_info, additional_compiler_info, proto_infos, module_mappings):
     """Compiles Swift source files from `ProtoInfo` providers.
@@ -315,7 +311,7 @@ For example:
         ),
         "plugin_name": attr.string(
             doc = """\
-Name of the proto compiler plugin passed to protoc. 
+Name of the proto compiler plugin passed to protoc.
 
 For example:
 

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -28,15 +28,9 @@ load(
     "//proto:swift_proto_utils.bzl",
     "compile_swift_protos_for_target",
 )
-load(
-    "//swift:swift.bzl",
-    "SwiftProtoCompilerInfo",
-    "swift_common",
-)
-load(
-    "//swift:swift_clang_module_aspect.bzl",
-    "swift_clang_module_aspect",
-)
+load("//swift:providers.bzl", "SwiftProtoCompilerInfo")
+load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
+load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
 load(

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -30,12 +30,12 @@ load(
     "compile_swift_protos_for_target",
 )
 load(
-    "//swift:swift.bzl",
+    "//swift:providers.bzl",
     "SwiftInfo",
     "SwiftProtoCompilerInfo",
     "SwiftProtoInfo",
-    "swift_common",
 )
+load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
 load(
@@ -160,19 +160,19 @@ from which the Swift source files should be generated.
 Generates a collection of Swift static library from a target producing `ProtoInfo` and its dependencies.
 
 This rule is intended to facilitate migration from the deprecated swift proto library rules to the new ones.
-Unlike `swift_proto_library` which is a drop-in-replacement for `swift_library`, 
+Unlike `swift_proto_library` which is a drop-in-replacement for `swift_library`,
 this rule uses an aspect over the direct proto library dependency and its transitive dependencies,
 compiling each into a swift static library.
 
 For example, in the following targets, the `proto_library_group_swift_proto` target only depends on
 `package_2_proto` target, and this transitively depends on `package_1_proto`.
 
-When used as a dependency from a `swift_library` or `swift_binary` target, 
-two modules generated from these proto library targets are visible. 
+When used as a dependency from a `swift_library` or `swift_binary` target,
+two modules generated from these proto library targets are visible.
 
 Because these are derived from the proto library targets via an aspect, though,
 you cannot customize many of the attributes including the swift proto compiler targets or
-the module names. The module names are derived from the proto library names. 
+the module names. The module names are derived from the proto library names.
 
 In this case, the module names are:
 ```

--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -21,12 +21,12 @@ load(
     "paths",
 )
 load(
-    "//swift:swift.bzl",
+    "//swift:providers.bzl",
     "SwiftInfo",
     "SwiftProtoCompilerInfo",
     "SwiftProtoInfo",
-    "swift_common",
 )
+load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
 load(

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -46,7 +46,10 @@ bzl_library(
 bzl_library(
     name = "providers",
     srcs = ["providers.bzl"],
-    visibility = ["//swift:__subpackages__"],
+    visibility = [
+        "//swift:__subpackages__",
+        "//test:__subpackages__",
+    ],
     deps = [
         "@bazel_skylib//lib:sets",
         "@bazel_skylib//lib:types",
@@ -96,6 +99,7 @@ bzl_library(
     visibility = [
         "//proto:__subpackages__",
         "//swift:__subpackages__",
+        "//test:__subpackages__",
     ],
     deps = [
         ":providers",

--- a/test/fixtures/BUILD
+++ b/test/fixtures/BUILD
@@ -5,7 +5,10 @@ package(default_visibility = ["//test:__subpackages__"])
 bzl_library(
     name = "starlark_tests_bzls",
     srcs = glob(["*.bzl"]),
-    deps = ["//swift"],
+    deps = [
+        "//swift:providers",
+        "//swift:swift_clang_module_aspect",
+    ],
 )
 
 bzl_library(

--- a/test/fixtures/basic/BUILD
+++ b/test/fixtures/basic/BUILD
@@ -1,4 +1,5 @@
-load("//swift:swift.bzl", "swift_library", "swift_library_group")
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_library_group.bzl", "swift_library_group")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/cc_library/BUILD
+++ b/test/fixtures/cc_library/BUILD
@@ -1,6 +1,9 @@
 load(
-    "//swift:swift.bzl",
+    "//swift:swift_interop_hint.bzl",
     "swift_interop_hint",
+)
+load(
+    "//swift:swift_library.bzl",
     "swift_library",
 )
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")

--- a/test/fixtures/common.bzl
+++ b/test/fixtures/common.bzl
@@ -14,9 +14,9 @@
 
 """Common build definitions used by test fixtures."""
 
+load("@build_bazel_rules_swift//swift:providers.bzl", "SwiftInfo")
 load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
+    "@build_bazel_rules_swift//swift:swift_clang_module_aspect.bzl",
     "swift_clang_module_aspect",
 )
 

--- a/test/fixtures/compiler_arguments/BUILD
+++ b/test/fixtures/compiler_arguments/BUILD
@@ -1,4 +1,6 @@
-load("//swift:swift.bzl", "swift_binary", "swift_library", "swift_test")
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_test.bzl", "swift_test")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/debug_settings/BUILD
+++ b/test/fixtures/debug_settings/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_library")
+load(
+    "//swift:swift_library.bzl",
+    "swift_library",
+)
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/generated_header/BUILD
+++ b/test/fixtures/generated_header/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_library")
+load(
+    "//swift:swift_library.bzl",
+    "swift_library",
+)
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/global_index_store/BUILD
+++ b/test/fixtures/global_index_store/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_library")
+load("//swift:swift_library.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/interop_hints/BUILD
+++ b/test/fixtures/interop_hints/BUILD
@@ -1,6 +1,9 @@
 load(
-    "//swift:swift.bzl",
+    "//swift:swift_interop_hint.bzl",
     "swift_interop_hint",
+)
+load(
+    "//swift:swift_library.bzl",
     "swift_library",
 )
 load(

--- a/test/fixtures/linking/BUILD
+++ b/test/fixtures/linking/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//swift:swift.bzl", "swift_binary", "swift_library")
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 load(":fake_framework.bzl", "fake_framework")
 

--- a/test/fixtures/mainattr/BUILD
+++ b/test/fixtures/mainattr/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_binary")
+load("//swift:swift_binary.bzl", "swift_binary")
 
 package(
     default_visibility = ["//test:__subpackages__"],

--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -1,13 +1,7 @@
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_import",
-    "swift_library",
-)
-load(
-    "//test/fixtures:common.bzl",
-    "FIXTURE_TAGS",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_import.bzl", "swift_import")
+load("//swift:swift_library.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 load(
     "//test/rules:swift_library_artifact_collector.bzl",
     "swift_library_artifact_collector",

--- a/test/fixtures/multiple_files/BUILD
+++ b/test/fixtures/multiple_files/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_library")
+load("//swift:swift_library.bzl", "swift_library")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/private_deps/BUILD
+++ b/test/fixtures/private_deps/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_library")
+load(
+    "//swift:swift_library.bzl",
+    "swift_library",
+)
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/private_swiftinterface/BUILD
+++ b/test/fixtures/private_swiftinterface/BUILD
@@ -18,16 +18,10 @@ This rule is used in tests to simulate "pre-built" artifacts without having to
 check them in directly.
 """
 
-load(
-    "//swift:swift.bzl",
-    "swift_binary",
-    "swift_import",
-    "swift_library",
-)
-load(
-    "//test/fixtures:common.bzl",
-    "FIXTURE_TAGS",
-)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_import.bzl", "swift_import")
+load("//swift:swift_library.bzl", "swift_library")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 load(
     "//test/rules:swift_library_artifact_collector.bzl",
     "swift_library_artifact_collector",

--- a/test/fixtures/swift_through_non_swift/BUILD
+++ b/test/fixtures/swift_through_non_swift/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_library")
+load(
+    "//swift:swift_library.bzl",
+    "swift_library",
+)
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/fixtures/symbol_graphs/BUILD
+++ b/test/fixtures/symbol_graphs/BUILD
@@ -1,6 +1,9 @@
 load(
-    "//swift:swift.bzl",
+    "//swift:swift_extract_symbol_graph.bzl",
     "swift_extract_symbol_graph",
+)
+load(
+    "//swift:swift_library.bzl",
     "swift_library",
 )
 load(

--- a/test/fixtures/xctest_runner/BUILD
+++ b/test/fixtures/xctest_runner/BUILD
@@ -1,4 +1,4 @@
-load("//swift:swift.bzl", "swift_test")
+load("//swift:swift_test.bzl", "swift_test")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
 
 package(

--- a/test/rules/provider_test.bzl
+++ b/test/rules/provider_test.bzl
@@ -21,7 +21,7 @@ load(
     "asserts",
     "unittest",
 )
-load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
+load("//swift:providers.bzl", "SwiftInfo")
 
 # A sentinel value returned by `_evaluate_field` when a `None` value is
 # encountered during the evaluation of a dotted path on any component other than

--- a/test/rules/swift_library_artifact_collector.bzl
+++ b/test/rules/swift_library_artifact_collector.bzl
@@ -18,10 +18,7 @@ This rule is used in tests to simulate "pre-built" artifacts without having to
 check them in directly.
 """
 
-load(
-    "@build_bazel_rules_swift//swift:swift.bzl",
-    "SwiftInfo",
-)
+load("//swift:providers.bzl", "SwiftInfo")
 
 def _swiftinterface_transition_impl(_settings, attr):
     return {

--- a/test/swift_bzl_macro.bzl
+++ b/test/swift_bzl_macro.bzl
@@ -3,7 +3,7 @@
 For more information, please see `bzl_test.bzl`.
 """
 
-load("//swift:swift.bzl", "SwiftInfo")
+load("//swift:providers.bzl", "SwiftInfo")
 
 def macro_with_doc(name):
     """This macro does nothing.

--- a/tools/test_discoverer/BUILD
+++ b/tools/test_discoverer/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_binary")
+load(
+    "//swift:swift_binary.bzl",
+    "swift_binary",
+)
 
 swift_binary(
     name = "test_discoverer",

--- a/tools/test_observer/BUILD
+++ b/tools/test_observer/BUILD
@@ -1,4 +1,7 @@
-load("//swift:swift.bzl", "swift_library")
+load(
+    "//swift:swift_library.bzl",
+    "swift_library",
+)
 
 swift_library(
     name = "test_observer",


### PR DESCRIPTION
PiperOrigin-RevId: 449278388
(cherry picked from commit 828d1064713b19bded428144cbb80d7138aa95bc)