### PR TITLE
Deprecate the umbrella `proto.bzl` file

### DIFF
--- a/doc/doc.bzl
+++ b/doc/doc.bzl
@@ -22,25 +22,31 @@ For example:
 
 ```build
 load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
-load("@build_bazel_rules_swift//proto:proto.bzl", "swift_proto_library")
+load("@build_bazel_rules_swift//proto:swift_proto_library.bzl", "swift_proto_library")
 ```
 """
 
 load(
-    "//proto:proto.bzl",
-    # providers
-    _SwiftProtoCompilerInfo = "SwiftProtoCompilerInfo",
-    _SwiftProtoInfo = "SwiftProtoInfo",
-    # api
+    "//proto:swift_proto_common.bzl",
     _swift_proto_common = "swift_proto_common",
-    # rules
+)
+load(
+    "//proto:swift_proto_compiler.bzl",
     _swift_proto_compiler = "swift_proto_compiler",
+)
+load(
+    "//proto:swift_proto_library.bzl",
     _swift_proto_library = "swift_proto_library",
+)
+load(
+    "//proto:swift_proto_library_group.bzl",
     _swift_proto_library_group = "swift_proto_library_group",
 )
 load(
     "//swift:providers.bzl",
     _SwiftInfo = "SwiftInfo",
+    _SwiftProtoCompilerInfo = "SwiftProtoCompilerInfo",
+    _SwiftProtoInfo = "SwiftProtoInfo",
     _SwiftToolchainInfo = "SwiftToolchainInfo",
 )
 load("//swift:swift_binary.bzl", _swift_binary = "swift_binary")

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -10,7 +10,7 @@ For example:
 
 ```build
 load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
-load("@build_bazel_rules_swift//proto:proto.bzl", "swift_proto_library")
+load("@build_bazel_rules_swift//proto:swift_proto_library.bzl", "swift_proto_library")
 ```
 On this page:
 
@@ -535,7 +535,7 @@ Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto:proto.bzl", "swift_proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "foo",
@@ -553,7 +553,7 @@ swift_proto_library targets which mirror the dependencies between the proto targ
 
 ```python
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto:proto.bzl", "swift_proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "bar",

--- a/examples/xplatform/custom_swift_proto_compiler/rules/custom_swift_proto_compiler.bzl
+++ b/examples/xplatform/custom_swift_proto_compiler/rules/custom_swift_proto_compiler.bzl
@@ -16,16 +16,9 @@
 Defines a rule for compiling Swift source files from ProtoInfo providers.
 """
 
-load(
-    "@bazel_skylib//lib:paths.bzl",
-    "paths",
-)
-load(
-    "//proto:proto.bzl",
-    "SwiftProtoCompilerInfo",
-    "swift_proto_common",
-)
-load("//swift:providers.bzl", "SwiftInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//proto:swift_proto_common.bzl", "swift_proto_common")
+load("//swift:providers.bzl", "SwiftInfo", "SwiftProtoCompilerInfo")
 
 def _custom_swift_proto_compile(label, actions, swift_proto_compiler_info, additional_compiler_info, proto_infos, module_mappings):
     """Compiles Swift source files from `ProtoInfo` providers.

--- a/examples/xplatform/custom_swift_proto_compiler/swift/BUILD
+++ b/examples/xplatform/custom_swift_proto_compiler/swift/BUILD
@@ -1,7 +1,4 @@
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 swift_proto_library(
     name = "example_proto_swift",

--- a/examples/xplatform/grpc/service/BUILD
+++ b/examples/xplatform/grpc/service/BUILD
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto:proto.bzl", "swift_proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "service_proto",

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -1,11 +1,5 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 
 licenses(["notice"])

--- a/examples/xplatform/proto_files/BUILD
+++ b/examples/xplatform/proto_files/BUILD
@@ -2,10 +2,7 @@ load(
     "@rules_proto//proto:defs.bzl",
     "proto_library",
 )
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 
 proto_library(

--- a/examples/xplatform/proto_glob/BUILD
+++ b/examples/xplatform/proto_glob/BUILD
@@ -1,11 +1,5 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 
 proto_library(

--- a/examples/xplatform/proto_library_group/service/BUILD
+++ b/examples/xplatform/proto_library_group/service/BUILD
@@ -1,9 +1,6 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-    "swift_proto_library_group",
-)
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
+load("//proto:swift_proto_library_group.bzl", "swift_proto_library_group")
 
 proto_library(
     name = "service_proto",

--- a/examples/xplatform/proto_path/protos/package_1/BUILD
+++ b/examples/xplatform/proto_path/protos/package_1/BUILD
@@ -1,11 +1,5 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "message_1_proto",

--- a/examples/xplatform/proto_path/protos/package_2/BUILD
+++ b/examples/xplatform/proto_path/protos/package_2/BUILD
@@ -1,11 +1,5 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
-load(
-    "//proto:proto.bzl",
-    "swift_proto_library",
-)
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "message_2_proto",

--- a/proto/compilers/BUILD
+++ b/proto/compilers/BUILD
@@ -1,8 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load(
-    "//proto:proto.bzl",
-    "swift_proto_compiler",
-)
+load("//proto:swift_proto_compiler.bzl", "swift_proto_compiler")
 load(
     "//proto/compilers:swift_proto_compiler_macros.bzl",
     "GRPC_VARIANT_CLIENT",

--- a/proto/compilers/swift_proto_compiler_macros.bzl
+++ b/proto/compilers/swift_proto_compiler_macros.bzl
@@ -16,14 +16,8 @@
 Utilities for proto compiler rules.
 """
 
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "//proto:proto.bzl",
-    "swift_proto_compiler",
-)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("//proto:swift_proto_compiler.bzl", "swift_proto_compiler")
 
 # NOTE: The ProtoPathModuleMappings option is set internally for all plugins.
 # This is used to inform the plugins which Swift module the generated code for each plugin is located in.

--- a/proto/proto.bzl
+++ b/proto/proto.bzl
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Bazel rules to define Swift proto libraries and compilers."""
+"""BUILD rules to define Swift proto libraries and compilers.
+
+**NOTE:** This file is deprecated. To avoid having Bazel do more work than
+necessary, users should import each rule/build definition they use from the
+`.bzl` file that defines it in this directory.
+
+Do not import any definitions directly from the `internal` directory; those are
+meant for build rule use only.
+"""
 
 load(
     "//proto:swift_proto_common.bzl",

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -155,7 +155,7 @@ Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto:proto.bzl", "swift_proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "foo",
@@ -173,7 +173,7 @@ swift_proto_library targets which mirror the dependencies between the proto targ
 
 ```python
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("//proto:proto.bzl", "swift_proto_library")
+load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
     name = "bar",


### PR DESCRIPTION
Similar to the deprecation of `swift.bzl`.