### PR TITLE
Remove Skylib `partial` usage

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -27,7 +27,6 @@ bzl_library(
     deps = [
         ":features",
         ":toolchain_config",
-        "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:types",
     ],
 )
@@ -84,7 +83,6 @@ bzl_library(
         ":vfsoverlay",
         "//swift/toolchains/config:compile_module_interface_config",
         "@bazel_skylib//lib:collections",
-        "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:types",
     ],
@@ -162,7 +160,6 @@ bzl_library(
         ":utils",
         "//swift:swift_clang_module_aspect",
         "@bazel_skylib//lib:collections",
-        "@bazel_skylib//lib:partial",
         "@bazel_tools//tools/build_defs/cc:action_names.bzl",
     ],
 )
@@ -238,7 +235,6 @@ bzl_library(
     srcs = ["toolchain_config.bzl"],
     visibility = ["//swift:__subpackages__"],
     deps = [
-        "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:types",
     ],

--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -14,7 +14,6 @@
 
 """Functions for registering actions that invoke Swift tools."""
 
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:types.bzl", "types")
 load(":features.bzl", "are_all_features_enabled")
 load(":toolchain_config.bzl", "swift_toolchain_config")
@@ -62,28 +61,6 @@ swift_action_names = struct(
 def _all_action_names():
     """A convenience function to return all actions defined by this rule set."""
     return struct_fields(swift_action_names).values()
-
-def _apply_configurator(configurator, prerequisites, args):
-    """Calls an action configurator with the given arguments.
-
-    This function appropriately handles whether the configurator is a Skylib
-    partial or a plain function.
-
-    Args:
-        configurator: The action configurator to call.
-        prerequisites: The prerequisites struct that the configurator may use
-            to control its behavior.
-        args: The `Args` object to which the configurator will add command line
-            arguments for the tool being invoked.
-
-    Returns:
-        The `swift_toolchain_config.config_result` value, or `None`, that was
-        returned by the configurator.
-    """
-    if types.is_function(configurator):
-        return configurator(prerequisites, args)
-    else:
-        return partial.call(configurator, prerequisites, args)
 
 def _apply_action_configs(
         action_name,
@@ -150,11 +127,7 @@ def _apply_action_configs(
         # configurators.
         if should_apply_configurators:
             for configurator in action_config.configurators:
-                action_inputs = _apply_configurator(
-                    configurator,
-                    prerequisites,
-                    args,
-                )
+                action_inputs = configurator(prerequisites, args)
 
                 # If we create an action configurator from a lambda that calls
                 # `Args.add*`, the result will be the `Args` objects (rather

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -15,7 +15,6 @@
 """Implementation of compilation logic for Swift."""
 
 load("@bazel_skylib//lib:collections.bzl", "collections")
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:types.bzl", "types")
@@ -1148,8 +1147,7 @@ def compile_action_configs(
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
-                partial.make(
-                    _wmo_thread_count_configurator,
+                _make_wmo_thread_count_configurator(
                     # WMO is implied by features, so don't check the user
                     # compile flags.
                     False,
@@ -1167,8 +1165,7 @@ def compile_action_configs(
                 swift_action_names.DERIVE_FILES,
             ],
             configurators = [
-                partial.make(
-                    _wmo_thread_count_configurator,
+                _make_wmo_thread_count_configurator(
                     # WMO is not implied by features, so check the user compile
                     # flags in case they enabled it there.
                     True,
@@ -1900,25 +1897,30 @@ def _user_compile_flags_configurator(prerequisites, args):
     """Adds user compile flags to the command line."""
     args.add_all(prerequisites.user_compile_flags)
 
-def _wmo_thread_count_configurator(should_check_flags, prerequisites, args):
+def _make_wmo_thread_count_configurator(should_check_flags):
     """Adds thread count flags for WMO compiles to the command line.
 
     Args:
         should_check_flags: If `True`, WMO wasn't enabled by a feature so the
-            user compile flags should be checked for an explicit WMO option.
-            This argument is pre-bound when the partial is created for the
-            action config. If `False`, unconditionally apply the flags, because
-            it is assumed that the configurator was triggered by feature
-            satisfaction.
-        prerequisites: The action prerequisites.
-        args: The `Args` object to which flags will be added.
+            user compile flags should be checked for an explicit WMO option. If
+            `False`, unconditionally apply the flags, because it is assumed that
+            the configurator was triggered by feature satisfaction.
+
+    Returns:
+        A function used to configure the `-num-threads` flag for WMO.
     """
-    if not should_check_flags or (
-        should_check_flags and
-        _is_wmo_manually_requested(prerequisites.user_compile_flags)
-    ):
-        # Force threaded mode for WMO builds.
+
+    def _add_num_threads(args):
         args.add("-num-threads", str(_DEFAULT_WMO_THREAD_COUNT))
+
+    if not should_check_flags:
+        return lambda _prerequisites, args: _add_num_threads(args)
+
+    def _flag_checking_wmo_thread_count_configurator(prerequisites, args):
+        if _is_wmo_manually_requested(prerequisites.user_compile_flags):
+            _add_num_threads(args)
+
+    return _flag_checking_wmo_thread_count_configurator
 
 def _is_wmo_manually_requested(user_compile_flags):
     """Returns `True` if a WMO flag is in the given list of compiler flags.

--- a/swift/internal/toolchain_config.bzl
+++ b/swift/internal/toolchain_config.bzl
@@ -14,7 +14,6 @@
 
 """Definitions used to configure toolchains and actions."""
 
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:types.bzl", "types")
 
@@ -115,12 +114,12 @@ def _action_config(
     Args:
         actions: A `list` of strings denoting the names of the actions for
             which the configurators should be invoked.
-        configurators: A `list` of functions or Skylib partials that will be
-            invoked to add command line arguments and collect inputs for the
-            actions. These functions/partials take two arguments---a
-            `prerequisites` struct and an `Args` object---and return a `depset`
-            of `File`s that should be used as inputs to the action (or `None`
-            if the configurator does not add any inputs).
+        configurators: A `list` of functions or that will be invoked to add
+            command line arguments and collect inputs for the actions. These
+            functions take two arguments---a `prerequisites` struct and an
+            `Args` object---and return a either a struct via `config_result`
+            that describes that `File`s that should be used as inputs to the
+            action, or `None` if the configurator does not add any inputs.
         features: The `list` of features that must be enabled for the
             configurators to be applied to the action. This argument can take
             one of three forms: `None` (the default), in which case the
@@ -150,33 +149,6 @@ def _action_config(
         not_features = _normalize_action_config_features(not_features),
     )
 
-def _add_arg_impl(
-        arg_name_or_value,
-        value,
-        _prerequisites,
-        args,
-        format = None):
-    """Implementation function for the `add_arg` convenience configurator.
-
-    Args:
-        arg_name_or_value: The `arg_name_or_value` passed to `Args.add`. Bound
-            at partial creation time.
-        value: The `value` passed to `Args.add`. Bound at partial creation
-            time.
-        _prerequisites: Unused by this function.
-        args: The `Args` object to which flags will be added.
-        format: The `format` passed to `Args.add`. Bound at partial creation
-            time.
-    """
-
-    # `Args.add` doesn't permit the `value` argument to be `None`, only
-    # "unbound", so we have to check for this and not pass it *at all* if it
-    # wasn't specified when the partial was created.
-    if value == None:
-        args.add(arg_name_or_value, format = format)
-    else:
-        args.add(arg_name_or_value, value, format = format)
-
 def _add_arg(arg_name_or_value, value = None, format = None):
     """Returns a configurator that adds a simple argument to the command line.
 
@@ -193,11 +165,20 @@ def _add_arg(arg_name_or_value, value = None, format = None):
             by default).
 
     Returns:
-        A Skylib `partial` that can be added to the `configurators` list of an
+        A function that can be added to the `configurators` list of an
         `action_config`.
     """
-    return partial.make(
-        _add_arg_impl,
+
+    # `Args.add` doesn't permit the `value` argument to be `None`, only
+    # "unbound", so we have to check for this and not pass it *at all* if it
+    # wasn't specified when the function was created.
+    if value == None:
+        return lambda _prerequisites, args: args.add(
+            arg_name_or_value,
+            format = format,
+        )
+
+    return lambda _prerequisites, args: args.add(
         arg_name_or_value,
         value,
         format = format,

--- a/swift/toolchains/BUILD
+++ b/swift/toolchains/BUILD
@@ -18,7 +18,6 @@ bzl_library(
         "//swift/internal:toolchain_config",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:partial",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",
     ],
 )
@@ -38,7 +37,6 @@ bzl_library(
         "//swift/internal:utils",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:partial",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//rules:common_settings",
         "@bazel_tools//tools/cpp:toolchain_utils.bzl",


### PR DESCRIPTION
Now that Bazel supports nested/capturing functions, just use those throughout.

PiperOrigin-RevId: 449500122
(cherry picked from commit ffba849c424f08c7236e3826d41cb75b63f2be1b)