### PR TITLE
Update Ubuntu CI to use Swift 5.9.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -14,7 +14,7 @@ x_defaults:
     platform: ubuntu2004
     environment:
       CC: clang
-      SWIFT_VERSION: "5.7.2"
+      SWIFT_VERSION: "5.9.2"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$PATH:$SWIFT_HOME/usr/bin"
     build_flags: &linux_flags

--- a/test/symbol_graphs_tests.bzl
+++ b/test/symbol_graphs_tests.bzl
@@ -57,9 +57,6 @@ def symbol_graphs_test_suite(name):
         },
         tags = [name],
         target_under_test = "@build_bazel_rules_swift//test/fixtures/symbol_graphs:some_module_symbol_graph_with_extension_block_symbols",
-        # TODO: remove this constraint once Swift version in CI for Linux/Windows is updated to 5.9+
-        # until then `-emit-extension-block-symbols` is not testable as the compiler does not have the flag.
-        target_compatible_with = ["@platforms//os:macos"],
     )
 
     # Verify that the `swift_extract_symbol_graph` rule produces a directory


### PR DESCRIPTION
Swift 5.9.2 is the version shipped with Xcode 15.2 (used by the current macOS CI) so this will more correctly match versions.