### PR TITLE
Fix `test_observer` usage

### DIFF
--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -457,6 +457,11 @@ swift_test = rule(
                 ),
                 executable = True,
             ),
+            "_test_observer": attr.label(
+                default = Label(
+                    "@build_bazel_rules_swift//tools/test_observer",
+                ),
+            ),
             "_xctest_runner_template": attr.label(
                 allow_single_file = True,
                 default = Label(

--- a/tools/test_observer/BUILD
+++ b/tools/test_observer/BUILD
@@ -5,6 +5,7 @@ load(
 
 swift_library(
     name = "test_observer",
+    testonly = True,
     srcs = [
         "BazelXMLTestObserver.swift",
         "BazelXMLTestObserverRegistration.swift",


### PR DESCRIPTION
Missed in d6b7f13d42d5a030247421e795e01148f517adc2.