### PR TITLE
Update rules that require a cpp toolchain to use a helper function that defines the toolchain type

### DIFF
--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -23,7 +23,11 @@ load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+    "find_cpp_toolchain",
+    "use_cpp_toolchain",
+)
 load(
     "//swift:providers.bzl",
     "SwiftFeatureAllowlistInfo",
@@ -596,6 +600,6 @@ The version of XCTest that the toolchain packages.
     ),
     doc = "Represents a Swift compiler toolchain.",
     fragments = [] if bazel_features.cc.swift_fragment_removed else ["swift"],
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = use_cpp_toolchain(),
     implementation = _swift_toolchain_impl,
 )

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -23,7 +23,11 @@ load("@bazel_features//:features.bzl", "bazel_features")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load(
+    "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+    "find_cpp_toolchain",
+    "use_cpp_toolchain",
+)
 load(
     "//swift:providers.bzl",
     "SwiftFeatureAllowlistInfo",
@@ -885,6 +889,6 @@ for incremental compilation using a persistent mode.
         "cpp",
         "objc",
     ] + ([] if bazel_features.cc.swift_fragment_removed else ["swift"]),
-    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+    toolchains = use_cpp_toolchain(),
     implementation = _xcode_swift_toolchain_impl,
 )

--- a/test/fixtures/linking/fake_framework.bzl
+++ b/test/fixtures/linking/fake_framework.bzl
@@ -1,6 +1,10 @@
 """Simple rule to emulate apple_static_framework_import"""
 
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load(
+    "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+    "find_cpp_toolchain",
+    "use_cpp_toolchain",
+)
 
 def _impl(ctx):
     binary1 = ctx.actions.declare_file("framework1.framework/framework1")


### PR DESCRIPTION
PiperOrigin-RevId: 456368560
(cherry picked from commit 0bb2adac2b2cc7dec0c62806e507d1a5c028e68d)