### PR TITLE
Correctly add `.swiftmodule` directories to the search path.

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1640,7 +1640,14 @@ def _swift_module_search_path_map_fn(module):
         The dirname of the module's `.swiftmodule` file.
     """
     if module.swift:
-        return module.swift.swiftmodule.dirname
+        search_path = module.swift.swiftmodule.dirname
+
+        # If the dirname also ends in .swiftmodule, remove it as well so that
+        # the compiler finds the module *directory*.
+        if search_path.endswith(".swiftmodule"):
+            search_path = paths.dirname(search_path)
+
+        return search_path
     else:
         return None
 


### PR DESCRIPTION
If a propagated `.swiftmodule` is ever in a directory-based layout (`Name.swiftmodule/$TARGET.swiftmodule`), then we need to add the path to the directory containing the top-level module directory, not the path to the `.swiftmodule` directory itself.

PiperOrigin-RevId: 456263364
(cherry picked from commit 21580ead964dc0e2690ba4bb64ede3293881e258)