### PR TITLE
Add a feature to always include all headers as inputs to SwiftCompile actions, even when using explicit modules

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -38,6 +38,7 @@ load(
     "SWIFT_FEATURE_EMIT_SWIFTSOURCEINFO",
     "SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION",
     "SWIFT_FEATURE_FULL_LTO",
+    "SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
@@ -662,6 +663,10 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
 
     prerequisites = struct(
         additional_inputs = additional_inputs,
+        always_include_headers = is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS,
+        ),
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_cc_info.compilation_context,
         const_protocols_to_gather_file = const_protocols_to_gather_file,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -30,6 +30,10 @@ SWIFT_FEATURE_DBG = "swift.dbg"
 SWIFT_FEATURE_FASTBUILD = "swift.fastbuild"
 SWIFT_FEATURE_OPT = "swift.opt"
 
+# If True, transitive C headers will be always be passed as inputs to Swift
+# compilation actions, even when building with explicit modules.
+SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS = "swift.headers_always_action_inputs"
+
 # This feature is enabled if coverage collection is enabled for the build. (See
 # the note above about not depending on the C++ features.)
 SWIFT_FEATURE_COVERAGE = "swift.coverage"

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1363,12 +1363,16 @@ def _dependencies_clang_defines_configurator(prerequisites, args):
     args.add_all(all_clang_defines, before_each = "-Xcc", format_each = "-D%s")
 
 def _collect_clang_module_inputs(
+        always_include_headers,
         explicit_module_compilation_context,
         modules,
         prefer_precompiled_modules):
     """Collects Clang module-related inputs to pass to an action.
 
     Args:
+        always_include_headers: If True, pass the transitive headers as inputs
+            to the compilation action, even if doing an explicit module
+            compilation.
         explicit_module_compilation_context: The `CcCompilationContext` of the
             target being compiled, if the inputs are being collected for an
             explicit module compilation action. This parameter should be `None`
@@ -1417,12 +1421,16 @@ def _collect_clang_module_inputs(
             direct_inputs.append(module_map)
 
         precompiled_module = clang_module.precompiled_module
+        use_precompiled_module = (
+            prefer_precompiled_modules and precompiled_module
+        )
 
-        if prefer_precompiled_modules and precompiled_module:
+        if use_precompiled_module:
             # For builds preferring explicit modules, use it if we have it
             # and don't include any headers as inputs.
             direct_inputs.append(precompiled_module)
-        else:
+
+        if not use_precompiled_module or always_include_headers:
             # If we don't have an explicit module (or we're not using it), we
             # need the transitive headers from the compilation context
             # associated with the module. This will likely overestimate the
@@ -1520,6 +1528,11 @@ def _dependencies_clang_modulemaps_configurator(prerequisites, args):
         compilation_context = prerequisites.cc_compilation_context
 
     return _collect_clang_module_inputs(
+        always_include_headers = getattr(
+            prerequisites,
+            "always_include_headers",
+            False,
+        ),
         explicit_module_compilation_context = compilation_context,
         modules = modules,
         prefer_precompiled_modules = False,
@@ -1550,6 +1563,11 @@ def _dependencies_clang_modules_configurator(prerequisites, args):
         compilation_context = prerequisites.cc_compilation_context
 
     return _collect_clang_module_inputs(
+        always_include_headers = getattr(
+            prerequisites,
+            "always_include_headers",
+            False,
+        ),
         explicit_module_compilation_context = compilation_context,
         modules = modules,
         prefer_precompiled_modules = True,


### PR DESCRIPTION
When building with explicit modules, Swift compilations do not require any of the headers to be present on disk, because the AST contains all the necessary information (save for a bug(?) in `canImport` which fails if the headers aren't also present). However, other tooling may want to inspect compilation actions and have access to those headers.

This feature is a no-op for implicit module builds, since the headers are always included to begin with, and it is off by default.

PiperOrigin-RevId: 461668350
(cherry picked from commit 81f7b547ff6dea6e67fb0ee4c59e1e5a945cd03d)