### PR TITLE
Add an API to compile a `.swiftinterface` file into a `.swiftmodule`

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -770,6 +770,13 @@ def compile_action_configs(
             features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
         ),
         ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [
+                add_arg("-disable-implicit-swift-modules"),
+            ],
+            features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
+        ),
+        ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
@@ -1733,6 +1740,8 @@ def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args, is_f
 def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = False):
     """Adds the explicit Swift module map file to the command line."""
     if is_frontend:
+        # If we're calling frontend directly we don't need to prepend each
+        # argument with -Xfrontend. Doing so will crash the invocation.
         args.add(
             "-explicit-swift-module-map-file",
             prerequisites.explicit_swift_module_map_file,

--- a/test/BUILD
+++ b/test/BUILD
@@ -28,9 +28,9 @@ licenses(["notice"])
 
 ast_file_test_suite(name = "ast_file")
 
-compiler_arguments_test_suite(name = "compiler_arguments")
-
 cc_library_test_suite(name = "cc_library")
+
+compiler_arguments_test_suite(name = "compiler_arguments")
 
 const_values_test_suite(name = "const_values")
 
@@ -44,47 +44,47 @@ generated_header_test_suite(name = "generated_header")
 
 imported_framework_test_suite(name = "imported_framework")
 
+interop_hints_test_suite()
+
 mainattr_test_suite(name = "mainattr")
 
 module_cache_settings_test_suite(name = "module_cache_settings")
 
-output_file_map_test_suite(name = "output_file_map")
-
 module_interface_test_suite(name = "module_interface")
 
-interop_hints_test_suite()
+output_file_map_test_suite(name = "output_file_map")
 
 private_deps_test_suite(name = "private_deps")
 
+split_derived_files_test_suite(name = "split_derived_files")
+
+swift_binary_linking_test_suite(name = "swift_binary_rules")
+
 swift_through_non_swift_test_suite(name = "swift_through_non_swift")
 
-split_derived_files_test_suite(name = "split_derived_files")
+symbol_graphs_test_suite(name = "symbol_graphs")
 
 pch_output_dir_test_suite(name = "pch_output_dir_settings")
 
 private_swiftinterface_test_suite(name = "private_swiftinterface")
 
-symbol_graphs_test_suite(name = "symbol_graphs")
+utils_test_suite(name = "utils")
 
 xctest_runner_test_suite(name = "xctest_runner")
 
-utils_test_suite(name = "utils")
-
-swift_binary_linking_test_suite(name = "swift_binary_rules")
-
 test_suite(
     name = "all_tests",
-)
-
-bzl_test(
-    name = "swift_bzl_test",
-    src = "swift_bzl_macro.bzl",
-    deps = ["//swift"],
 )
 
 bzl_library(
     name = "swift_bzl_macro",
     srcs = ["swift_bzl_macro.bzl"],
     visibility = ["//visibility:private"],
+    deps = ["//swift"],
+)
+
+bzl_test(
+    name = "swift_bzl_test",
+    src = "swift_bzl_macro.bzl",
     deps = ["//swift"],
 )


### PR DESCRIPTION
PiperOrigin-RevId: 462641052
(cherry picked from commit 47b464853d7a78cd387a095ebfeb61bf6f132410)

---

Cherry-pick notes: We already picked most of this in 9abae7d7340c5e9e520f5170054a085d485879e0. This is just applying missed changes and formatting changes.