### PR TITLE
Support order file instrumentation in swift compile actions

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -595,6 +595,19 @@ def compile_action_configs(
         ),
     ]
 
+    #### FDO flags
+    action_configs.append(
+        # Support for order-file instrumentation.
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [
+                add_arg("-sanitize=undefined"),
+                add_arg("-sanitize-coverage=func"),
+            ],
+            features = ["fdo_instrument_order_file"],
+        ),
+    )
+
     #### Flags controlling how Swift/Clang modular inputs are processed
 
     action_configs += [


### PR DESCRIPTION
PiperOrigin-RevId: 467339063
(cherry picked from commit 2a1a3874718305aeb83ff5506d2c58616bf81584)