### PR TITLE
Switch the toolchain type name back to `toolchain_type`, the canonical spelling.

### DIFF
--- a/swift/internal/toolchain_utils.bzl
+++ b/swift/internal/toolchain_utils.bzl
@@ -14,7 +14,7 @@
 
 """Helpers used to depend on and access the Swift toolchain."""
 
-SWIFT_TOOLCHAIN_TYPE = "@build_bazel_rules_swift//toolchains:toolchain-type"
+SWIFT_TOOLCHAIN_TYPE = "@build_bazel_rules_swift//toolchains:toolchain_type"
 
 def get_swift_toolchain(ctx, attr = "_toolchain"):
     """Gets the Swift toolchain associated with the rule or aspect.


### PR DESCRIPTION
PiperOrigin-RevId: 471276851
(cherry picked from commit d3302c7ef0c4e159699c043f6f4f5191c5ef51d5)