### PR TITLE
Add initial rules_swift support for visionOS

### DIFF
--- a/swift/internal/target_triples.bzl
+++ b/swift/internal/target_triples.bzl
@@ -185,6 +185,8 @@ def _platform_name_for_swift(triple):
         return "visionossimulator" if is_simulator else "visionos"
     if os == "watchos":
         return "watchsimulator" if is_simulator else "watchos"
+    if os == "xros":
+        return "xrsimulator" if is_simulator else "xros"
 
     # Fall back to the operating system name if we aren't one of the cases
     # covered above. If more platforms need to be supported in the future, add


### PR DESCRIPTION
PiperOrigin-RevId: 565694162
(cherry picked from commit fa88027a20d3816f5df621b37553128cac9f6c51)

---

Cherry-pick notes: We already had most of this, just missed a part.