### PR TITLE
Annotate the test observer with `@MainActor` where needed to be concurrency-safe

### DIFF
--- a/tools/test_observer/BazelXMLTestObserver.swift
+++ b/tools/test_observer/BazelXMLTestObserver.swift
@@ -29,6 +29,7 @@ public final class BazelXMLTestObserver: NSObject {
   ///
   /// If the `XML_OUTPUT_FILE` environment variable is not set or the file at that path could not be
   /// created and opened for writing, the value of this property will be nil.
+  @MainActor
   public static let `default`: BazelXMLTestObserver? = {
     guard
       let outputPath = ProcessInfo.processInfo.environment["XML_OUTPUT_FILE"],

--- a/tools/test_observer/BazelXMLTestObserverRegistration.swift
+++ b/tools/test_observer/BazelXMLTestObserverRegistration.swift
@@ -19,6 +19,7 @@
   /// The principal class in an XCTest bundle on Darwin-based platforms, which registers the
   /// XML-generating observer with the XCTest observation center when the bundle is loaded.
   @objc(BazelXMLTestObserverRegistration)
+  @MainActor
   public final class BazelXMLTestObserverRegistration: NSObject {
     @objc public override init() {
       super.init()


### PR DESCRIPTION
PiperOrigin-RevId: 631886302
(cherry picked from commit 36992305ad9a4f01aeea907c14838031cb80d38a)