### PR TITLE
Add infrastructure to ban certain Swift compiler flags

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1946,6 +1946,10 @@ def _fail_if_flag_is_banned(copt):
     Returns:
         The original flag, if the function didn't fail.
     """
-    if copt in _BANNED_SWIFTCOPTS:
-        fail("The Swift compiler flag '{}' may not be used.".format(copt))
+    reason = _BANNED_SWIFTCOPTS.get(copt)
+    if reason:
+        fail("The Swift compiler flag '{}' may not be used. {}".format(
+            copt,
+            reason,
+        ))
     return copt

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1132,7 +1132,10 @@ def compile_action_configs(
                     SWIFT_ACTION_DUMP_AST,
                 ],
                 configurators = [
-                    lambda _, args: args.add_all(additional_swiftc_copts),
+                    lambda _, args: args.add_all(
+                        additional_swiftc_copts,
+                        map_each = _fail_if_flag_is_banned,
+                    ),
                 ],
             ),
         )
@@ -1814,7 +1817,10 @@ def _source_files_configurator(prerequisites, args):
 
 def _user_compile_flags_configurator(prerequisites, args):
     """Adds user compile flags to the command line."""
-    args.add_all(prerequisites.user_compile_flags)
+    args.add_all(
+        prerequisites.user_compile_flags,
+        map_each = _fail_if_flag_is_banned,
+    )
 
 def _make_wmo_thread_count_configurator(should_check_flags):
     """Adds thread count flags for WMO compiles to the command line.
@@ -1919,3 +1925,27 @@ def _additional_inputs_configurator(prerequisites, _args):
     return ConfigResultInfo(
         inputs = prerequisites.additional_inputs,
     )
+
+# Swift compiler flags that should be banned (in either `copts` on a target or
+# by passing `--swiftcopt` on the command line) should be listed here.
+_BANNED_SWIFTCOPTS = {
+}
+
+def _fail_if_flag_is_banned(copt):
+    """Fails the build if the given compiler flag matches a banned flag.
+
+    This is meant to be used as a `map_each` argument to `args.add_all`,
+    delaying the check until the action is actually executed and allowing it to
+    happen during the building of the command line (when the flags are already
+    being iterated), instead of doing a less-efficient separate traversal of the
+    list earlier at analysis time.
+
+    Args:
+        copt: The flag to check.
+
+    Returns:
+        The original flag, if the function didn't fail.
+    """
+    if copt in _BANNED_SWIFTCOPTS:
+        fail("The Swift compiler flag '{}' may not be used.".format(copt))
+    return copt


### PR DESCRIPTION
PiperOrigin-RevId: 632457020
(cherry picked from commit 542ecfe9a509b68957ee4aa092b9e74a3b6dbd11)