### PR TITLE
Fix LLDB expr evaluation for `swift_{binary,test}` targets only containing Swift in their `srcs`

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -258,6 +258,7 @@ bzl_library(
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
     ],
 )
 

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -102,6 +102,7 @@ bzl_library(
         ":actions",
         ":feature_names",
         ":features",
+        "@bazel_skylib//lib:paths",
     ],
 )
 

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -14,6 +14,7 @@
 
 """Functions relating to debugging support during compilation and linking."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":action_names.bzl", "SWIFT_ACTION_MODULEWRAP")
 load(
     ":actions.bzl",
@@ -60,7 +61,7 @@ def ensure_swiftmodule_is_embedded(
         # to wrap the .swiftmodule file in a .o file that gets propagated to the
         # linker.
         modulewrap_obj = actions.declare_file(
-            "{}.modulewrap.o".format(label.name),
+            paths.replace_extension(swiftmodule.basename, ".modulewrap.o"),
         )
         prerequisites = struct(
             object_file = modulewrap_obj,

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -62,6 +62,7 @@ def _swift_compiler_plugin_impl(ctx):
 
     deps = ctx.attr.deps
     srcs = ctx.files.srcs
+    module_contexts = []
 
     if not srcs:
         fail("A compiler plugin must have at least one file in 'srcs'.")
@@ -105,24 +106,22 @@ def _swift_compiler_plugin_impl(ctx):
         workspace_name = ctx.workspace_name,
     )
     module_context = compile_result.module_context
+    module_contexts.append(module_context)
     compilation_outputs = compile_result.compilation_outputs
     supplemental_outputs = compile_result.supplemental_outputs
-
-    cc_feature_configuration = swift_common.cc_feature_configuration(
-        feature_configuration = feature_configuration,
-    )
 
     binary_linking_outputs = register_link_binary_action(
         actions = ctx.actions,
         additional_inputs = ctx.files.swiftc_inputs,
         additional_linking_contexts = [malloc_linking_context(ctx)],
-        cc_feature_configuration = cc_feature_configuration,
         compilation_outputs = compilation_outputs,
         deps = deps,
+        feature_configuration = feature_configuration,
+        module_contexts = module_contexts,
         name = ctx.label.name,
         output_type = "executable",
-        stamp = ctx.attr.stamp,
         owner = ctx.label,
+        stamp = ctx.attr.stamp,
         swift_toolchain = swift_toolchain,
         user_link_flags = expand_locations(
             ctx,


### PR DESCRIPTION
The `.swiftmodule` resulting from compilation of the target's sources was being ignored (since it cannot be a dependency of anything else), but it needs to be embedded as with any other `.swiftmodule` in order for LLDB to find it and initialize the AST context properly.

PiperOrigin-RevId: 477544434
(cherry picked from commit c0cdb8b5a2100b3962993654f7409b80f3ce96f2)