### PR TITLE
Delete the `swift.bundled_xctests` feature

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -38,13 +38,6 @@ SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS = "swift.headers_always_action_inputs
 # the note above about not depending on the C++ features.)
 SWIFT_FEATURE_COVERAGE = "swift.coverage"
 
-# If enabled, the `swift_test` rule will output an `.xctest` bundle for Darwin
-# targets instead of a standalone binary. This is necessary for XCTest-based
-# tests that use runtime reflection to locate test methods. This feature can be
-# explicitly disabled on a per-target or per-package basis if needed to make
-# `swift_test` output just a binary.
-SWIFT_FEATURE_BUNDLED_XCTESTS = "swift.bundled_xctests"
-
 # If enabled, debug builds will use the `-debug-prefix-map` feature to remap the
 # current working directory to `.`, which permits debugging remote or sandboxed
 # builds.

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -47,7 +47,6 @@ load(
 load("//swift/internal:attrs.bzl", "swift_toolchain_driver_attrs")
 load(
     "//swift/internal:feature_names.bzl",
-    "SWIFT_FEATURE_BUNDLED_XCTESTS",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
     "SWIFT_FEATURE_COVERAGE",
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
@@ -698,7 +697,6 @@ def _xcode_swift_toolchain_impl(ctx):
     ) + wmo_features_from_swiftcopts(swiftcopts = swiftcopts)
     requested_features.extend(ctx.features)
     requested_features.extend([
-        SWIFT_FEATURE_BUNDLED_XCTESTS,
         SWIFT_FEATURE_CACHEABLE_SWIFTMODULES,
         SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
         SWIFT_FEATURE_DEBUG_PREFIX_MAP,


### PR DESCRIPTION
PiperOrigin-RevId: 471797061
(cherry picked from commit 585e7a7f55a392050687e9b2cf90f2348cee0caa)