### PR TITLE
Only link in the Bazel test observer when discovering tests.

### DIFF
--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -371,8 +371,14 @@ def _swift_test_impl(ctx):
     srcs = ctx.files.srcs
     owner_symbol_graph_dir = None
 
-    # Inject the test observer that prints the xUnit-style output for Bazel.
-    all_deps = ctx.attr.deps + [ctx.attr._test_observer]
+    all_deps = list(ctx.attr.deps)
+
+    # In test discovery mode (whether manual or by the Obj-C runtime), inject
+    # the test observer that prints the xUnit-style output for Bazel. Otherwise
+    # don't link this, because we don't want it to pull in link time
+    # dependencies on XCTest, which the test binary may not be using.
+    if discover_tests:
+        all_deps.append(ctx.attr._test_observer)
 
     module_name = ctx.attr.module_name
     if not module_name:


### PR DESCRIPTION
Otherwise, the binary might link to XCTest when it otherwise isn't using it (strongly linking to `@rpath/libXCTestSwiftSupport.dylib`, which won't be found at runtime when not using the `xctest` launcher).

PiperOrigin-RevId: 471801873
(cherry picked from commit 5da9abdea9d67fbe80ba7246f0b2335cf6657f68)