### PR TITLE
Pass `-enable-testing` when compiling the sources in a `swift_test` in discovery mode

### DIFF
--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -391,8 +391,13 @@ def _swift_test_impl(ctx):
             # In test discovery mode (whether manual or by the Obj-C runtime),
             # compile the code with `-parse-as-library` to avoid the case where
             # a single file with no top-level code still produces an empty
-            # `main`.
-            additional_copts = ["-parse-as-library"] if discover_tests else _maybe_parse_as_library_copts(srcs),
+            # `main`. Also compile with `-enable-testing`, because the generated
+            # sources will `@testable import` this module, and this allows that
+            # to work even when building in `-c opt` mode.
+            additional_copts = [
+                "-parse-as-library",
+                "-enable-testing",
+            ] if discover_tests else _maybe_parse_as_library_copts(srcs),
             cc_infos = deps_cc_infos,
             feature_configuration = feature_configuration,
             include_dev_srch_paths = include_dev_srch_paths,


### PR DESCRIPTION
When doing manual discovery, this allows the generated sources to `@testable import` that module even when building with `-c opt`.

PiperOrigin-RevId: 471809177
(cherry picked from commit 82f828b983baecd0fa3ee14a6754eb71938895c0)