### PR TITLE
Upgrade swift_argument_parser to 1.3.1.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 bazel_dep(name = "nlohmann_json", version = "3.6.1", repo_name = "com_github_nlohmann_json")
 bazel_dep(
     name = "swift_argument_parser",
-    version = "1.3.0",
+    version = "1.3.1.1",
     repo_name = "com_github_apple_swift_argument_parser",
 )
 


### PR DESCRIPTION
It has its `max_compatibility_level` increased to support rules_swift 2.0.