### PR TITLE
Add C++ Interoperability example

### DIFF
--- a/examples/xplatform/c_from_swift/BUILD
+++ b/examples/xplatform/c_from_swift/BUILD
@@ -12,10 +12,12 @@ cc_library(
     linkstatic = True,
 )
 
-# 2. ...but Swift can't import C++ yet, so we implement a wrapper API in C. Use
-# the `swift_interop_hint` rule to enable module map generation and provide the
-# module name for these headers, since `cc_library` doesn't do enable this by
-# default.
+# 2. ...but Swift can't import C++ without explicitly enabling it using the
+# `-cxx-interoperability-mode` build flag, so for this example we implement a
+# wrapper API in C. See the `cxx_from_swift` example for how to use C++ code
+# directly. In either case, we use the `swift_interop_hint` rule to enable
+# module map generation and provide the module name for these headers, since
+# `cc_library` doesn't do enable this by default.
 cc_library(
     name = "c_counter",
     srcs = ["c_counter.cc"],

--- a/examples/xplatform/cxx_from_swift/BUILD
+++ b/examples/xplatform/cxx_from_swift/BUILD
@@ -1,0 +1,34 @@
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
+
+licenses(["notice"])
+
+# 1. This library has some C++ code that you want to interact with from Swift.
+# Use the `swift_interop_hint` rule to enable module map generation and provide
+# the module name for these headers, since `cc_library` doesn't do enable this
+# by default.
+cc_library(
+    name = "counter",
+    srcs = ["counter.cc"],
+    hdrs = ["counter.h"],
+    aspect_hints = [":cxx_counter_swift_hint"],
+    linkstatic = True,
+)
+
+swift_interop_hint(
+    name = "cxx_counter_swift_hint",
+    module_name = "CxxCounter",
+)
+
+# 2. The Swift binary then depends on the `cc_library`. This causes a
+# Swift-compatible module map to be created for the `cc_library` so that the
+# Swift code can import it. Be sure to enable C++ Interoperability in the Swift
+# compiler using the `-cxx-interoperability-mode` build flag.
+# https://www.swift.org/documentation/cxx-interop/project-build-setup/#mixing-swift-and-c-using-other-build-systems
+swift_binary(
+    name = "cxx_from_swift",
+    srcs = ["main.swift"],
+    copts = ["-cxx-interoperability-mode=default"],
+    module_name = "main",
+    deps = [":counter"],
+)

--- a/examples/xplatform/cxx_from_swift/counter.cc
+++ b/examples/xplatform/cxx_from_swift/counter.cc
@@ -1,0 +1,23 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "examples/xplatform/cxx_from_swift/counter.h"
+
+namespace swiftexample {
+
+int Counter::Get() const { return count_; }
+
+void Counter::Increment() { ++count_; }
+
+}  // namespace swiftexample

--- a/examples/xplatform/cxx_from_swift/counter.h
+++ b/examples/xplatform/cxx_from_swift/counter.h
@@ -1,0 +1,26 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace swiftexample {
+
+class Counter {
+ public:
+  int Get() const;
+  void Increment();
+
+ private:
+  int count_ = 0;
+};
+
+}  // namespace swiftexample

--- a/examples/xplatform/cxx_from_swift/main.swift
+++ b/examples/xplatform/cxx_from_swift/main.swift
@@ -1,0 +1,24 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Import the C++ interface.
+import CxxCounter
+
+var counter = swiftexample.Counter()
+for _ in 1...10 {
+  counter.Increment()
+}
+
+// This should print 10.
+print(counter.Get())


### PR DESCRIPTION
Extends the simple "counter" example from `c_from_swift` to show how to use the [`-cxx-interoperability-mode`](https://www.swift.org/documentation/cxx-interop/project-build-setup/#mixing-swift-and-c-using-other-build-systems) build flag to invoke C++ directly from Swift.

https://www.swift.org/documentation/cxx-interop/