### PR TITLE
Fix usage of params files in _swift_proto_compile

### DIFF
--- a/proto/swift_proto_compiler.bzl
+++ b/proto/swift_proto_compiler.bzl
@@ -154,7 +154,8 @@ def _swift_proto_compile(label, actions, swift_proto_compiler_info, additional_c
 
     # Build the arguments for protoc:
     arguments = actions.args()
-    arguments.use_param_file("--param=%s")
+    arguments.set_param_file_format("multiline")
+    arguments.use_param_file("@%s")
 
     # Add the plugin argument with the provided name to namespace all of the options:
     plugin_name_argument = "--plugin=protoc-gen-{}={}".format(


### PR DESCRIPTION
I noticed that when I had a long list of deps for a `swift_proto_library` target, my builds would fail with an error `unrecognized argument: --param`. This is because protoc expects param files to be prefixed with `@` instead of a `--param` arg. That change + using the `multiline` file format allows everything to work as intended.