### PR TITLE
Add features to enable strict concurrency checking

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -351,3 +351,12 @@ SWIFT_FEATURE_THIN_LTO = "swift.thin_lto"
 
 # Enable full LTO and update output-file-map correctly
 SWIFT_FEATURE_FULL_LTO = "swift.full_lto"
+
+# Enable minimal strict concurrency checking (most 'Sendable' checking is disabled)
+SWIFT_FEATURE_STRICT_CONCURRENCY_MINIMAL = "swift.strict_concurrency.minimal"
+
+# Enable targeted strict concurrency checking ('Sendable' checking is enabled in code that uses the concurrency mode)
+SWIFT_FEATURE_STRICT_CONCURRENCY_TARGETED = "swift.strict_concurrency.targeted"
+
+# Enable complete strict concurrency checking ('Sendable' and other checking is enabled for all code in the module)
+SWIFT_FEATURE_STRICT_CONCURRENCY_COMPLETE = "swift.strict_concurrency.complete"

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -62,6 +62,9 @@ load(
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_REWRITE_GENERATED_HEADER",
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
+    "SWIFT_FEATURE_STRICT_CONCURRENCY_COMPLETE",
+    "SWIFT_FEATURE_STRICT_CONCURRENCY_MINIMAL",
+    "SWIFT_FEATURE_STRICT_CONCURRENCY_TARGETED",
     "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_THIN_LTO",
@@ -266,6 +269,21 @@ def compile_action_configs(
             actions = [SWIFT_ACTION_COMPILE],
             configurators = [add_arg("-lto=llvm-full")],
             features = [SWIFT_FEATURE_FULL_LTO],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [add_arg("-strict-concurrency=minimal")],
+            features = [SWIFT_FEATURE_STRICT_CONCURRENCY_MINIMAL],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [add_arg("-strict-concurrency=targeted")],
+            features = [SWIFT_FEATURE_STRICT_CONCURRENCY_TARGETED],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [add_arg("-strict-concurrency=complete")],
+            features = [SWIFT_FEATURE_STRICT_CONCURRENCY_COMPLETE],
         ),
     ]
 

--- a/test/compiler_arguments_tests.bzl
+++ b/test/compiler_arguments_tests.bzl
@@ -30,6 +30,30 @@ full_lto_test = make_action_command_line_test_rule(
     },
 )
 
+strict_concurrency_minimal_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.strict_concurrency.minimal",
+        ],
+    },
+)
+
+strict_concurrency_targeted_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.strict_concurrency.targeted",
+        ],
+    },
+)
+
+strict_concurrency_complete_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.strict_concurrency.complete",
+        ],
+    },
+)
+
 def compiler_arguments_test_suite(name, tags = []):
     """Test suite for various command line flags passed to Swift compiles.
 
@@ -98,6 +122,30 @@ def compiler_arguments_test_suite(name, tags = []):
     full_lto_test(
         name = "{}_full_lto".format(name),
         expected_argv = ["-lto=llvm-full"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",
+    )
+
+    strict_concurrency_minimal_test(
+        name = "{}_strict_concurrency_minimal".format(name),
+        expected_argv = ["-strict-concurrency=minimal"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",
+    )
+
+    strict_concurrency_targeted_test(
+        name = "{}_strict_concurrency_targeted".format(name),
+        expected_argv = ["-strict-concurrency=targeted"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",
+    )
+
+    strict_concurrency_complete_test(
+        name = "{}_strict_concurrency_complete".format(name),
+        expected_argv = ["-strict-concurrency=complete"],
         mnemonic = "SwiftCompile",
         tags = all_tags,
         target_under_test = "@build_bazel_rules_swift//test/fixtures/compiler_arguments:bin",


### PR DESCRIPTION
Add features for the three accepted combinations of `-strict-concurrency=<value>`.
