### PR TITLE
Remove BCR fixed releaser config

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,3 +1,0 @@
-fixedReleaser:
-  login: BalestraPatrick
-  email: me@patrickbalestra.com


### PR DESCRIPTION
Without this file the commit should be attributed to the BCR bot which probably makes more sense.