### PR TITLE
Simplify `swift_library_group`

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -429,7 +429,7 @@ need to import the grouped libraries directly.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="swift_library_group-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="swift_library_group-deps"></a>deps |  A list of targets that should be included in the group.<br><br>Allowed kinds of dependencies are:<br><br>*   `swift_library` (or anything propagating `SwiftInfo`)<br><br>*   `cc_library` (or anything propagating `CcInfo`)<br><br>Additionally, on platforms that support Objective-C interop, `objc_library` targets (or anything propagating the `apple_common.Objc` provider) are allowed as dependencies. On platforms that do not support Objective-C interop (such as Linux), those dependencies will be **ignored.**   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="swift_library_group-deps"></a>deps |  A list of targets that should be included in the group. Allowed kinds of dependencies are:<br><br>*   `swift_library` (or anything propagating `SwiftInfo`)<br><br>*   `cc_library` (or anything propagating `CcInfo`)<br><br>Additionally, on platforms that support Objective-C interop, `objc_library` targets (or anything propagating the `apple_common.Objc` provider) are allowed as dependencies. On platforms that do not support Objective-C interop (such as Linux), those dependencies will be **ignored.**   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 
 
 <a id="swift_module_alias"></a>

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -203,11 +203,9 @@ bzl_library(
     deps = [
         ":providers",
         ":swift_clang_module_aspect",
-        ":swift_common",
         "//swift/internal:attrs",
-        "//swift/internal:toolchain_utils",
+        "//swift/internal:providers",
         "//swift/internal:utils",
-        "@bazel_skylib//lib:dicts",
     ],
 )
 


### PR DESCRIPTION
While working on something else I realized that the code for `swift_library_group` was more complex than it needed to be.