### PR TITLE
CI: complete the Windows CI coverage

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,6 +48,8 @@ x_defaults:
       # available on Windows
       - "--strategy=SwiftCompile="
       - "--compiler=clang-cl"
+      - "--subcommands=pretty_print"
+      - "--verbose_failures"
     build_targets:
       - "//tools/..."
     test_flags:
@@ -140,6 +142,7 @@ tasks:
       - echo --- Downloading and installing Swift %SWIFT_VERSION%
       - curl.exe -L https://download.swift.org/swift-5.10-branch/windows10/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a-windows10.exe -o %TEMP%\installer.exe
       - PowerShell Start-Process -FilePath ${env:TEMP}\installer.exe -ArgumentList(\"/install\", \"/passive\", \"/norestart\", \"/log log.txt\") -Wait -PassThru -Verb RunAs
+      - dir %LOCALAPPDATA%\Programs\Swift\Toolchains\%SWIFT_VERSION%+Asserts\\usr\\bin
     <<: *windows_common
 
   doc_tests:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -42,6 +42,7 @@ x_defaults:
       SWIFT_VERSION: 0.0.0
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
+      BAZEL_LLVM: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr"
     build_flags:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -38,12 +38,23 @@ x_defaults:
       - "-//test:output_file_map_default"
   windows_common: &windows_common
     platform: windows
+    environment:
+      SWIFT_VERSION: 0.0.0
+      PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
+      SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows
       - "--strategy=SwiftCompile="
     build_targets:
       - "//tools/..."
+    test_flags:
+     - "--compiler=clang-cl"
+    test_targets:
+      - "//examples/..."
+      - "-//examples/apple/..."
+      # TODO: Fix gRPC on Windows
+      - "-//examples/xplatform/grpc/..."
 
 tasks:
   macos_6:
@@ -120,11 +131,14 @@ tasks:
       - .bazelci/update_workspace_to_deps_heads.sh
     <<: *linux_common
 
-  # TODO: re-enable when Windows in Bazel CI is properly configured for Swift.
-  # windows_last_green:
-  #   name: "Last Green Bazel"
-  #   bazel: last_green
-  #   <<: *windows_common
+  windows_last_green:
+    name: "Last Green Bazel"
+    bazel: last_green
+    batch_commands:
+      - echo --- Downloading and installing Swift %SWIFT_VERSION%
+      - curl.exe -L https://download.swift.org/swift-5.10-branch/windows10/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a-windows10.exe -o %TEMP%\installer.exe
+      - PowerShell Start-Process -FilePath ${env:TEMP}\installer.exe -ArgumentList(\"/install\", \"/passive\", \"/norestart\", \"/log log.txt\") -Wait -PassThru -Verb RunAs
+    <<: *windows_common
 
   doc_tests:
     name: "Doc tests"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,6 +40,7 @@ x_defaults:
     platform: windows
     environment:
       SWIFT_VERSION: 0.0.0
+      CC: clang-cl
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,6 +40,7 @@ x_defaults:
     platform: windows
     environment:
       SWIFT_VERSION: 0.0.0
+      CC: "clang-cl"
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
       BAZEL_LLVM: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr"
@@ -50,10 +51,6 @@ x_defaults:
       - "--compiler=clang-cl"
       # TODO: Use the new way of setting toolchains.
       - "--noincompatible_enable_cc_toolchain_resolution"
-      - "--repo_env=CC=clang-cl"
-      - "--repo_env=BAZEL_LLVM=${{ env.BAZEL_LLVM }}"
-      - "--repo_env=SDKROOT=${{ env.SDKROOT }}"
-      - "--repo_env=Path=${{ env.PATH }}"
     build_targets:
       - "//tools/..."
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -50,6 +50,10 @@ x_defaults:
       - "--compiler=clang-cl"
       # TODO: Use the new way of setting toolchains.
       - "--noincompatible_enable_cc_toolchain_resolution"
+      - "--repo_env=CC=clang-cl"
+      - "--repo_env=BAZEL_LLVM=${{ env.BAZEL_LLVM }}"
+      - "--repo_env=SDKROOT=${{ env.SDKROOT }}"
+      - "--repo_env=Path=${{ env.PATH }}"
     build_targets:
       - "//tools/..."
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,13 +40,13 @@ x_defaults:
     platform: windows
     environment:
       SWIFT_VERSION: 0.0.0
-      CC: clang
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows
       - "--strategy=SwiftCompile="
+      - "--compiler=clang-cl"
     build_targets:
       - "//tools/..."
     test_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,20 +40,20 @@ x_defaults:
     platform: windows
     environment:
       SWIFT_VERSION: 0.0.0
-      CC: clang-cl
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows
       - "--strategy=SwiftCompile="
-      - "--compiler=clang-cl"
-      - "--subcommands=pretty_print"
-      - "--verbose_failures"
+      # TODO: Use the new way of setting toolchains.
+      - "--noincompatible_enable_cc_toolchain_resolution"
     build_targets:
       - "//tools/..."
     test_flags:
-     - "--compiler=clang-cl"
+      - "--compiler=clang-cl"
+      # TODO: Use the new way of setting toolchains.
+      - "--noincompatible_enable_cc_toolchain_resolution"
     test_targets:
       - "//examples/..."
       - "-//examples/apple/..."
@@ -142,7 +142,6 @@ tasks:
       - echo --- Downloading and installing Swift %SWIFT_VERSION%
       - curl.exe -L https://download.swift.org/swift-5.10-branch/windows10/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a/swift-5.10-DEVELOPMENT-SNAPSHOT-2024-01-18-a-windows10.exe -o %TEMP%\installer.exe
       - PowerShell Start-Process -FilePath ${env:TEMP}\installer.exe -ArgumentList(\"/install\", \"/passive\", \"/norestart\", \"/log log.txt\") -Wait -PassThru -Verb RunAs
-      - dir %LOCALAPPDATA%\Programs\Swift\Toolchains\%SWIFT_VERSION%+Asserts\\usr\\bin
     <<: *windows_common
 
   doc_tests:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -40,6 +40,7 @@ x_defaults:
     platform: windows
     environment:
       SWIFT_VERSION: 0.0.0
+      CC: clang
       PATH: "%LOCALAPPDATA%\\Programs\\Swift\\Toolchains\\%SWIFT_VERSION%+Asserts\\usr\\bin;%LOCALAPPDATA%\\Programs\\Swift\\Runtimes\\%SWIFT_VERSION%\\usr\\bin;%PATH%"
       SDKROOT: "%LOCALAPPDATA%\\Programs\\Swift\\Platforms\\%SWIFT_VERSION%\\Windows.platform\\Developer\\SDKs\\Windows.sdk"
     build_flags:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -46,6 +46,7 @@ x_defaults:
       # Override 'sandboxed' strategy set in .bazelrc because it's not
       # available on Windows
       - "--strategy=SwiftCompile="
+      - "--compiler=clang-cl"
       # TODO: Use the new way of setting toolchains.
       - "--noincompatible_enable_cc_toolchain_resolution"
     build_targets:

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -366,6 +366,8 @@ def _create_windows_toolchain(repository_ctx):
         "print(plistlib.loads(open(os.path.join(r'{}', '..', '..', '..', 'Info.plist'), 'rb').read(), fmt=plistlib.FMT_XML)['DefaultProperties']['XCTEST_VERSION'])".format(repository_ctx.os.environ["SDKROOT"]),
     ])
 
+    fail("Environment: {}".format(repository_ctx.os.environ))
+
     env = {
         "PATH": repository_ctx.os.environ["PATH"],
         "ProgramData": repository_ctx.os.environ["ProgramData"],

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -368,7 +368,7 @@ def _create_windows_toolchain(repository_ctx):
 
     env = {
         "PATH": repository_ctx.os.environ["PATH"],
-        "PROGRAMDATA": repository_ctx.os.environ["PROGRAMDATA"],
+        "ProgramData": repository_ctx.os.environ["ProgramData"],
     }
 
     repository_ctx.file(
@@ -416,7 +416,7 @@ def _swift_autoconfiguration_impl(repository_ctx):
         _create_linux_toolchain(repository_ctx)
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "PROGRAMDATA"],
+    environ = ["CC", "PATH", "ProgramData"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -366,11 +366,9 @@ def _create_windows_toolchain(repository_ctx):
         "print(plistlib.loads(open(os.path.join(r'{}', '..', '..', '..', 'Info.plist'), 'rb').read(), fmt=plistlib.FMT_XML)['DefaultProperties']['XCTEST_VERSION'])".format(repository_ctx.os.environ["SDKROOT"]),
     ])
 
-    fail("Environment: {}".format(repository_ctx.os.environ))
-
     env = {
-        "PATH": repository_ctx.os.environ["PATH"],
-        "ProgramData": repository_ctx.os.environ["ProgramData"],
+        "PATH": repository_ctx.os.environ["PATH"] if "PATH" in repository_ctx.os.environ else repository_ctx.os.environ["Path"],
+        "ProgramData": repository_ctx.os.environ["ProgramData"] if "ProgramData" in repository_ctx.os.environ else repository_ctx.os.environ["PROGRAMDATA"],
     }
 
     repository_ctx.file(
@@ -418,7 +416,7 @@ def _swift_autoconfiguration_impl(repository_ctx):
         _create_linux_toolchain(repository_ctx)
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "ProgramData"],
+    environ = ["CC", "PATH", "ProgramData", "Path"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -367,8 +367,8 @@ def _create_windows_toolchain(repository_ctx):
     ])
 
     env = {
-        "Path": repository_ctx.os.environ["Path"] if "Path" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
-        "ProgramData": repository_ctx.os.environ["ProgramData"],
+        "PATH": repository_ctx.os.environ["PATH"] if "PATH" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
+        "PROGRAMDATA": repository_ctx.os.environ["PROGRAMDATA"],
     }
 
     repository_ctx.file(
@@ -416,7 +416,7 @@ def _swift_autoconfiguration_impl(repository_ctx):
         _create_linux_toolchain(repository_ctx)
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "ProgramData", "Path"],
+    environ = ["CC", "PATH", "PROGRAMDATA"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -367,7 +367,7 @@ def _create_windows_toolchain(repository_ctx):
     ])
 
     env = {
-        "PATH": repository_ctx.os.environ["Path"] if "Path" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
+        "PATH": repository_ctx.os.environ["PATH"],
         "PROGRAMDATA": repository_ctx.os.environ["PROGRAMDATA"],
     }
 
@@ -416,7 +416,7 @@ def _swift_autoconfiguration_impl(repository_ctx):
         _create_linux_toolchain(repository_ctx)
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "PROGRAMDATA", "Path"],
+    environ = ["CC", "PATH", "PROGRAMDATA"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -367,7 +367,7 @@ def _create_windows_toolchain(repository_ctx):
     ])
 
     env = {
-        "PATH": repository_ctx.os.environ["PATH"] if "PATH" in repository_ctx.os.environ else repository_ctx.os.environ["Path"],
+        "Path": repository_ctx.os.environ["Path"] if "Path" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
         "ProgramData": repository_ctx.os.environ["ProgramData"] if "ProgramData" in repository_ctx.os.environ else repository_ctx.os.environ["PROGRAMDATA"],
     }
 

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -367,7 +367,7 @@ def _create_windows_toolchain(repository_ctx):
     ])
 
     env = {
-        "PATH": repository_ctx.os.environ["PATH"] if "PATH" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
+        "PATH": repository_ctx.os.environ["Path"] if "Path" in repository_ctx.os.environ else repository_ctx.os.environ["PATH"],
         "PROGRAMDATA": repository_ctx.os.environ["PROGRAMDATA"],
     }
 
@@ -416,7 +416,7 @@ def _swift_autoconfiguration_impl(repository_ctx):
         _create_linux_toolchain(repository_ctx)
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "PROGRAMDATA"],
+    environ = ["CC", "PATH", "PROGRAMDATA", "Path"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -421,7 +421,8 @@ def _swift_toolchain_impl(ctx):
     if "clang" not in cc_toolchain.compiler:
         fail("Swift requires the configured CC toolchain to be LLVM (clang). " +
              "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
-             "before invoking Bazel, or configure a Bazel LLVM CC toolchain. Configured compiler is %s." % cc_toolchain.compiler)
+             "before invoking Bazel, or configure a Bazel LLVM CC toolchain. " +
+             "Found compiler is %s." % cc_toolchain.compiler)
 
     if ctx.attr.os == "windows":
         swift_linkopts_cc_info = _swift_windows_linkopts_cc_info(

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -421,7 +421,7 @@ def _swift_toolchain_impl(ctx):
     if "clang" not in cc_toolchain.compiler:
         fail("Swift requires the configured CC toolchain to be LLVM (clang). " +
              "Either use the locally installed LLVM by setting `CC=clang` in your environment " +
-             "before invoking Bazel, or configure a Bazel LLVM CC toolchain.")
+             "before invoking Bazel, or configure a Bazel LLVM CC toolchain. Configured compiler is %s." % cc_toolchain.compiler)
 
     if ctx.attr.os == "windows":
         swift_linkopts_cc_info = _swift_windows_linkopts_cc_info(

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -506,7 +506,7 @@ def _swift_toolchain_impl(ctx):
         xctest = paths.normalize(paths.join(ctx.attr.sdkroot, "..", "..", "Library", "XCTest-{}".format(ctx.attr.xctest_version), "usr", bindir))
         env = dicts.add(
             ctx.attr.env,
-            {"Path": xctest + ";" + ctx.attr.env["Path"]},
+            {"Path": xctest + ";" + ctx.attr.env["PATH"]},
         )
     else:
         env = ctx.attr.env


### PR DESCRIPTION
Extend the Windows CI to include the tests as well.  This will mostly complete the Windows support (the remaining pieces remain in supporting the Windows ARM64 build host).