### PR TITLE
Fix coverage executable substitution in template

### DIFF
--- a/tools/xctest_runner/xctest_runner.sh.template
+++ b/tools/xctest_runner/xctest_runner.sh.template
@@ -88,7 +88,7 @@ xcrun llvm-cov \
   -instr-profile "$profdata" \
   -ignore-filename-regex='.*external/.+' \
   -path-equivalence="$ROOT",. \
-  "%executable%" \
+  "$executable_path" \
   @"$COVERAGE_MANIFEST" \
   > "$COVERAGE_OUTPUT_FILE" \
   2> "$error_file" \


### PR DESCRIPTION
Looks like the change in https://github.com/bazelbuild/rules_swift/commit/d6b7f13d42d5a030247421e795e01148f517adc2 forgot to replace the `%executable%` reference for running coverage.