### PR TITLE
Expose additional utilities through swift_common for custom swift libraries

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -156,6 +156,38 @@ A `struct` with the following fields:
           macros).
 
 
+<a id="swift_common.compile_and_create_linking_context"></a>
+
+## swift_common.compile_and_create_linking_context
+
+<pre>
+swift_common.compile_and_create_linking_context(<a href="#swift_common.compile_and_create_linking_context-attr">attr</a>, <a href="#swift_common.compile_and_create_linking_context-ctx">ctx</a>, <a href="#swift_common.compile_and_create_linking_context-target_label">target_label</a>, <a href="#swift_common.compile_and_create_linking_context-module_name">module_name</a>, <a href="#swift_common.compile_and_create_linking_context-swift_srcs">swift_srcs</a>,
+                                                <a href="#swift_common.compile_and_create_linking_context-compiler_deps">compiler_deps</a>)
+</pre>
+
+Compiles the Swift source files into a module and creates a linking context from it.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.compile_and_create_linking_context-attr"></a>attr |  The attributes of the target for which the module is being compiled.   |  none |
+| <a id="swift_common.compile_and_create_linking_context-ctx"></a>ctx |  The context of the aspect or rule.   |  none |
+| <a id="swift_common.compile_and_create_linking_context-target_label"></a>target_label |  The label of the target for which the module is being compiled.   |  none |
+| <a id="swift_common.compile_and_create_linking_context-module_name"></a>module_name |  The name of the Swift module that should be compiled from the source files.   |  none |
+| <a id="swift_common.compile_and_create_linking_context-swift_srcs"></a>swift_srcs |  List of Swift source files to be compiled into the module.   |  none |
+| <a id="swift_common.compile_and_create_linking_context-compiler_deps"></a>compiler_deps |  List of dependencies required to compile the source files.   |  none |
+
+**RETURNS**
+
+A struct with the following fields:
+  direct_cc_info: CcInfo provider generated directly by this target.
+  direct_objc_info: apple_common.Objc provider generated directly by this target.
+  direct_swift_info: SwiftInfo provider generated directly by this target.
+  direct_output_group_info: OutputGroupInfo provider generated directly by this target.
+
+
 <a id="swift_common.compile_module_interface"></a>
 
 ## swift_common.compile_module_interface
@@ -573,6 +605,37 @@ Extracts the symbol graph from a Swift module.
 | <a id="swift_common.extract_symbol_graph-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 
 
+<a id="swift_common.get_providers"></a>
+
+## swift_common.get_providers
+
+<pre>
+swift_common.get_providers(<a href="#swift_common.get_providers-targets">targets</a>, <a href="#swift_common.get_providers-provider">provider</a>, <a href="#swift_common.get_providers-map_fn">map_fn</a>)
+</pre>
+
+Returns the given provider (or a field) from each target in the list.
+
+The returned list may not be the same size as `targets` if some of the
+targets do not contain the requested provider. This is not an error.
+
+The main purpose of this function is to make this common operation more
+readable and prevent mistyping the list comprehension.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.get_providers-targets"></a>targets |  A list of targets.   |  none |
+| <a id="swift_common.get_providers-provider"></a>provider |  The provider to retrieve.   |  none |
+| <a id="swift_common.get_providers-map_fn"></a>map_fn |  A function that takes a single argument and returns a single value. If this is present, it will be called on each provider in the list and the result will be returned in the list returned by `get_providers`.   |  `None` |
+
+**RETURNS**
+
+A list of the providers requested from the targets.
+
+
 <a id="swift_common.get_toolchain"></a>
 
 ## swift_common.get_toolchain
@@ -594,6 +657,29 @@ Gets the Swift toolchain associated with the rule or aspect.
 **RETURNS**
 
 A `SwiftToolchainInfo` provider.
+
+
+<a id="swift_common.include_developer_search_paths"></a>
+
+## swift_common.include_developer_search_paths
+
+<pre>
+swift_common.include_developer_search_paths(<a href="#swift_common.include_developer_search_paths-attr">attr</a>)
+</pre>
+
+Determines whether to include developer search paths.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.include_developer_search_paths-attr"></a>attr |  A rule's `ctx.attr`.   |  none |
+
+**RETURNS**
+
+A `bool` where `True` indicates that the developer search paths should
+  be included during compilation. Otherwise, `False`.
 
 
 <a id="swift_common.is_enabled"></a>
@@ -675,6 +761,40 @@ A new attribute dictionary that can be added to the attributes of a
   custom build rule to provide the same interface as `swift_library`.
 
 
+<a id="swift_common.new_objc_provider"></a>
+
+## swift_common.new_objc_provider
+
+<pre>
+swift_common.new_objc_provider(<a href="#swift_common.new_objc_provider-additional_link_inputs">additional_link_inputs</a>, <a href="#swift_common.new_objc_provider-additional_objc_infos">additional_objc_infos</a>, <a href="#swift_common.new_objc_provider-alwayslink">alwayslink</a>, <a href="#swift_common.new_objc_provider-deps">deps</a>,
+                               <a href="#swift_common.new_objc_provider-feature_configuration">feature_configuration</a>, <a href="#swift_common.new_objc_provider-is_test">is_test</a>, <a href="#swift_common.new_objc_provider-libraries_to_link">libraries_to_link</a>, <a href="#swift_common.new_objc_provider-module_context">module_context</a>,
+                               <a href="#swift_common.new_objc_provider-user_link_flags">user_link_flags</a>, <a href="#swift_common.new_objc_provider-swift_toolchain">swift_toolchain</a>)
+</pre>
+
+Creates an `apple_common.Objc` provider for a Swift target.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.new_objc_provider-additional_link_inputs"></a>additional_link_inputs |  Additional linker input files that should be propagated to dependents.   |  `[]` |
+| <a id="swift_common.new_objc_provider-additional_objc_infos"></a>additional_objc_infos |  Additional `apple_common.Objc` providers from transitive dependencies not provided by the `deps` argument.   |  `[]` |
+| <a id="swift_common.new_objc_provider-alwayslink"></a>alwayslink |  If True, any binary that depends on the providers returned by this function will link in all of the library's object files, even if some contain no symbols referenced by the binary.   |  `False` |
+| <a id="swift_common.new_objc_provider-deps"></a>deps |  The dependencies of the target being built, whose `Objc` providers will be passed to the new one in order to propagate the correct transitive fields.   |  none |
+| <a id="swift_common.new_objc_provider-feature_configuration"></a>feature_configuration |  The Swift feature configuration.   |  none |
+| <a id="swift_common.new_objc_provider-is_test"></a>is_test |  Represents if the `testonly` value of the context.   |  none |
+| <a id="swift_common.new_objc_provider-libraries_to_link"></a>libraries_to_link |  A list (typically of one element) of the `LibraryToLink` objects from which the static archives (`.a` files) containing the target's compiled code will be retrieved.   |  none |
+| <a id="swift_common.new_objc_provider-module_context"></a>module_context |  The module context as returned by `swift_common.compile`.   |  none |
+| <a id="swift_common.new_objc_provider-user_link_flags"></a>user_link_flags |  Linker options that should be propagated to dependents.   |  `[]` |
+| <a id="swift_common.new_objc_provider-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
+
+**RETURNS**
+
+An `apple_common.Objc` provider that should be returned by the calling
+  rule.
+
+
 <a id="swift_common.precompile_clang_module"></a>
 
 ## swift_common.precompile_clang_module
@@ -705,6 +825,30 @@ Precompiles an explicit Clang module that is compatible with Swift.
 
 A `File` representing the precompiled module (`.pcm`) file, or `None` if
   the toolchain or target does not support precompiled modules.
+
+
+<a id="swift_common.supplemental_compilation_output_groups"></a>
+
+## swift_common.supplemental_compilation_output_groups
+
+<pre>
+swift_common.supplemental_compilation_output_groups(<a href="#swift_common.supplemental_compilation_output_groups-supplemental_outputs">supplemental_outputs</a>)
+</pre>
+
+Computes output groups from supplemental compilation outputs.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="swift_common.supplemental_compilation_output_groups-supplemental_outputs"></a>supplemental_outputs |  Zero or more supplemental outputs `struct`s returned from calls to `swift_common.compile`.   |  none |
+
+**RETURNS**
+
+A dictionary whose keys are output group names and whose values are
+  depsets of `File`s, which is suitable to be `**kwargs`-expanded into an
+  `OutputGroupInfo` provider.
 
 
 <a id="swift_common.toolchain_attrs"></a>

--- a/examples/xplatform/custom_swift_library/BUILD.bazel
+++ b/examples/xplatform/custom_swift_library/BUILD.bazel
@@ -1,27 +1,27 @@
 load(
-    "//examples/xplatform/custom_swift_library:custom_swift_library.bzl", 
-    "custom_swift_library"
+    "//examples/xplatform/custom_swift_library:custom_swift_library.bzl",
+    "custom_swift_library",
 )
 load("//swift:swift_binary.bzl", "swift_binary")
 load("//swift:swift_library.bzl", "swift_library")
 
 swift_library(
     name = "regular",
-    module_name = "Regular",
     srcs = [
-        "Regular.swift"
-    ]
+        "Regular.swift",
+    ],
+    module_name = "Regular",
 )
 
 custom_swift_library(
     name = "custom",
+    custom_type_name = "Custom",
     module_name = "Custom",
     regular_import = "import Regular",
     regular_type_name = "Regular",
-    custom_type_name = "Custom",
     deps = [
-        ":regular"
-    ]
+        ":regular",
+    ],
 )
 
 swift_binary(
@@ -29,6 +29,6 @@ swift_binary(
     srcs = ["main.swift"],
     deps = [
         ":custom",
-        ":regular"
-    ]
+        ":regular",
+    ],
 )

--- a/examples/xplatform/custom_swift_library/BUILD.bazel
+++ b/examples/xplatform/custom_swift_library/BUILD.bazel
@@ -1,0 +1,34 @@
+load(
+    "//examples/xplatform/custom_swift_library:custom_swift_library.bzl", 
+    "custom_swift_library"
+)
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_library.bzl", "swift_library")
+
+swift_library(
+    name = "regular",
+    module_name = "Regular",
+    srcs = [
+        "Regular.swift"
+    ]
+)
+
+custom_swift_library(
+    name = "custom",
+    module_name = "Custom",
+    regular_import = "import Regular",
+    regular_type_name = "Regular",
+    custom_type_name = "Custom",
+    deps = [
+        ":regular"
+    ]
+)
+
+swift_binary(
+    name = "binary",
+    srcs = ["main.swift"],
+    deps = [
+        ":custom",
+        ":regular"
+    ]
+)

--- a/examples/xplatform/custom_swift_library/Regular.swift
+++ b/examples/xplatform/custom_swift_library/Regular.swift
@@ -1,0 +1,4 @@
+
+public struct Regular {
+    public init() {}
+}

--- a/examples/xplatform/custom_swift_library/custom_swift_library.bzl
+++ b/examples/xplatform/custom_swift_library/custom_swift_library.bzl
@@ -1,0 +1,107 @@
+"""
+A custom Bazel rule which behaves similar to swift_library but it autogenerates its source files.
+"""
+
+load(
+    "@bazel_skylib//lib:dicts.bzl",
+    "dicts",
+)
+load(
+    "//swift:swift_clang_module_aspect.bzl",
+    "swift_clang_module_aspect"
+)
+load(
+    "//swift:swift_common.bzl", 
+    "swift_common"
+)
+
+def _compact(sequence):
+    return [item for item in sequence if item != None]
+
+def _custom_swift_library_impl(ctx):
+    target_label = ctx.label
+
+    # Create the swift file:
+    custom_file_format = """\
+{}
+public struct {} {{
+    let regular: {}
+
+    public init(regular: {}) {{
+        self.regular = regular
+    }}
+}}
+"""
+    custom_file_content = custom_file_format.format(
+        ctx.attr.regular_import,
+        ctx.attr.custom_type_name,
+        ctx.attr.regular_type_name,
+        ctx.attr.regular_type_name,
+    )
+    custom_file = ctx.actions.declare_file("{}.swift".format(ctx.label.name))
+    ctx.actions.write(custom_file, custom_file_content)
+
+    # Compile the swift file into a library:
+    direct_providers = swift_common.compile_and_create_linking_context(
+        attr = ctx.attr,
+        ctx = ctx,
+        target_label = target_label,
+        module_name = getattr(ctx.attr, "module_name", target_label.name),
+        swift_srcs = [custom_file],
+        compiler_deps = getattr(ctx.attr, "deps", []),
+    )
+
+    # Map the providers:
+    direct_cc_info = direct_providers.direct_cc_info
+    direct_objc_info = direct_providers.direct_objc_info
+    direct_swift_info = direct_providers.direct_swift_info
+    direct_output_group_info = direct_providers.direct_output_group_info
+    direct_files = _compact(
+        [module.swift.swiftdoc for module in direct_swift_info.direct_modules] +
+        [module.swift.swiftinterface for module in direct_swift_info.direct_modules] +
+        [module.swift.private_swiftinterface for module in direct_swift_info.direct_modules] +
+        [module.swift.swiftmodule for module in direct_swift_info.direct_modules] +
+        [module.swift.swiftsourceinfo for module in direct_swift_info.direct_modules]
+    )
+
+    return [
+        DefaultInfo(
+            files = depset(
+                direct_files,
+                transitive = [depset([custom_file])],
+            ),
+            runfiles = ctx.runfiles(
+                collect_data = True,
+                collect_default = True,
+                files = ctx.files.data,
+            ),
+        ),
+        direct_cc_info,
+        direct_objc_info,
+        direct_swift_info,
+        direct_output_group_info,
+    ]
+
+custom_swift_library = rule(
+    attrs = dicts.add(
+        swift_common.library_rule_attrs(
+            additional_deps_aspects = [
+                swift_clang_module_aspect,
+            ],
+            requires_srcs = False,
+        ),
+        {
+            "regular_import": attr.string(),
+            "regular_type_name": attr.string(),
+            "custom_type_name": attr.string(),
+        }
+    ),
+    doc = """
+Demonstrates how to create a custom rule which propagates the same providers 
+as swift_library, while having custom logic to generate the source files and other
+configurations.
+""",
+    fragments = ["cpp"],
+    implementation = _custom_swift_library_impl,
+    toolchains = swift_common.use_toolchain(),
+)

--- a/examples/xplatform/custom_swift_library/custom_swift_library.bzl
+++ b/examples/xplatform/custom_swift_library/custom_swift_library.bzl
@@ -8,11 +8,11 @@ load(
 )
 load(
     "//swift:swift_clang_module_aspect.bzl",
-    "swift_clang_module_aspect"
+    "swift_clang_module_aspect",
 )
 load(
-    "//swift:swift_common.bzl", 
-    "swift_common"
+    "//swift:swift_common.bzl",
+    "swift_common",
 )
 
 def _compact(sequence):
@@ -61,7 +61,7 @@ public struct {} {{
         [module.swift.swiftinterface for module in direct_swift_info.direct_modules] +
         [module.swift.private_swiftinterface for module in direct_swift_info.direct_modules] +
         [module.swift.swiftmodule for module in direct_swift_info.direct_modules] +
-        [module.swift.swiftsourceinfo for module in direct_swift_info.direct_modules]
+        [module.swift.swiftsourceinfo for module in direct_swift_info.direct_modules],
     )
 
     return [
@@ -94,7 +94,7 @@ custom_swift_library = rule(
             "regular_import": attr.string(),
             "regular_type_name": attr.string(),
             "custom_type_name": attr.string(),
-        }
+        },
     ),
     doc = """
 Demonstrates how to create a custom rule which propagates the same providers 

--- a/examples/xplatform/custom_swift_library/custom_swift_library.bzl
+++ b/examples/xplatform/custom_swift_library/custom_swift_library.bzl
@@ -19,7 +19,6 @@ def _compact(sequence):
     return [item for item in sequence if item != None]
 
 def _custom_swift_library_impl(ctx):
-
     # Create the swift file:
     custom_file_format = """\
 {}

--- a/examples/xplatform/custom_swift_library/custom_swift_library.bzl
+++ b/examples/xplatform/custom_swift_library/custom_swift_library.bzl
@@ -19,7 +19,6 @@ def _compact(sequence):
     return [item for item in sequence if item != None]
 
 def _custom_swift_library_impl(ctx):
-    target_label = ctx.label
 
     # Create the swift file:
     custom_file_format = """\
@@ -45,8 +44,8 @@ public struct {} {{
     direct_providers = swift_common.compile_and_create_linking_context(
         attr = ctx.attr,
         ctx = ctx,
-        target_label = target_label,
-        module_name = getattr(ctx.attr, "module_name", target_label.name),
+        target_label = ctx.label,
+        module_name = getattr(ctx.attr, "module_name", ctx.label.name),
         swift_srcs = [custom_file],
         compiler_deps = getattr(ctx.attr, "deps", []),
     )

--- a/examples/xplatform/custom_swift_library/main.swift
+++ b/examples/xplatform/custom_swift_library/main.swift
@@ -1,0 +1,7 @@
+import Custom
+import Regular
+
+let regular = Regular()
+let custom = Custom(regular: regular)
+
+print(String(describing: custom))

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -32,9 +32,6 @@ load("//swift:swift_common.bzl", "swift_common")
 load("//swift/internal:attrs.bzl", "swift_deps_attr")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:toolchain_utils.bzl", "use_swift_toolchain")
-
-# buildifier: disable=bzl-visibility
 load("//swift/internal:utils.bzl", "compact")
 load(
     ":swift_proto_utils.bzl",
@@ -187,5 +184,5 @@ swift_proto_library(
 """,
     fragments = ["cpp"],
     implementation = _swift_proto_library_impl,
-    toolchains = use_swift_toolchain(),
+    toolchains = swift_common.use_toolchain(),
 )

--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -28,25 +28,6 @@ load(
 )
 load("//swift:swift_common.bzl", "swift_common")
 
-# buildifier: disable=bzl-visibility
-load(
-    "//swift/internal:linking.bzl",
-    "new_objc_provider",
-)
-
-# buildifier: disable=bzl-visibility
-load(
-    "//swift/internal:output_groups.bzl",
-    "supplemental_compilation_output_groups",
-)
-
-# buildifier: disable=bzl-visibility
-load(
-    "//swift/internal:utils.bzl",
-    "get_providers",
-    "include_developer_search_paths",
-)
-
 def proto_path(proto_src, proto_info):
     """Derives the string used to import the proto.
 
@@ -266,19 +247,19 @@ def compile_swift_protos_for_target(
     )
 
     # Compile the generated Swift source files as a module:
-    include_dev_srch_paths = include_developer_search_paths(attr)
+    include_dev_srch_paths = swift_common.include_developer_search_paths(attr)
     compile_result = swift_common.compile(
         actions = ctx.actions,
-        cc_infos = get_providers(compiler_deps, CcInfo),
+        cc_infos = swift_common.get_providers(compiler_deps, CcInfo),
         copts = ["-parse-as-library"],
         feature_configuration = feature_configuration,
         include_dev_srch_paths = include_dev_srch_paths,
         module_name = module_name,
-        objc_infos = get_providers(compiler_deps, apple_common.Objc),
+        objc_infos = swift_common.get_providers(compiler_deps, apple_common.Objc),
         package_name = None,
         srcs = generated_swift_srcs,
         swift_toolchain = swift_toolchain,
-        swift_infos = get_providers(compiler_deps, SwiftInfo),
+        swift_infos = swift_common.get_providers(compiler_deps, SwiftInfo),
         target_name = target_label.name,
         workspace_name = ctx.workspace_name,
     )
@@ -305,37 +286,28 @@ def compile_swift_protos_for_target(
         )
     )
 
-    # Extract the swift toolchain and configure the features:
-    swift_toolchain = swift_common.get_toolchain(ctx)
-    feature_configuration = swift_common.configure_features(
-        ctx = ctx,
-        requested_features = ctx.features,
-        swift_toolchain = swift_toolchain,
-        unsupported_features = ctx.disabled_features,
-    )
-
     # Gather the transitive cc info providers:
-    transitive_cc_infos = get_providers(
+    transitive_cc_infos = swift_common.get_providers(
         compiler_deps,
         SwiftProtoCcInfo,
         lambda proto_cc_info: proto_cc_info.cc_info,
-    ) + get_providers(compiler_deps, CcInfo)
+    ) + swift_common.get_providers(compiler_deps, CcInfo)
 
     # Gather the transitive objc info providers:
-    transitive_objc_infos = get_providers(
+    transitive_objc_infos = swift_common.get_providers(
         compiler_deps,
         SwiftProtoCcInfo,
         lambda proto_cc_info: proto_cc_info.objc_info,
-    ) + get_providers(compiler_deps, apple_common.Objc)
+    ) + swift_common.get_providers(compiler_deps, apple_common.Objc)
 
     # Gather the transitive swift info providers:
-    transitive_swift_infos = get_providers(
+    transitive_swift_infos = swift_common.get_providers(
         compiler_deps,
         SwiftInfo,
     )
 
     # Gather the transitive swift proto info providers:
-    transitive_swift_proto_infos = get_providers(
+    transitive_swift_proto_infos = swift_common.get_providers(
         compiler_deps,
         SwiftProtoInfo,
     )
@@ -352,7 +324,7 @@ def compile_swift_protos_for_target(
     )
 
     # Create the direct objc info provider:
-    direct_objc_info = new_objc_provider(
+    direct_objc_info = swift_common.new_objc_provider(
         additional_objc_infos = (
             transitive_objc_infos +
             swift_toolchain.implicit_deps_providers.objc_infos
@@ -373,7 +345,7 @@ def compile_swift_protos_for_target(
 
     # Create the direct output group info provider:
     direct_output_group_info = OutputGroupInfo(
-        **supplemental_compilation_output_groups(
+        **swift_common.supplemental_compilation_output_groups(
             supplemental_outputs,
         )
     )

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -111,6 +111,7 @@ bzl_library(
     deps = [
         "//swift/internal:attrs",
         "//swift/internal:compiling",
+        "//swift/internal:compiling_and_linking",
         "//swift/internal:features",
         "//swift/internal:linking",
         "//swift/internal:providers",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -292,6 +292,7 @@ filegroup(
         "//swift:__pkg__",
     ],
 )
+
 bzl_library(
     name = "compiling_and_linking",
     srcs = ["compiling_and_linking.bzl"],
@@ -307,4 +308,3 @@ bzl_library(
         "//swift:providers",
     ],
 )
-

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -292,3 +292,19 @@ filegroup(
         "//swift:__pkg__",
     ],
 )
+bzl_library(
+    name = "compiling_and_linking",
+    srcs = ["compiling_and_linking.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        ":compiling",
+        ":features",
+        ":linking",
+        ":output_groups",
+        ":providers",
+        ":toolchain_utils",
+        ":utils",
+        "//swift:providers",
+    ],
+)
+

--- a/swift/internal/compiling_and_linking.bzl
+++ b/swift/internal/compiling_and_linking.bzl
@@ -1,0 +1,168 @@
+"""
+Utility function to compile and link swift source files into a module,
+producing a similar set of providers as swift_library.
+"""
+
+load(
+    "//swift:providers.bzl",
+    "SwiftInfo",
+)
+load(
+    "//swift/internal:compiling.bzl",
+    "compile"
+)
+load(
+    "//swift/internal:features.bzl",
+    "configure_features"
+)
+load(
+    "//swift/internal:linking.bzl",
+    "create_linking_context_from_compilation_outputs",
+    "new_objc_provider",
+)
+load(
+    "//swift/internal:output_groups.bzl",
+    "supplemental_compilation_output_groups",
+)
+load(
+    "//swift/internal:providers.bzl",
+    "create_swift_info"
+)
+load(
+    "//swift/internal:toolchain_utils.bzl",
+    "get_swift_toolchain"
+)
+load(
+    "//swift/internal:utils.bzl",
+    "get_providers",
+    "include_developer_search_paths",
+)
+
+def compile_and_create_linking_context(
+        *,
+        attr,
+        ctx,
+        target_label,
+        module_name,
+        swift_srcs,
+        compiler_deps):
+    """ Compiles the Swift source files into a module and creates a linking context from it.
+
+    Args:
+        attr: The attributes of the target for which the module is being compiled.
+        ctx: The context of the aspect or rule.
+        target_label: The label of the target for which the module is being compiled.
+        module_name: The name of the Swift module that should be compiled from the source files.
+        swift_srcs: List of Swift source files to be compiled into the module.
+        compiler_deps: List of dependencies required to compile the source files.
+
+    Returns:
+        A struct with the following fields:
+        direct_cc_info: CcInfo provider generated directly by this target.
+        direct_objc_info: apple_common.Objc provider generated directly by this target.
+        direct_swift_info: SwiftInfo provider generated directly by this target.
+        direct_output_group_info: OutputGroupInfo provider generated directly by this target.
+    """
+
+    # Extract the swift toolchain and configure the features:
+    swift_toolchain = get_swift_toolchain(ctx)
+    feature_configuration = configure_features(
+        ctx = ctx,
+        requested_features = ctx.features,
+        swift_toolchain = swift_toolchain,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    # Compile the generated Swift source files as a module:
+    include_dev_srch_paths = include_developer_search_paths(attr)
+    compile_result = compile(
+        actions = ctx.actions,
+        cc_infos = get_providers(compiler_deps, CcInfo),
+        copts = ["-parse-as-library"],
+        feature_configuration = feature_configuration,
+        include_dev_srch_paths = include_dev_srch_paths,
+        module_name = module_name,
+        objc_infos = get_providers(compiler_deps, apple_common.Objc),
+        package_name = None,
+        srcs = swift_srcs,
+        swift_toolchain = swift_toolchain,
+        swift_infos = get_providers(compiler_deps, SwiftInfo),
+        target_name = target_label.name,
+        workspace_name = ctx.workspace_name,
+    )
+
+    module_context = compile_result.module_context
+    compilation_outputs = compile_result.compilation_outputs
+    supplemental_outputs = compile_result.supplemental_outputs
+
+    # Create the linking context from the compilation outputs:
+    linking_context, linking_output = (
+        create_linking_context_from_compilation_outputs(
+            actions = ctx.actions,
+            compilation_outputs = compilation_outputs,
+            feature_configuration = feature_configuration,
+            include_dev_srch_paths = include_dev_srch_paths,
+            label = target_label,
+            linking_contexts = [
+                dep[CcInfo].linking_context
+                for dep in compiler_deps
+                if CcInfo in dep
+            ],
+            module_context = module_context,
+            swift_toolchain = swift_toolchain,
+        )
+    )
+
+    # Gather the transitive cc info providers:
+    transitive_cc_infos = get_providers(compiler_deps, CcInfo)
+
+    # Gather the transitive objc info providers:
+    transitive_objc_infos = get_providers(compiler_deps, apple_common.Objc)
+
+    # Gather the transitive swift info providers:
+    transitive_swift_infos = get_providers(compiler_deps, SwiftInfo)
+
+    # Create the direct cc info provider:
+    direct_cc_info = cc_common.merge_cc_infos(
+        direct_cc_infos = [
+            CcInfo(
+                compilation_context = module_context.clang.compilation_context,
+                linking_context = linking_context,
+            ),
+        ],
+        cc_infos = transitive_cc_infos,
+    )
+
+    # Create the direct objc info provider:
+    direct_objc_info = new_objc_provider(
+        additional_objc_infos = (
+            transitive_objc_infos +
+            swift_toolchain.implicit_deps_providers.objc_infos
+        ),
+        deps = [],
+        feature_configuration = feature_configuration,
+        is_test = False,
+        module_context = module_context,
+        libraries_to_link = [linking_output.library_to_link],
+        swift_toolchain = swift_toolchain,
+    )
+
+    # Create the direct swift info provider:
+    direct_swift_info = create_swift_info(
+        modules = [module_context],
+        swift_infos = transitive_swift_infos,
+    )
+
+    # Create the direct output group info provider:
+    direct_output_group_info = OutputGroupInfo(
+        **supplemental_compilation_output_groups(
+            supplemental_outputs,
+        )
+    )
+
+    return struct(
+        direct_cc_info = direct_cc_info,
+        direct_objc_info = direct_objc_info,
+        direct_swift_info = direct_swift_info,
+        direct_output_group_info = direct_output_group_info,
+    )

--- a/swift/internal/compiling_and_linking.bzl
+++ b/swift/internal/compiling_and_linking.bzl
@@ -9,11 +9,11 @@ load(
 )
 load(
     "//swift/internal:compiling.bzl",
-    "compile"
+    "compile",
 )
 load(
     "//swift/internal:features.bzl",
-    "configure_features"
+    "configure_features",
 )
 load(
     "//swift/internal:linking.bzl",
@@ -26,11 +26,11 @@ load(
 )
 load(
     "//swift/internal:providers.bzl",
-    "create_swift_info"
+    "create_swift_info",
 )
 load(
     "//swift/internal:toolchain_utils.bzl",
-    "get_swift_toolchain"
+    "get_swift_toolchain",
 )
 load(
     "//swift/internal:utils.bzl",

--- a/swift/swift_common.bzl
+++ b/swift/swift_common.bzl
@@ -35,6 +35,10 @@ load(
     "precompile_clang_module",
 )
 load(
+    "//swift/internal:compiling_and_linking.bzl",
+    "compile_and_create_linking_context",
+)
+load(
     "//swift/internal:features.bzl",
     "configure_features",
     "get_cc_feature_configuration",
@@ -43,6 +47,11 @@ load(
 load(
     "//swift/internal:linking.bzl",
     "create_linking_context_from_compilation_outputs",
+    "new_objc_provider",
+)
+load(
+    "//swift/internal:output_groups.bzl",
+    "supplemental_compilation_output_groups",
 )
 load(
     "//swift/internal:providers.bzl",
@@ -61,6 +70,11 @@ load(
     "get_swift_toolchain",
     "use_swift_toolchain",
 )
+load(
+    "//swift/internal:utils.bzl",
+    "get_providers",
+    "include_developer_search_paths",
+)
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -73,6 +87,7 @@ swift_common = struct(
     create_clang_module = create_clang_module,
     create_compilation_context = create_compilation_context,
     create_linking_context_from_compilation_outputs = create_linking_context_from_compilation_outputs,
+    compile_and_create_linking_context = compile_and_create_linking_context,
     create_module = create_module,
     create_swift_info = create_swift_info,
     create_swift_interop_info = create_swift_interop_info,
@@ -80,9 +95,13 @@ swift_common = struct(
     derive_module_name = derive_module_name,
     extract_symbol_graph = extract_symbol_graph,
     get_toolchain = get_swift_toolchain,
+    get_providers = get_providers,
+    include_developer_search_paths = include_developer_search_paths,
     is_enabled = is_feature_enabled,
     library_rule_attrs = swift_library_rule_attrs,
+    new_objc_provider = new_objc_provider,
     precompile_clang_module = precompile_clang_module,
+    supplemental_compilation_output_groups = supplemental_compilation_output_groups,
     toolchain_attrs = swift_toolchain_attrs,
     use_toolchain = use_swift_toolchain,
 )


### PR DESCRIPTION
3rd party consumers of rules_swift may wish to create custom rules which behave similar to swift_library from the perspective of other rules and tools.

Right now this is a fairly complex process as you would need to reimplement or fork some logic which is currently internal to rules_swift. It is easy to make mistakes, or this logic could diverge from the rules_swift implementation over time.

I want to provide, through swift_common, an API which is basically just "give us a list of swift source files and their dependencies, and we'll compile them for you and create the necessary providers".

This PR does exactly that, and provides an example demonstrating how easy it is to create such a rule using these utilities from swift_common.

One question you might ask is, "Why not just create a macro which runs your custom rule to create swift source file(s) as outputs, and pass those to a real swift_library target?"

This can work for some simpler use cases, but when your rule does complex logic involving aspects and other custom rules, things break down quickly. It also creates additional targets in the build graph which could be confusing for consumers.