### PR TITLE
Remove some lingering references to `swift_common` members that were extracted as free functions

### DIFF
--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -602,9 +602,9 @@ def _find_swift_interop_info(target, aspect_ctx):
 
     This function first looks at the target itself to determine if it propagated
     a `SwiftInteropInfo` provider directly (that is, its rule implementation
-    function called `swift_common.create_swift_interop_info`). If it did not,
-    then the target's `aspect_hints` attribute is checked for a reference to a
-    target that propagates `SwiftInteropInfo` (such as `swift_interop_hint`).
+    function called `create_swift_interop_info`). If it did not, then the
+    target's `aspect_hints` attribute is checked for a reference to a target
+    that propagates `SwiftInteropInfo` (such as `swift_interop_hint`).
 
     It is an error if `aspect_hints` contains two or more targets that propagate
     `SwiftInteropInfo`, or if the target directly propagates the provider and
@@ -759,11 +759,10 @@ a non-Swift target in the build graph (for example, a `swift_library` that
 depends on an `objc_library` that depends on a `swift_library`).
 
 It also manages module map generation for targets that call
-`swift_common.create_swift_interop_info` and do not provide their own module
-map, and for targets that use the `swift_interop_hint` aspect hint. Note that if
-one of these approaches is used to interop with a target such as a `cc_library`,
-the headers must be parsable as C, since Swift does not support C++ interop at
-this time.
+`create_swift_interop_info` and do not provide their own module map, and for
+targets that use the `swift_interop_hint` aspect hint. Note that if one of these
+approaches is used to interop with a target such as a `cc_library`, the headers
+must be parsable as C, since Swift does not support C++ interop at this time.
 
 Most users will not need to interact directly with this aspect, since it is
 automatically applied to the `deps` attribute of all `swift_binary`,

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -140,6 +140,10 @@ def _swift_import_impl(ctx):
                 files = ctx.files.data,
             ),
         ),
+        SwiftInfo(
+            modules = [module_context],
+            swift_infos = swift_infos,
+        ),
         cc_info,
         # Propagate an `Objc` provider so that Apple-specific rules like
         # apple_binary` will link the imported library properly. Typically we'd
@@ -154,10 +158,6 @@ def _swift_import_impl(ctx):
             libraries_to_link = libraries_to_link,
             module_context = module_context,
             swift_toolchain = swift_toolchain,
-        ),
-        SwiftInfo(
-            modules = [module_context],
-            swift_infos = swift_infos,
         ),
     ]
 


### PR DESCRIPTION
PiperOrigin-RevId: 493691217
(cherry picked from commit 359435eb76b19479f94b9877b57f46439b03f6ef)