### PR TITLE
Add execution groups for actions that don't have to use the same toolchain used when building the target

### DIFF
--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -60,6 +60,9 @@ load(
     "create_swift_module_context",
 )
 
+# Name of the execution group used for `SwiftTestDiscovery` actions.
+_DISCOVER_TESTS_EXEC_GROUP = "discover_tests"
+
 _test_discovery_symbol_graph_aspect = make_swift_symbol_graph_aspect(
     default_emit_extension_block_symbols = "0",
     default_minimum_access_level = "internal",
@@ -251,6 +254,7 @@ def _generate_test_discovery_srcs(
     actions.run(
         arguments = [args],
         executable = test_discoverer,
+        exec_group = _DISCOVER_TESTS_EXEC_GROUP,
         inputs = inputs,
         mnemonic = "SwiftTestDiscovery",
         outputs = outputs,
@@ -663,7 +667,7 @@ standard executable binary that is invoked directly.
                 ),
             ),
             "_test_discoverer": attr.label(
-                cfg = "exec",
+                cfg = config.exec(_DISCOVER_TESTS_EXEC_GROUP),
                 default = Label("//tools/test_discoverer"),
                 executable = True,
             ),
@@ -738,6 +742,13 @@ Multiple such filters can be separated by commas. For example:
 bazel test --test_filter=AModule,BModule.SomeTests,BModule.OtherTests/testX //my/package/...
 ```
 """,
+    exec_groups = {
+        # Define an execution group for `SwiftTestDiscovery` actions that does
+        # not have constraints, so that test discovery using the already
+        # generated symbol graphs can be routed to any platform that supports it
+        # (even one with a different toolchain).
+        _DISCOVER_TESTS_EXEC_GROUP: exec_group(),
+    },
     executable = True,
     fragments = ["cpp"],
     test = True,


### PR DESCRIPTION
Once we migrate to platforms/toolchains, this will avoid the default behavior where a toolchain's `exec_compatible_with` determines the action routing for all actions under that rule.

PiperOrigin-RevId: 501277236
(cherry picked from commit 11e5b45a3cff3ec240bb9fbbabb90d6572c86e54)