### PR TITLE
Add toolchains

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -202,7 +202,10 @@ bzl_library(
     name = "swift_autoconfiguration",
     srcs = ["swift_autoconfiguration.bzl"],
     visibility = ["//swift:__subpackages__"],
-    deps = ["//swift/internal:feature_names"],
+    deps = [
+        ":toolchain_utils",
+        "//swift/internal:feature_names",
+    ],
 )
 
 bzl_library(

--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -1,0 +1,4 @@
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
These can be used once we flip the ruleset to actual return the toolchain type from `use_swift_toolchain()`.