### PR TITLE
Add -file-prefix-map support

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -38,6 +38,14 @@ SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS = "swift.headers_always_action_inputs
 # the note above about not depending on the C++ features.)
 SWIFT_FEATURE_COVERAGE = "swift.coverage"
 
+# If enabled, builds will use the `-file-prefix-map` feature to remap the
+# current working directory to `.`, which avoids embedding non-hermetic
+# absolute path information in build artifacts. Specifically what this flag
+# does is subject to change in Swift, but it should imply all other
+# `-*-prefix-map` flags. How those flags compose is potentially complicated, so
+# using only this flag, or the same values for each flag, is recommended.
+SWIFT_FEATURE_FILE_PREFIX_MAP = "swift.file_prefix_map"
+
 # If enabled, debug builds will use the `-debug-prefix-map` feature to remap the
 # current working directory to `.`, which permits debugging remote or sandboxed
 # builds.
@@ -47,14 +55,6 @@ SWIFT_FEATURE_DEBUG_PREFIX_MAP = "swift.debug_prefix_map"
 # remap the current working directory to `.`, which increases reproducibility
 # of remote builds.
 SWIFT_FEATURE_COVERAGE_PREFIX_MAP = "swift.coverage_prefix_map"
-
-# If enabled, builds will use the `-file-prefix-map` feature to remap the
-# current working directory to `.`, which avoids embedding non-hermetic
-# absolute path information in build artifacts. Specifically what this flag
-# does is subject to change in Swift, but it should imply all other
-# `-*-prefix-map` flags. How those flags compose is potentially complicated, so
-# using only this flag, or the same values for each flag, is recommended.
-SWIFT_FEATURE_FILE_PREFIX_MAP = "swift.file_prefix_map"
 
 # If enabled, C and Objective-C libraries that are direct or transitive
 # dependencies of a Swift library will emit explicit precompiled modules that

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -503,11 +503,13 @@ def compile_action_configs(
                 [SWIFT_FEATURE_DEBUG_PREFIX_MAP, SWIFT_FEATURE_FASTBUILD],
                 [SWIFT_FEATURE_DEBUG_PREFIX_MAP, SWIFT_FEATURE_FULL_DEBUG_INFO],
             ],
+            not_features = [SWIFT_FEATURE_FILE_PREFIX_MAP],
         ),
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
                 SWIFT_ACTION_DERIVE_FILES,
+                SWIFT_ACTION_PRECOMPILE_C_MODULE,
             ],
             configurators = [
                 add_arg("-Xwrapped-swift=-file-prefix-pwd-is-dot"),

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -24,6 +24,15 @@ DBG_CONFIG_SETTINGS = {
     "//command_line_option:features": [
         "-swift.cacheable_swiftmodules",
         "swift.debug_prefix_map",
+        "-swift.file_prefix_map",
+    ],
+}
+
+FILE_PREFIX_MAP_CONFIG_SETTINGS = {
+    "//command_line_option:compilation_mode": "dbg",
+    "//command_line_option:features": [
+        "swift.debug_prefix_map",
+        "swift.file_prefix_map",
     ],
 }
 
@@ -32,6 +41,7 @@ CACHEABLE_DBG_CONFIG_SETTINGS = {
     "//command_line_option:features": [
         "swift.cacheable_swiftmodules",
         "swift.debug_prefix_map",
+        "-swift.file_prefix_map",
     ],
 }
 
@@ -40,6 +50,7 @@ FASTBUILD_CONFIG_SETTINGS = {
     "//command_line_option:features": [
         "-swift.cacheable_swiftmodules",
         "swift.debug_prefix_map",
+        "-swift.file_prefix_map",
     ],
 }
 
@@ -48,6 +59,7 @@ FASTBUILD_FULL_DI_CONFIG_SETTINGS = {
     "//command_line_option:features": [
         "-swift.cacheable_swiftmodules",
         "swift.debug_prefix_map",
+        "-swift.file_prefix_map",
         "swift.full_debug_info",
     ],
 }
@@ -72,6 +84,10 @@ CACHEABLE_OPT_CONFIG_SETTINGS = {
 
 dbg_action_command_line_test = make_action_command_line_test_rule(
     config_settings = DBG_CONFIG_SETTINGS,
+)
+
+file_prefix_map_command_line_test = make_action_command_line_test_rule(
+    config_settings = FILE_PREFIX_MAP_CONFIG_SETTINGS,
 )
 
 cacheable_dbg_action_command_line_test = make_action_command_line_test_rule(
@@ -127,6 +143,20 @@ def debug_settings_test_suite(name, tags = []):
             "-DNDEBUG",
             "-Xfrontend -no-serialize-debugging-options",
             "-gline-tables-only",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "@build_bazel_rules_swift//test/fixtures/debug_settings:simple",
+    )
+
+    # Verify that the build is remapping paths with a file prefix map.
+    file_prefix_map_command_line_test(
+        name = "{}_file_prefix_map_build".format(name),
+        expected_argv = [
+            "-Xwrapped-swift=-file-prefix-pwd-is-dot",
+        ],
+        not_expected_argv = [
+            "-Xwrapped-swift=-debug-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
         tags = all_tags,

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -47,6 +47,12 @@ extern bool ArgumentEnablesWMO(const std::string &arg);
 //     applied here because we do not know the current working directory at
 //     analysis time when the argument list is constructed.
 //
+// -Xwrapped-swift=-file-prefix-pwd-is-dot
+//     When specified, the Swift compiler will be directed to remap the current
+//     directory's path to the string "." in debug, coverage, and index info.
+//     This remapping must be applied here because we do not know the current
+//     working directory at analysis time when the argument list is constructed.
+//
 // -Xwrapped-swift=-ephemeral-module-cache
 //     When specified, the spawner will create a new temporary directory, pass
 //     that to the Swift compiler using `-module-cache-path`, and then delete


### PR DESCRIPTION
We can use -file-prefix-map instead of -debug-prefix-map starting in Xcode 14. This has the main benefit of remapping debugging, indexing, and coverage paths, all with a single flag.

Keeping this opt-in for now, we'll test this out locally before a further rollout.

PiperOrigin-RevId: 477010867
(cherry picked from commit bead1236f52a66b705315f0334a937ad174ed3f5)

Cherry-pick notes: we implemented this in 20d7d9df4dcd8d0ad96c27d9fd477df846e8eab4. This cherry-pick just adds a couple things from upstream’s version of the same change.