### PR TITLE
Add new swift.modular_indexing feature to index explicit PCMs

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -709,8 +709,8 @@ Precompiles an explicit Clang module that is compatible with Swift.
 
 **RETURNS**
 
-A `File` representing the precompiled module (`.pcm`) file, or `None` if
-  the toolchain or target does not support precompiled modules.
+A struct containing the precompiled module and optional indexstore directory,
+  or `None` if the toolchain or target does not support precompiled modules.
 
 
 <a id="swift_common.toolchain_attrs"></a>

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -39,6 +39,7 @@ load(
     "SWIFT_FEATURE_FULL_LTO",
     "SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
+    "SWIFT_FEATURE_MODULAR_INDEXING",
     "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_WMO",
@@ -758,7 +759,8 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
                 swift_infos = swift_infos,
             )
         )
-        precompiled_module = _precompile_clang_module(
+
+        pcm_outputs = _precompile_clang_module(
             actions = actions,
             cc_compilation_context = compilation_context_to_compile,
             exec_group = exec_group,
@@ -770,6 +772,10 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             swift_toolchain = swift_toolchain,
             target_name = target_name,
         )
+        if pcm_outputs:
+            precompiled_module = pcm_outputs.pcm_file
+        else:
+            precompiled_module = None
     else:
         precompiled_module = None
 
@@ -882,8 +888,8 @@ def precompile_clang_module(
             required to compile this module.
 
     Returns:
-        A `File` representing the precompiled module (`.pcm`) file, or `None` if
-        the toolchain or target does not support precompiled modules.
+        A struct containing the precompiled module and optional indexstore directory,
+        or `None` if the toolchain or target does not support precompiled modules.
     """
     return _precompile_clang_module(
         actions = actions,
@@ -941,8 +947,8 @@ def _precompile_clang_module(
             outputs.
 
     Returns:
-        A `File` representing the precompiled module (`.pcm`) file, or `None` if
-        the toolchain or target does not support precompiled modules.
+        A struct containing the precompiled module and optional indexstore directory,
+        or `None` if the toolchain or target does not support precompiled modules.
     """
 
     # Exit early if the toolchain does not support precompiled modules or if the
@@ -987,11 +993,31 @@ def _precompile_clang_module(
     else:
         transitive_modules = []
 
+    outputs = [precompiled_module]
+    if are_all_features_enabled(
+        feature_configuration = feature_configuration,
+        feature_names = [
+            SWIFT_FEATURE_INDEX_WHILE_BUILDING,
+            SWIFT_FEATURE_MODULAR_INDEXING,
+            SWIFT_FEATURE_SYSTEM_MODULE,
+        ],
+    ):
+        indexstore_directory = actions.declare_directory(
+            "{}.swift.pcm.indexstore".format(target_name),
+        )
+        outputs.append(indexstore_directory)
+        index_unit_output_path = _index_unit_output_path(precompiled_module)
+    else:
+        indexstore_directory = None
+        index_unit_output_path = None
+
     prerequisites = struct(
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = cc_compilation_context,
         genfiles_dir = feature_configuration._genfiles_dir,
         include_dev_srch_paths = False,
+        indexstore_directory = indexstore_directory,
+        index_unit_output_path = index_unit_output_path,
         is_swift = False,
         is_swift_generated_header = is_swift_generated_header,
         module_name = module_name,
@@ -1008,13 +1034,16 @@ def _precompile_clang_module(
         action_name = SWIFT_ACTION_PRECOMPILE_C_MODULE,
         exec_group = exec_group,
         feature_configuration = feature_configuration,
-        outputs = [precompiled_module],
+        outputs = outputs,
         prerequisites = prerequisites,
         progress_message = "Precompiling C module %{label}",
         swift_toolchain = swift_toolchain,
     )
 
-    return precompiled_module
+    return struct(
+        indexstore_directory = indexstore_directory,
+        pcm_file = precompiled_module,
+    )
 
 def _create_cc_compilation_context(
         *,
@@ -1282,6 +1311,8 @@ def _declare_compile_outputs(
         ]
         output_file_map = None
         derived_files_output_file_map = None
+        # TODO(b/147451378): Support indexing even with a single object file.
+
     else:
         split_derived_file_generation = is_feature_enabled(
             feature_configuration = feature_configuration,
@@ -1371,6 +1402,14 @@ def _intermediate_frontend_file_path(target_name, src):
     safe_name = paths.basename(owner_rel_path)
 
     return paths.join(objs_dir, paths.dirname(owner_rel_path)), safe_name
+
+def _index_unit_output_path(output_file):
+    """Returns the hermetic index unit output path for indexing.
+
+    We use an absolute path since IndexStoreDB can't properly handle relative
+    paths.
+    """
+    return "/BAZEL_EXECUTION_ROOT/{}".format(output_file.path)
 
 def _declare_per_source_ast_file(*, actions, target_name, src):
     """Declares a file for an ast file during compilation.
@@ -1550,6 +1589,8 @@ def _declare_multiple_outputs_and_write_output_file_map(
             )
             output_objs.append(obj)
             src_output_map["object"] = obj.path
+
+        src_output_map["index-unit-output-path"] = _index_unit_output_path(obj)
 
         ast = _declare_per_source_ast_file(
             actions = actions,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -74,6 +74,15 @@ SWIFT_FEATURE_DISABLE_SYSTEM_INDEX = "swift.disable_system_index"
 # Index while building - using a global index store cache
 SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE = "swift.use_global_index_store"
 
+# If enabled, indexing will be completely modular - PCMs and Swift Modules will only
+# be indexed when they are compiled. While indexing a module/PCM, none of its dependencies
+# will be indexed.
+#
+# NOTE: This is only applicable if both `SWIFT_FEATURE_EMIT_C_MODULE` and
+# `SWIFT_FEATURE_INDEX_WHILE_BUILDING` are enabled as well. In addition, this feature requires
+# Xcode 14 in order to work.
+SWIFT_FEATURE_MODULAR_INDEXING = "swift.modular_indexing"
+
 # If enabled, when compiling an explicit C or Objectve-C module, every header
 # included by the module being compiled must belong to one of the modules listed
 # in its dependencies. This is ignored for system modules.

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -503,7 +503,7 @@ def _handle_module(
         )
     )
 
-    precompiled_module = precompile_clang_module(
+    pcm_outputs = precompile_clang_module(
         actions = aspect_ctx.actions,
         cc_compilation_context = compilation_context_to_compile,
         feature_configuration = feature_configuration,
@@ -513,6 +513,8 @@ def _handle_module(
         swift_toolchain = swift_toolchain,
         target_name = target.label.name,
     )
+    precompiled_module = getattr(pcm_outputs, "pcm_file", None)
+    indexstore_directory = getattr(pcm_outputs, "indexstore_directory", None)
 
     providers = [
         create_swift_info(
@@ -533,10 +535,11 @@ def _handle_module(
     ]
 
     if precompiled_module:
+        output_groups = {"swift_explicit_module": depset([precompiled_module])}
+        if indexstore_directory:
+            output_groups["indexstore"] = depset([indexstore_directory])
         providers.append(
-            OutputGroupInfo(
-                swift_explicit_module = depset([precompiled_module]),
-            ),
+            OutputGroupInfo(**output_groups),
         )
 
     return providers

--- a/test/rules/expected_files.bzl
+++ b/test/rules/expected_files.bzl
@@ -1,0 +1,155 @@
+# Copyright 2022 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit test helpers for Starlark analysis tests.
+
+This contains various helpers for dealing with collections and file expectations.
+"""
+
+load("@bazel_skylib//lib:types.bzl", "types")
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "asserts",
+    "unittest",
+)
+
+def _prettify(object):
+    """Returns a prettified version of the given value for failure messages.
+
+    If the object is a list, it will be formatted as a multiline string;
+    otherwise, it will simply be the `repr` of the value.
+
+    Args:
+        object: The object to prettify.
+
+    Returns:
+        A string that can be used to display the value in a failure message.
+    """
+    object = normalize_collection(object)
+    if types.is_list(object):
+        return ("[\n    " +
+                ",\n    ".join([repr(item) for item in object]) +
+                "\n]")
+    else:
+        return repr(object)
+
+def normalize_collection(object):
+    """Returns object as a list if it is a collection, otherwise returns itself.
+
+    Args:
+        object: The object to normalize. If it is a list or a depset, it will be
+            returned as a list. Otherwise, it will be returned unchanged.
+
+    Returns:
+        A list containing the same items in `object` if it is a collection,
+        otherwise the original object is returned.
+    """
+    if types.is_depset(object):
+        return object.to_list()
+    else:
+        return object
+
+def compare_expected_files(env, access_description, expected, actual):
+    """Implements the `expected_files` comparison.
+
+    This compares a set of files retrieved from a provider field against a list
+    of expected strings that are equal to or suffixes of the paths to those
+    files, as well as excluded files and a wildcard. See the documentation of
+    the `expected_files` attribute on the rule definition below for specifics.
+
+    Args:
+        env: The analysis test environment.
+        access_description: A target/provider/field access description string
+            printed in assertion failure messages.
+        expected: The list of expected file path inclusions/exclusions.
+        actual: The collection of files obtained from the provider.
+    """
+    actual = normalize_collection(actual)
+
+    expected_is_subset = "*" in expected
+    expected_include = [
+        s
+        for s in expected
+        if not s.startswith("-") and s != "*"
+    ]
+
+    if actual == [None] and not expected_include:
+        return
+
+    if (
+        not types.is_list(actual) or
+        any([type(item) != "File" for item in actual])
+    ):
+        unittest.fail(
+            env,
+            ("Expected '{}' to be a collection of files, " +
+             "but got a {}: {}.").format(
+                access_description,
+                type(actual),
+                _prettify(actual),
+            ),
+        )
+        return
+
+    remaining = list(actual)
+    expected_exclude = [s[1:] for s in expected if s.startswith("-")]
+
+    # For every expected file, pick off the first actual that we find that has
+    # the expected string as a suffix.
+    failed = False
+    for suffix in expected_include:
+        if not remaining:
+            # It's a failure if we are still expecting files but there are no
+            # more actual files.
+            failed = True
+            break
+
+        found_expected_file = False
+        for i in range(len(remaining)):
+            actual_path = remaining[i].path
+            if actual_path.endswith(suffix):
+                found_expected_file = True
+                remaining.pop(i)
+                break
+
+        # It's a failure if we never found a file we expected.
+        if not found_expected_file:
+            failed = True
+            break
+
+    # For every file expected to *not* be present, check the list of remaining
+    # files and fail if we find a match.
+    for suffix in expected_exclude:
+        for f in remaining:
+            if f.path.endswith(suffix):
+                failed = True
+                break
+
+    # If we found all the expected files, the remaining list should be empty.
+    # Fail if the list is not empty and we're not looking for a subset.
+    if not expected_is_subset and remaining:
+        failed = True
+
+    asserts.false(
+        env,
+        failed,
+        "Expected '{}' to match {}, but got {}.".format(
+            access_description,
+            _prettify(expected),
+            _prettify([
+                f.path if type(f) == "File" else repr(f)
+                for f in actual
+            ]),
+        ),
+    )

--- a/test/rules/provider_test.bzl
+++ b/test/rules/provider_test.bzl
@@ -18,10 +18,14 @@ load("@bazel_skylib//lib:types.bzl", "types")
 load(
     "@bazel_skylib//lib:unittest.bzl",
     "analysistest",
-    "asserts",
     "unittest",
 )
 load("//swift:providers.bzl", "SwiftInfo")
+load(
+    "//test/rules:expected_files.bzl",
+    "compare_expected_files",
+    "normalize_collection",
+)
 
 # A sentinel value returned by `_evaluate_field` when a `None` value is
 # encountered during the evaluation of a dotted path on any component other than
@@ -74,7 +78,7 @@ def _evaluate_field(env, source, field):
     components = field.split(".")
 
     for component in components:
-        source = _normalize_collection(source)
+        source = normalize_collection(source)
         filter_nones = component.endswith("!")
         if filter_nones:
             component = component[:-1]
@@ -94,7 +98,7 @@ def _evaluate_field(env, source, field):
             # a single list.
             flattened = []
             for item in source:
-                item = _normalize_collection(item)
+                item = normalize_collection(item)
                 if types.is_list(item):
                     flattened.extend(item)
                 else:
@@ -115,7 +119,7 @@ def _evaluate_field(env, source, field):
 
             source = evaluate_component(source, component)
             if filter_nones:
-                source = _normalize_collection(source)
+                source = normalize_collection(source)
                 if types.is_list(source):
                     source = [item for item in source if item != None]
                 else:
@@ -191,136 +195,6 @@ def _field_access_description(target, provider, field):
     """
     return "<{}>[{}].{}".format(target.label, provider, field)
 
-def _prettify(object):
-    """Returns a prettified version of the given value for failure messages.
-
-    If the object is a list, it will be formatted as a multiline string;
-    otherwise, it will simply be the `repr` of the value.
-
-    Args:
-        object: The object to prettify.
-
-    Returns:
-        A string that can be used to display the value in a failure message.
-    """
-    object = _normalize_collection(object)
-    if types.is_list(object):
-        return ("[\n    " +
-                ",\n    ".join([repr(item) for item in object]) +
-                "\n]")
-    else:
-        return repr(object)
-
-def _normalize_collection(object):
-    """Returns object as a list if it is a collection, otherwise returns itself.
-
-    Args:
-        object: The object to normalize. If it is a list or a depset, it will be
-            returned as a list. Otherwise, it will be returned unchanged.
-
-    Returns:
-        A list containing the same items in `object` if it is a collection,
-        otherwise the original object is returned.
-    """
-    if types.is_depset(object):
-        return object.to_list()
-    else:
-        return object
-
-def _compare_expected_files(env, access_description, expected, actual):
-    """Implements the `expected_files` comparison.
-
-    This compares a set of files retrieved from a provider field against a list
-    of expected strings that are equal to or suffixes of the paths to those
-    files, as well as excluded files and a wildcard. See the documentation of
-    the `expected_files` attribute on the rule definition below for specifics.
-
-    Args:
-        env: The analysis test environment.
-        access_description: A target/provider/field access description string
-            printed in assertion failure messages.
-        expected: The list of expected file path inclusions/exclusions.
-        actual: The collection of files obtained from the provider.
-    """
-    actual = _normalize_collection(actual)
-
-    expected_is_subset = "*" in expected
-    expected_include = [
-        s
-        for s in expected
-        if not s.startswith("-") and s != "*"
-    ]
-
-    if actual == [None] and not expected_include:
-        return
-
-    if (
-        not types.is_list(actual) or
-        any([type(item) != "File" for item in actual])
-    ):
-        unittest.fail(
-            env,
-            ("Expected '{}' to be a collection of files, " +
-             "but got a {}: {}.").format(
-                access_description,
-                type(actual),
-                _prettify(actual),
-            ),
-        )
-        return
-
-    remaining = list(actual)
-    expected_exclude = [s[1:] for s in expected if s.startswith("-")]
-
-    # For every expected file, pick off the first actual that we find that has
-    # the expected string as a suffix.
-    failed = False
-    for suffix in expected_include:
-        if not remaining:
-            # It's a failure if we are still expecting files but there are no
-            # more actual files.
-            failed = True
-            break
-
-        found_expected_file = False
-        for i in range(len(remaining)):
-            actual_path = remaining[i].path
-            if actual_path.endswith(suffix):
-                found_expected_file = True
-                remaining.pop(i)
-                break
-
-        # It's a failure if we never found a file we expected.
-        if not found_expected_file:
-            failed = True
-            break
-
-    # For every file expected to *not* be present, check the list of remaining
-    # files and fail if we find a match.
-    for suffix in expected_exclude:
-        for f in remaining:
-            if f.path.endswith(suffix):
-                failed = True
-                break
-
-    # If we found all the expected files, the remaining list should be empty.
-    # Fail if the list is not empty and we're not looking for a subset.
-    if not expected_is_subset and remaining:
-        failed = True
-
-    asserts.false(
-        env,
-        failed,
-        "Expected '{}' to match {}, but got {}.".format(
-            access_description,
-            _prettify(expected),
-            _prettify([
-                f.path if type(f) == "File" else repr(f)
-                for f in actual
-            ]),
-        ),
-    )
-
 def _provider_test_impl(ctx):
     env = analysistest.begin(ctx)
     target_under_test = ctx.attr.target_under_test
@@ -378,7 +252,7 @@ def _provider_test_impl(ctx):
 
     # TODO(allevato): Support other comparisons as they become needed.
     if ctx.attr.expected_files:
-        _compare_expected_files(
+        compare_expected_files(
             env,
             access_description,
             ctx.attr.expected_files,


### PR DESCRIPTION
This allows us to index explicit PCMs once they are built and then
never again. Currently we only do this for system SDKs as we assume
that we already have source code available for other SDKs, but this
can be expanded in the future.

In addition, make swift.file_prefix_map also remap DEVELOPER_DIR.

PiperOrigin-RevId: 478594522
(cherry picked from commit a5d5c2b54055ec20edbd14a4f38ad333ff3bc919)

---

Only add "index-unit-output-path" in the output map for modular indexing

Pre Xcode 14 you'll get a warning if this is specified without having indexing enabled:

```
<unknown>:0: warning: -index-unit-output-path is ignored without -index-store-path
```

We can reconsider this in the future (e.g. to automatically set this for Xcode 14+),
but for now limit the scope based on the modular indexing feature.

PiperOrigin-RevId: 480943677
(cherry picked from commit c9b500297f45b504d7b9766a9bbd48a87f59e35b)