### PR TITLE
`swift_import`: always link the import.

### DIFF
--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -65,6 +65,7 @@ def _swift_import_impl(ctx):
     libraries_to_link = [
         cc_common.create_library_to_link(
             actions = ctx.actions,
+            alwayslink = True,
             cc_toolchain = swift_toolchain.cc_toolchain_info,
             feature_configuration = swift_common.cc_feature_configuration(
                 feature_configuration,


### PR DESCRIPTION
`swift_library` is also moving in this direction.

SwiftPM works by linking all the .o files, so this should end up in a state that seem users familiar with SwiftPM/Xcode will expect. Otherwise an `@objc` class might not be findable by name only, or a protocol conformance might not get included leading to confusing runtime problems.

PiperOrigin-RevId: 527908878
(cherry picked from commit 2cc542ab55335dff09da8af42e4c69d7f005699d)