### PR TITLE
Extract `derive_swift_module_name` as a free function in its own `.bzl` file

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -111,7 +111,7 @@ Compiles a Swift module.
 | <a id="swift_common.compile-generated_header_name"></a>generated_header_name |  The name of the Objective-C generated header that should be generated for this module. If omitted, no header will be generated.   |  `None` |
 | <a id="swift_common.compile-is_test"></a>is_test |  Deprecated. This argument will be removed in the next major release. Use the `include_dev_srch_paths` attribute instead. Represents if the `testonly` value of the context.   |  `None` |
 | <a id="swift_common.compile-include_dev_srch_paths"></a>include_dev_srch_paths |  A `bool` that indicates whether the developer framework search paths will be added to the compilation command.   |  `None` |
-| <a id="swift_common.compile-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `swift_common.derive_module_name` to generate a default from the target's label if needed.   |  none |
+| <a id="swift_common.compile-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `derive_swift_module_name` to generate a default from the target's label if needed.   |  none |
 | <a id="swift_common.compile-objc_infos"></a>objc_infos |  A list of `apple_common.ObjC` providers that represent C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from a target's dependencies.   |  none |
 | <a id="swift_common.compile-package_name"></a>package_name |  The semantic package of the name of the Swift module being compiled.   |  none |
 | <a id="swift_common.compile-plugins"></a>plugins |  A list of `SwiftCompilerPluginInfo` providers that represent plugins that should be loaded by the compiler.   |  `[]` |
@@ -180,7 +180,7 @@ Compiles a Swift module interface.
 | <a id="swift_common.compile_module_interface-copts"></a>copts |  A list of compiler flags that apply to the target being built.   |  `[]` |
 | <a id="swift_common.compile_module_interface-exec_group"></a>exec_group |  Runs the Swift compilation action under the given execution group's context. If `None`, the default execution group is used.   |  `None` |
 | <a id="swift_common.compile_module_interface-feature_configuration"></a>feature_configuration |  A feature configuration obtained from `swift_common.configure_features`.   |  none |
-| <a id="swift_common.compile_module_interface-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `swift_common.derive_module_name` to generate a default from the target's label if needed.   |  none |
+| <a id="swift_common.compile_module_interface-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `derive_swift_module_name` to generate a default from the target's label if needed.   |  none |
 | <a id="swift_common.compile_module_interface-swiftinterface_file"></a>swiftinterface_file |  The Swift module interface file to compile.   |  none |
 | <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled.   |  none |
 | <a id="swift_common.compile_module_interface-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |

--- a/doc/doc.bzl
+++ b/doc/doc.bzl
@@ -47,6 +47,10 @@ load(
     _swift_proto_library_group = "swift_proto_library_group",
 )
 load(
+    "//swift:module_name.bzl",
+    _derive_swift_module_name = "derive_swift_module_name",
+)
+load(
     "//swift:providers.bzl",
     _SwiftInfo = "SwiftInfo",
     _SwiftProtoCompilerInfo = "SwiftProtoCompilerInfo",
@@ -103,6 +107,7 @@ swift_proto_library = _swift_proto_library
 swift_proto_library_group = _swift_proto_library_group
 
 # swift symbols
+derive_swift_module_name = _derive_swift_module_name
 swift_common = _swift_common
 SwiftInfo = _SwiftInfo
 SwiftToolchainInfo = _SwiftToolchainInfo

--- a/mixed_language/BUILD
+++ b/mixed_language/BUILD
@@ -18,6 +18,7 @@ bzl_library(
         "//mixed_language/internal:library",
         "//mixed_language/internal:module_map",
         "//mixed_language/internal:umbrella_header",
+        "//swift:module_name",
         "//swift:swift_interop_hint",
         "//swift:swift_library",
         "//swift/internal:compiling",

--- a/mixed_language/mixed_language_library.bzl
+++ b/mixed_language/mixed_language_library.bzl
@@ -26,11 +26,9 @@ load(
     "//mixed_language/internal:umbrella_header.bzl",
     "mixed_language_umbrella_header",
 )
+load("//swift:module_name.bzl", "derive_swift_module_name")
 load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
 load("//swift:swift_library.bzl", "swift_library")
-
-# buildifier: disable=bzl-visibility
-load("//swift/internal:compiling.bzl", "derive_module_name")
 
 # `mixed_language_library`
 
@@ -225,7 +223,7 @@ a mixed language Swift library, use a clang only library rule like \
         )
 
     if not module_name:
-        module_name = derive_module_name(native.package_name(), name)
+        module_name = derive_swift_module_name(native.package_name(), name)
 
     if not module_map:
         internal_modulemap_name = name + "_modulemap"

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -33,6 +33,7 @@ bzl_library(
     srcs = ["swift_proto_library.bzl"],
     deps = [
         ":swift_proto_utils",
+        "//swift:module_name",
         "//swift:swift_clang_module_aspect",
         "//swift:swift_common",
         "//swift/internal:attrs",
@@ -54,6 +55,7 @@ bzl_library(
     srcs = ["swift_proto_library_group.bzl"],
     deps = [
         ":swift_proto_utils",
+        "//swift:module_name",
         "//swift:providers",
         "//swift:swift_common",
         "//swift/internal:toolchain_utils",

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -24,6 +24,7 @@ load(
     "@rules_proto//proto:defs.bzl",
     "ProtoInfo",
 )
+load("//swift:module_name.bzl", "derive_swift_module_name")
 load("//swift:providers.bzl", "SwiftProtoCompilerInfo")
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load("//swift:swift_common.bzl", "swift_common")
@@ -51,7 +52,7 @@ def _get_module_name(attr, target_label):
     """
     module_name = attr.module_name
     if not module_name:
-        module_name = swift_common.derive_module_name(target_label)
+        module_name = derive_swift_module_name(target_label)
     return module_name
 
 # Rule

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -29,6 +29,7 @@ load(
     "SwiftProtoCcInfo",
     "compile_swift_protos_for_target",
 )
+load("//swift:module_name.bzl", "derive_swift_module_name")
 load(
     "//swift:providers.bzl",
     "SwiftInfo",
@@ -47,7 +48,7 @@ load("//swift/internal:utils.bzl", "compact")
 
 def _swift_proto_library_group_aspect_impl(target, aspect_ctx):
     # Get the module name and generate the module mappings:
-    module_name = swift_common.derive_module_name(target.label)
+    module_name = derive_swift_module_name(target.label)
 
     # Compile the source files to a module:
     direct_providers = compile_swift_protos_for_target(

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -57,6 +57,7 @@ bzl_library(
     name = "swift_binary",
     srcs = ["swift_binary.bzl"],
     deps = [
+        ":module_name",
         ":providers",
         ":swift_common",
         "//swift/internal:compiling",
@@ -72,6 +73,7 @@ bzl_library(
     name = "swift_clang_module_aspect",
     srcs = ["swift_clang_module_aspect.bzl"],
     deps = [
+        ":module_name",
         ":providers",
         "//swift/internal:attrs",
         "//swift/internal:compiling",
@@ -88,6 +90,7 @@ bzl_library(
     name = "swift_common",
     srcs = ["swift_common.bzl"],
     deps = [
+        ":module_name",
         "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:features",
@@ -160,6 +163,7 @@ bzl_library(
     name = "swift_library",
     srcs = ["swift_library.bzl"],
     deps = [
+        ":module_name",
         ":providers",
         ":swift_clang_module_aspect",
         ":swift_common",
@@ -192,6 +196,7 @@ bzl_library(
     name = "swift_module_alias",
     srcs = ["swift_module_alias.bzl"],
     deps = [
+        ":module_name",
         ":providers",
         ":swift_common",
         "//swift/internal:linking",
@@ -214,6 +219,7 @@ bzl_library(
     name = "swift_module_mapping_test",
     srcs = ["swift_module_mapping_test.bzl"],
     deps = [
+        ":providers",
         "//swift/internal:providers",
     ],
 )
@@ -241,6 +247,7 @@ bzl_library(
     name = "swift_test",
     srcs = ["swift_test.bzl"],
     deps = [
+        ":module_name",
         ":providers",
         ":swift_common",
         "//swift/internal:env_expansion",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -91,7 +91,6 @@ bzl_library(
         ":wmo",
         "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:sets",
-        "@bazel_skylib//lib:types",
     ],
 )
 

--- a/swift/module_name.bzl
+++ b/swift/module_name.bzl
@@ -54,8 +54,8 @@ def derive_swift_module_name(*args):
         package = args[0]
         name = args[1]
     else:
-        fail("derive_module_name may only be called with a single argument " +
-             "of type 'Label' or two arguments of type 'str'.")
+        fail("derive_swift_module_name may only be called with a single " +
+             "argument of type 'Label' or two arguments of type 'str'.")
 
     package_part = _module_name_safe(package.lstrip("//"))
     name_part = _module_name_safe(name)

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -37,6 +37,7 @@ load(
     "get_providers",
     "include_developer_search_paths",
 )
+load(":module_name.bzl", "derive_swift_module_name")
 load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
 
@@ -79,7 +80,7 @@ def _swift_binary_impl(ctx):
     if srcs:
         module_name = ctx.attr.module_name
         if not module_name:
-            module_name = swift_common.derive_module_name(ctx.label)
+            module_name = derive_swift_module_name(ctx.label)
 
         include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -16,11 +16,7 @@
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
-load(
-    "//swift/internal:compiling.bzl",
-    "derive_module_name",
-    "precompile_clang_module",
-)
+load("//swift/internal:compiling.bzl", "precompile_clang_module")
 load(
     "//swift/internal:feature_names.bzl",
     "SWIFT_FEATURE_EMIT_C_MODULE",
@@ -54,6 +50,7 @@ load(
     "//swift/internal:utils.bzl",
     "compilation_context_for_explicit_module_compilation",
 )
+load(":module_name.bzl", "derive_swift_module_name")
 load(":providers.bzl", "SwiftInfo")
 
 _MULTIPLE_TARGET_ASPECT_ATTRS = [
@@ -360,7 +357,7 @@ def _module_info_for_target(
         # was some other `Objc`-providing target, derive the module name
         # now.
         if not module_name:
-            module_name = derive_module_name(target.label)
+            module_name = derive_swift_module_name(target.label)
 
     # If we didn't get a module map above, generate it now.
     if not module_map_file:
@@ -696,7 +693,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
         exclude_headers = interop_info.exclude_headers
         module_map_file = interop_info.module_map
         module_name = (
-            interop_info.module_name or derive_module_name(target.label)
+            interop_info.module_name or derive_swift_module_name(target.label)
         )
         swift_infos.extend(interop_info.swift_infos)
         requested_features.extend(interop_info.requested_features)

--- a/swift/swift_common.bzl
+++ b/swift/swift_common.bzl
@@ -31,7 +31,6 @@ load(
     "compile",
     "compile_module_interface",
     "create_compilation_context",
-    "derive_module_name",
     "precompile_clang_module",
 )
 load(
@@ -61,6 +60,7 @@ load(
     "get_swift_toolchain",
     "use_swift_toolchain",
 )
+load(":module_name.bzl", "derive_swift_module_name")
 
 # The exported `swift_common` module, which defines the public API for directly
 # invoking actions that compile Swift code from other rules.
@@ -77,7 +77,9 @@ swift_common = struct(
     create_swift_info = create_swift_info,
     create_swift_interop_info = create_swift_interop_info,
     create_swift_module = create_swift_module,
-    derive_module_name = derive_module_name,
+    # TODO(b/261444771): Remove this after everyone is migrated to the free
+    # function.
+    derive_module_name = derive_swift_module_name,
     extract_symbol_graph = extract_symbol_graph,
     get_toolchain = get_swift_toolchain,
     is_enabled = is_feature_enabled,

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -43,6 +43,7 @@ load(
     "get_providers",
     "include_developer_search_paths",
 )
+load(":module_name.bzl", "derive_swift_module_name")
 load(":providers.bzl", "SwiftCompilerPluginInfo", "SwiftInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 load(":swift_common.bzl", "swift_common")
@@ -139,7 +140,7 @@ def _swift_library_impl(ctx):
 
     module_name = ctx.attr.module_name
     if not module_name:
-        module_name = swift_common.derive_module_name(ctx.label)
+        module_name = derive_swift_module_name(ctx.label)
 
     swift_toolchain = swift_common.get_toolchain(ctx)
     feature_configuration = swift_common.configure_features(

--- a/swift/swift_module_alias.bzl
+++ b/swift/swift_module_alias.bzl
@@ -22,6 +22,7 @@ load(
 )
 load("//swift/internal:toolchain_utils.bzl", "use_swift_toolchain")
 load("//swift/internal:utils.bzl", "compact", "get_providers")
+load(":module_name.bzl", "derive_swift_module_name")
 load(":providers.bzl", "SwiftInfo")
 load(":swift_common.bzl", "swift_common")
 
@@ -35,7 +36,7 @@ def _swift_module_alias_impl(ctx):
 
     module_name = ctx.attr.module_name
     if not module_name:
-        module_name = swift_common.derive_module_name(ctx.label)
+        module_name = derive_swift_module_name(ctx.label)
 
     # Generate a source file that imports each of the deps using `@_exported`.
     reexport_src = ctx.actions.declare_file(

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -42,6 +42,7 @@ load(
     "expand_locations",
     "include_developer_search_paths",
 )
+load(":module_name.bzl", "derive_swift_module_name")
 load(
     ":providers.bzl",
     "SwiftCompilerPluginInfo",
@@ -382,7 +383,7 @@ def _swift_test_impl(ctx):
 
     module_name = ctx.attr.module_name
     if not module_name:
-        module_name = swift_common.derive_module_name(ctx.label)
+        module_name = derive_swift_module_name(ctx.label)
 
     include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 


### PR DESCRIPTION
Since rules may want to use this without the other functionality in `swift_common` (e.g., compilation), isolating it to its own file can reduce analysis churn when other parts of the rule implementations change.

PiperOrigin-RevId: 493078921
(cherry picked from commit 47bd14c2be5ac36bf1ae616ea5eb680c42f15ef2)