### PR TITLE
Remove `compilation_attrs` and `library_rule_attrs` from `swift_common`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -73,59 +73,6 @@ A C++ `FeatureConfiguration` value (see
   for more information).
 
 
-<a id="swift_common.compilation_attrs"></a>
-
-## swift_common.compilation_attrs
-
-<pre>
-swift_common.compilation_attrs(<a href="#swift_common.compilation_attrs-additional_deps_aspects">additional_deps_aspects</a>, <a href="#swift_common.compilation_attrs-additional_deps_providers">additional_deps_providers</a>,
-                               <a href="#swift_common.compilation_attrs-include_dev_srch_paths_attrib">include_dev_srch_paths_attrib</a>, <a href="#swift_common.compilation_attrs-requires_srcs">requires_srcs</a>)
-</pre>
-
-Returns an attribute dictionary for rules that compile Swift code.
-
-The returned dictionary contains the subset of attributes that are shared by
-the `swift_binary`, `swift_library`, and `swift_test` rules that deal with
-inputs and options for compilation. Users who are authoring custom rules
-that compile Swift code but not as a library can add this dictionary to
-their own rule's attributes to give it a familiar API.
-
-Do note, however, that it is the responsibility of the rule implementation
-to retrieve the values of those attributes and pass them correctly to the
-other `swift_common` APIs.
-
-There is a hierarchy to the attribute sets offered by the `swift_common`
-API:
-
-1.  If you only need access to the toolchain for its tools and libraries but
-    are not doing any compilation, use `toolchain_attrs`.
-2.  If you need to invoke compilation actions but are not making the
-    resulting object files into a static or shared library, use
-    `compilation_attrs`.
-3.  If you want to provide a rule interface that is suitable as a drop-in
-    replacement for `swift_library`, use `library_rule_attrs`.
-
-Each of the attribute functions in the list above also contains the
-attributes from the earlier items in the list.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="swift_common.compilation_attrs-additional_deps_aspects"></a>additional_deps_aspects |  A list of additional aspects that should be applied to `deps`. Defaults to the empty list. These must be passed by the individual rules to avoid potential circular dependencies between the API and the aspects; the API loaded the aspects directly, then those aspects would not be able to load the API.   |  `[]` |
-| <a id="swift_common.compilation_attrs-additional_deps_providers"></a>additional_deps_providers |  A list of lists representing additional providers that should be allowed by the `deps` attribute of the rule.   |  `[]` |
-| <a id="swift_common.compilation_attrs-include_dev_srch_paths_attrib"></a>include_dev_srch_paths_attrib |  A `bool` that indicates whether to include the `always_include_developer_search_paths` attribute.   |  `False` |
-| <a id="swift_common.compilation_attrs-requires_srcs"></a>requires_srcs |  Indicates whether the `srcs` attribute should be marked as mandatory and non-empty. Defaults to `True`.   |  `True` |
-
-**RETURNS**
-
-A new attribute dictionary that can be added to the attributes of a
-  custom build rule to provide a similar interface to `swift_binary`,
-  `swift_library`, and `swift_test`.
-
-
 <a id="swift_common.compile"></a>
 
 ## swift_common.compile
@@ -650,57 +597,6 @@ check it.
 **RETURNS**
 
 `True` if the given feature is enabled in the feature configuration.
-
-
-<a id="swift_common.library_rule_attrs"></a>
-
-## swift_common.library_rule_attrs
-
-<pre>
-swift_common.library_rule_attrs(<a href="#swift_common.library_rule_attrs-additional_deps_aspects">additional_deps_aspects</a>, <a href="#swift_common.library_rule_attrs-requires_srcs">requires_srcs</a>)
-</pre>
-
-Returns an attribute dictionary for `swift_library`-like rules.
-
-The returned dictionary contains the same attributes that are defined by the
-`swift_library` rule (including the private `_toolchain` attribute that
-specifies the toolchain dependency). Users who are authoring custom rules
-can use this dictionary verbatim or add other custom attributes to it in
-order to make their rule a drop-in replacement for `swift_library` (for
-example, if writing a custom rule that does some preprocessing or generation
-of sources and then compiles them).
-
-Do note, however, that it is the responsibility of the rule implementation
-to retrieve the values of those attributes and pass them correctly to the
-other `swift_common` APIs.
-
-There is a hierarchy to the attribute sets offered by the `swift_common`
-API:
-
-1.  If you only need access to the toolchain for its tools and libraries but
-    are not doing any compilation, use `toolchain_attrs`.
-2.  If you need to invoke compilation actions but are not making the
-    resulting object files into a static or shared library, use
-    `compilation_attrs`.
-3.  If you want to provide a rule interface that is suitable as a drop-in
-    replacement for `swift_library`, use `library_rule_attrs`.
-
-Each of the attribute functions in the list above also contains the
-attributes from the earlier items in the list.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="swift_common.library_rule_attrs-additional_deps_aspects"></a>additional_deps_aspects |  A list of additional aspects that should be applied to `deps`. Defaults to the empty list. These must be passed by the individual rules to avoid potential circular dependencies between the API and the aspects; the API loaded the aspects directly, then those aspects would not be able to load the API.   |  `[]` |
-| <a id="swift_common.library_rule_attrs-requires_srcs"></a>requires_srcs |  Indicates whether the `srcs` attribute should be marked as mandatory and non-empty. Defaults to `True`.   |  `True` |
-
-**RETURNS**
-
-A new attribute dictionary that can be added to the attributes of a
-  custom build rule to provide the same interface as `swift_library`.
 
 
 <a id="swift_common.precompile_clang_module"></a>

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -35,7 +35,6 @@ bzl_library(
         ":swift_proto_utils",
         "//swift:module_name",
         "//swift:swift_clang_module_aspect",
-        "//swift:swift_common",
         "//swift/internal:attrs",
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -27,10 +27,13 @@ load(
 load("//swift:module_name.bzl", "derive_swift_module_name")
 load("//swift:providers.bzl", "SwiftProtoCompilerInfo")
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
-load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:attrs.bzl", "swift_deps_attr")
+load(
+    "//swift/internal:attrs.bzl",
+    "swift_deps_attr",
+    "swift_library_rule_attrs",
+)
 
 # buildifier: disable=bzl-visibility
 load("//swift/internal:toolchain_utils.bzl", "use_swift_toolchain")
@@ -106,7 +109,7 @@ def _swift_proto_library_impl(ctx):
 
 swift_proto_library = rule(
     attrs = dicts.add(
-        swift_common.library_rule_attrs(
+        swift_library_rule_attrs(
             additional_deps_aspects = [
                 swift_clang_module_aspect,
             ],

--- a/swift/swift_common.bzl
+++ b/swift/swift_common.bzl
@@ -20,12 +20,7 @@ example, `swift_proto_library` generates Swift source code from `.proto` files
 and then needs to compile them. This module provides that lower-level interface.
 """
 
-load(
-    "//swift/internal:attrs.bzl",
-    "swift_compilation_attrs",
-    "swift_library_rule_attrs",
-    "swift_toolchain_attrs",
-)
+load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load(
     "//swift/internal:compiling.bzl",
     "compile",
@@ -66,7 +61,6 @@ load(":swift_interop_info.bzl", "create_swift_interop_info")
 # invoking actions that compile Swift code from other rules.
 swift_common = struct(
     cc_feature_configuration = get_cc_feature_configuration,
-    compilation_attrs = swift_compilation_attrs,
     compile = compile,
     compile_module_interface = compile_module_interface,
     configure_features = configure_features,
@@ -93,7 +87,6 @@ swift_common = struct(
     extract_symbol_graph = extract_symbol_graph,
     get_toolchain = get_swift_toolchain,
     is_enabled = is_feature_enabled,
-    library_rule_attrs = swift_library_rule_attrs,
     precompile_clang_module = precompile_clang_module,
     toolchain_attrs = swift_toolchain_attrs,
     use_toolchain = use_swift_toolchain,


### PR DESCRIPTION
No custom rules are using these today. If they need to, they can just declare whatever attributes they need on their own.

PiperOrigin-RevId: 495328434
(cherry picked from commit 28a27e1f8d9263cfba2210feb6f3192024822e80)