### PR TITLE
Remove the `swift_explicit_module` output group from `swift_clang_module_aspect`

### DIFF
--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -534,12 +534,9 @@ def _handle_module(
         ),
     ]
 
-    if precompiled_module:
-        output_groups = {"swift_explicit_module": depset([precompiled_module])}
-        if indexstore_directory:
-            output_groups["indexstore"] = depset([indexstore_directory])
+    if indexstore_directory:
         providers.append(
-            OutputGroupInfo(**output_groups),
+            OutputGroupInfo(indexstore = depset([indexstore_directory])),
         )
 
     return providers


### PR DESCRIPTION
This is no longer used anywhere.

PiperOrigin-RevId: 495593700
(cherry picked from commit 3cb3d5ba8390a9e8de2d78197694059fd0bff093)