### PR TITLE
Allow configuring clang module dependencies for precompiled c modules

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -98,6 +98,7 @@ def compile_action_configs(
         *,
         additional_objc_copts = [],
         additional_swiftc_copts = [],
+        configure_precompile_c_module_clang_modules = None,
         generated_header_rewriter = None):
     """Returns the list of action configs needed to perform Swift compilation.
 
@@ -112,6 +113,10 @@ def compile_action_configs(
         additional_swiftc_copts: An optional list of additional Swift compiler
             flags that should be passed to Swift compile actions only after any
             other toolchain- or user-provided flags.
+        configure_precompile_c_module_clang_modules: An optional function that
+            configures clang module dependencies for precompiled c modules if
+            present. Takes the configurator for clang module dependencies as an
+            argument, and returns a list of action configs. Defaults to None.
         generated_header_rewriter: An executable that will be invoked after
             compilation to rewrite the generated header, or None if this is not
             desired.
@@ -887,7 +892,6 @@ def compile_action_configs(
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DERIVE_FILES,
                 SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_PRECOMPILE_C_MODULE,
                 SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [_dependencies_clang_modules_configurator],
@@ -906,6 +910,19 @@ def compile_action_configs(
             not_features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
     ])
+
+    if configure_precompile_c_module_clang_modules:
+        action_configs.extend(configure_precompile_c_module_clang_modules(
+            _dependencies_clang_modules_configurator,
+        ))
+    else:
+        action_configs.append(ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_PRECOMPILE_C_MODULE,
+            ],
+            configurators = [_dependencies_clang_modules_configurator],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ))
 
     #### Various other Swift compilation flags
     action_configs += [
@@ -1588,13 +1605,16 @@ def _dependencies_clang_modulemaps_configurator(prerequisites, args):
         prefer_precompiled_modules = False,
     )
 
-def _dependencies_clang_modules_configurator(prerequisites, args):
+def _dependencies_clang_modules_configurator(prerequisites, args, include_modules = True):
     """Configures precompiled Clang modules from dependencies."""
-    modules = [
-        module
-        for module in prerequisites.transitive_modules
-        if module.clang
-    ]
+    if include_modules:
+        modules = [
+            module
+            for module in prerequisites.transitive_modules
+            if module.clang
+        ]
+    else:
+        modules = []
 
     # Uniquify the arguments because different modules might be defined in the
     # same module map file, so it only needs to be present once on the command


### PR DESCRIPTION
PiperOrigin-RevId: 516571440
(cherry picked from commit cda3e7f60c9822ee61c08774e8a232fe81a3418e)