### PR TITLE
Remove checks for Xcode versions prior to 14.0 and unconditionally enable features that require 14.0 or greater

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -200,11 +200,6 @@ SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE = "swift.use_global_module_cache"
 # This feature requires `swift.use_global_module_cache` to be enabled.
 SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR = "swift.global_module_cache_uses_tmpdir"
 
-# If enabled, actions invoking the Swift driver will use the legacy driver
-# instead of the new driver (https://github.com/apple/swift-driver) that
-# launched in Xcode 13/Swift 5.5.
-SWIFT_FEATURE_USE_OLD_DRIVER = "swift.use_old_driver"
-
 # If enabled, Swift linking actions will use `swift-autolink-extract` to extract
 # the linker arguments.  This is required for ELF targets.  This is used
 # internally to determine the behaviour of the actions across different

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -39,7 +39,6 @@ load(
     "SWIFT_FEATURE_SUPPORTS_BARE_SLASH_REGEX",
     "SWIFT_FEATURE_USE_AUTOLINK_EXTRACT",
     "SWIFT_FEATURE_USE_MODULE_WRAP",
-    "SWIFT_FEATURE_USE_OLD_DRIVER",
 )
 load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 
@@ -368,9 +367,7 @@ def _create_windows_toolchain(repository_ctx):
         SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE,
         SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS,
     ]
-    disabled_features = [
-        SWIFT_FEATURE_USE_OLD_DRIVER,
-    ]
+    disabled_features = []
 
     version_file = _write_swift_version(repository_ctx, path_to_swiftc)
     xctest_version = repository_ctx.execute([

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -72,7 +72,6 @@ load(
     "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
-    "SWIFT_FEATURE_USE_OLD_DRIVER",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
@@ -120,24 +119,8 @@ def compile_action_configs(
         The list of action configs needed to perform compilation.
     """
 
-    #### Flags that control the driver
-    action_configs = [
-        # Use the legacy driver if requested.
-        ActionConfigInfo(
-            actions = [
-                SWIFT_ACTION_COMPILE,
-                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
-                SWIFT_ACTION_DERIVE_FILES,
-                SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_PRECOMPILE_C_MODULE,
-            ],
-            configurators = [add_arg("-disallow-use-new-driver")],
-            features = [SWIFT_FEATURE_USE_OLD_DRIVER],
-        ),
-    ]
-
     #### Flags that control compilation outputs
-    action_configs += [
+    action_configs = [
         # Emit object file(s).
         ActionConfigInfo(
             actions = [SWIFT_ACTION_COMPILE],

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -530,7 +530,9 @@ def _swift_toolchain_impl(ctx):
         generated_header_module_implicit_deps_providers = (
             collect_implicit_deps_providers([])
         ),
-        module_aliases = ctx.attr._module_mapping[SwiftModuleAliasesInfo].aliases,
+        module_aliases = (
+            ctx.attr._module_mapping[SwiftModuleAliasesInfo].aliases
+        ),
         implicit_deps_providers = collect_implicit_deps_providers(
             [],
             additional_cc_infos = [swift_linkopts_cc_info],


### PR DESCRIPTION
PiperOrigin-RevId: 523108542
(cherry picked from commit dc20ca5800e42675fd5ac249bc8e1569606a60b4)