### PR TITLE
Capture macro expansions in an output group named `macro_expansions` during debug builds

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -811,6 +811,10 @@ def compile_action_configs(
                 SWIFT_ACTION_DERIVE_FILES,
             ],
             configurators = [_macro_expansion_configurator],
+            # The compiler only generates these in debug builds, unless we pass
+            # additional frontend flags. At the current time, we only want to
+            # capture these for debug builds.
+            not_features = [SWIFT_FEATURE_OPT],
         ),
 
         # swift-symbolgraph-extract doesn't yet support explicit Swift module


### PR DESCRIPTION
LLDB wants these files to be present on the file system to step into macro expansions, because their file paths are recorded in debug info. The compiler uses `TMPDIR` (if set) as the location for those files, so we can have the worker set `TMPDIR` to a target-specific location before spawning `swiftc`. If this location is workspace-relative, then those file paths are also remapped via `-debug-prefix-map`—an added bonus.

The `macro_expansions` group will contain a tree (directory) artifact that contains a `swift-generated-sources` subdirectory (the compiler forces that name), which contains one or more `.swift` files representing the expanded macro buffers.

PiperOrigin-RevId: 549932429
(cherry picked from commit 69349eeba42ed7b7365759ba208067b4aa23854d)

Cherry-pick notes: We already included most of this in c9d1f5fb43d2003d091e2f3b88c29a3f110a9f7c. This just restricts `_macro_expansion_configurator` to debug builds.