### PR TITLE
Disable AEGs inside xcode_swift_toolchain

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -952,6 +952,8 @@ for incremental compilation using a persistent mode.
                     fragment = "apple",
                 ),
             ),
+            # TODO(b/301253335): Enable AEGs later.
+            "_use_auto_exec_groups": attr.bool(default = False),
         },
     ),
     doc = "Represents a Swift compiler toolchain provided by Xcode.",


### PR DESCRIPTION
Because of the complexity, I would like to disable AEGs in this rule and proceed with the rest of the migration and flip the flag. I'll come back in the near future to enable them and add `toolchain` param to the affected actions.

PiperOrigin-RevId: 567319616
(cherry picked from commit ee7f493a87e206db35f724601c52d1a18d64eb50)