### PR TITLE
Disable AEGs inside rules which uses swift toolchain from a rule's attribute

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -65,6 +65,7 @@ bzl_library(
         "//swift/internal:linking",
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
+        "@bazel_skylib//lib:dicts",
         "@bazel_skylib//lib:paths",
     ],
 )

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -14,6 +14,7 @@
 
 """Implementation of the `swift_binary` and `swift_test` rules."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//swift/internal:feature_names.bzl",
@@ -185,9 +186,15 @@ def _swift_binary_impl(ctx):
     ]
 
 swift_binary = rule(
-    attrs = binary_rule_attrs(
-        additional_deps_providers = [[SwiftCompilerPluginInfo]],
-        stamp_default = -1,
+    attrs = dicts.add(
+        binary_rule_attrs(
+            additional_deps_providers = [[SwiftCompilerPluginInfo]],
+            stamp_default = -1,
+        ),
+        {
+            # TODO(b/301253335): Enable AEGs and switch from `swift` exec_group to swift `toolchain` param.
+            "_use_auto_exec_groups": attr.bool(default = False),
+        },
     ),
     doc = """\
 Compiles and links Swift code into an executable binary.

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -336,6 +336,8 @@ universal_swift_compiler_plugin = rule(
             "_allowlist_function_transition": attr.label(
                 default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
             ),
+            # TODO(b/301253335): Enable AEGs and switch from `swift` exec_group to swift `toolchain` param.
+            "_use_auto_exec_groups": attr.bool(default = False),
         },
     ),
     doc = """\

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -188,6 +188,8 @@ May not be specified if `swiftinterface` is specified.
 """,
                 mandatory = False,
             ),
+            # TODO(b/301253335): Enable AEGs and add `toolchain` param once this rule starts using toolchain resolution.
+            "_use_auto_exec_groups": attr.bool(default = False),
         },
     ),
     doc = """\

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -670,6 +670,8 @@ standard executable binary that is invoked directly.
                     "@build_bazel_rules_swift//tools/xctest_runner:xctest_runner_template",
                 ),
             ),
+            # TODO(b/301253335): Enable AEGs and switch from `swift` exec_group to swift `toolchain` param.
+            "_use_auto_exec_groups": attr.bool(default = False),
         },
     ),
     doc = """\


### PR DESCRIPTION
These rules should register swift toolchain and then use it inside run_toolchain_action. Until then, AEGs will be disabled.

PiperOrigin-RevId: 567330453
(cherry picked from commit 3e50799d9a54bd84de114eb5a1660135e79b15ce)