### PR TITLE
Add visibility to `copt` and `exec_copt` Starlark flags

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -316,6 +316,7 @@ filegroup(
 repeatable_string_flag(
     name = "copt",
     build_setting_default = [],
+    visibility = ["//visibility:public"],
 )
 
 # Additional Swift compiler flags that will be applied to all `SwiftCompile`
@@ -324,6 +325,7 @@ repeatable_string_flag(
 repeatable_string_flag(
     name = "exec_copt",
     build_setting_default = [],
+    visibility = ["//visibility:public"],
 )
 
 # An aspect hint that enables module map generation for a non-Swift,


### PR DESCRIPTION
PiperOrigin-RevId: 584323059
(cherry picked from commit 8be724720ee6d1b73c52851106cf95b3cf158b3f)