### PR TITLE
Simplify `swift_common.compile` so that it returns a `SwiftInfo` that can be propagated by callers

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -171,6 +171,14 @@ Compiles a Swift module.
 
 A `struct` with the following fields:
 
+  *   `swift_info`: A `SwiftInfo` provider whose list of direct modules
+      contains the single Swift module context produced by this function
+      (identical to the `module_context` field below) and whose transitive
+      modules represent the transitive non-private dependencies. Rule
+      implementations that call this function can typically return this
+      provider directly, except in rare cases like making multiple calls
+      to `swift_common.compile` that need to be merged.
+
   *   `module_context`: A Swift module context (as returned by
       `create_swift_module_context`) that contains the Swift (and
       potentially C/Objective-C) compilation prerequisites of the compiled

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -374,6 +374,14 @@ def compile(
     Returns:
         A `struct` with the following fields:
 
+        *   `swift_info`: A `SwiftInfo` provider whose list of direct modules
+            contains the single Swift module context produced by this function
+            (identical to the `module_context` field below) and whose transitive
+            modules represent the transitive non-private dependencies. Rule
+            implementations that call this function can typically return this
+            provider directly, except in rare cases like making multiple calls
+            to `swift_common.compile` that need to be merged.
+
         *   `module_context`: A Swift module context (as returned by
             `create_swift_module_context`) that contains the Swift (and
             potentially C/Objective-C) compilation prerequisites of the compiled
@@ -511,17 +519,26 @@ def compile(
         providers = objc_infos + swift_toolchain.implicit_deps_providers.objc_infos,
     )
 
-    merged_swift_info = SwiftInfo(
-        swift_infos = (
-            swift_infos +
-            private_swift_infos +
-            swift_toolchain.implicit_deps_providers.swift_infos +
-            _cross_imported_swift_infos(
-                swift_toolchain = swift_toolchain,
-                user_swift_infos = swift_infos + private_swift_infos,
-            )
-        ),
+    # These are the `SwiftInfo` providers that will be merged with the compiled
+    # module context and returned as the `swift_info` field of this function's
+    # result. Note that private deps are explicitly not included here, as they
+    # are not supposed to be propagated.
+    #
+    # TODO(allevato): It would potentially clean things up if we included the
+    # toolchain's implicit dependencies here as well. Do this and make sure it
+    # doesn't break anything unexpected.
+    swift_infos_to_propagate = swift_infos + _cross_imported_swift_infos(
+        swift_toolchain = swift_toolchain,
+        user_swift_infos = swift_infos + private_swift_infos,
     )
+
+    all_swift_infos = (
+        swift_infos_to_propagate +
+        private_swift_infos +
+        swift_toolchain.implicit_deps_providers.swift_infos
+    )
+
+    merged_swift_info = SwiftInfo(swift_infos = all_swift_infos)
 
     # Flattening this `depset` is necessary because we need to extract the
     # module maps or precompiled modules out of structured values and do so
@@ -788,6 +805,10 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             const_values_files = compile_outputs.const_values_files,
             indexstore_directory = compile_outputs.indexstore_directory,
             macro_expansion_directory = compile_outputs.macro_expansion_directory,
+        ),
+        swift_info = SwiftInfo(
+            modules = [module_context],
+            swift_infos = swift_infos_to_propagate,
         ),
     )
 

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -183,9 +183,7 @@ def _swift_compiler_plugin_impl(ctx):
             ),
             executable = binary_linking_outputs.executable,
             module_names = depset([module_name]),
-            swift_info = SwiftInfo(
-                modules = [module_context],
-            ),
+            swift_info = compile_result.swift_info,
         ),
     ]
 

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -259,12 +259,7 @@ def _swift_library_impl(ctx):
             extensions = ["swift"],
             source_attributes = ["srcs"],
         ),
-        SwiftInfo(
-            modules = [module_context],
-            # Note that private_deps are explicitly omitted here; they should
-            # not propagate.
-            swift_infos = swift_infos,
-        ),
+        compile_result.swift_info,
         OutputGroupInfo(
             **supplemental_compilation_output_groups(supplemental_outputs)
         ),

--- a/swift/swift_module_alias.bzl
+++ b/swift/swift_module_alias.bzl
@@ -119,10 +119,7 @@ def _swift_module_alias_impl(ctx):
             compilation_context = module_context.clang.compilation_context,
             linking_context = linking_context,
         ),
-        SwiftInfo(
-            modules = [module_context],
-            swift_infos = swift_infos,
-        ),
+        compile_result.swift_info,
     ]
 
     # Propagate an `apple_common.Objc` provider with linking info about the

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -429,10 +429,7 @@ def _swift_test_impl(ctx):
         compilation_outputs = compile_result.compilation_outputs
         all_supplemental_outputs.append(compile_result.supplemental_outputs)
 
-        swift_infos_including_owner = [SwiftInfo(
-            modules = [compile_result.module_context],
-            swift_infos = deps_swift_infos,
-        )]
+        swift_infos_including_owner = [compile_result.swift_info]
 
         # If we're going to do test discovery below, extract the symbol graph of
         # the module that we just compiled so that we can discover any tests in


### PR DESCRIPTION
The impetus for this change was the fact that inferred cross-import overlay providers weren't being merged into the propagated `SwiftInfo`, so compiling a target that directly depended on one would succeed but compiling something depending on that other target would fail.

Since provider merging was being done by the rules, not by the `compile` call that collected the providers, we would have had to offer a separate API for rule implementations to collect those same cross-import providers or have `compile` return them in some separate fashion.

However, all current callers of `swift_common.compile` are doing exactly the same thing: creating a new `SwiftInfo` that merges the returned module context with the deps `SwiftInfo`s that it already collected and passed to `compile`. So, it's straightforward to just return that `SwiftInfo`, into which we can merge the cross-import providers. This ensures we don't drop anything on the floor *and* it's a major API improvement.

PiperOrigin-RevId: 500710468
(cherry picked from commit ac4375db60e55ee0b7180685fa02aa4b562245d7)