### PR TITLE
Add an `is_framework` parameter to `compile_module_interface`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -119,7 +119,7 @@ A `struct` with the following fields:
 
 <pre>
 swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
-                                      <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
+                                      <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
                                       <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>)
 </pre>
 
@@ -136,6 +136,7 @@ Compiles a Swift module interface.
 | <a id="swift_common.compile_module_interface-copts"></a>copts |  A list of compiler flags that apply to the target being built.   |  `[]` |
 | <a id="swift_common.compile_module_interface-exec_group"></a>exec_group |  Runs the Swift compilation action under the given execution group's context. If `None`, the default execution group is used.   |  `None` |
 | <a id="swift_common.compile_module_interface-feature_configuration"></a>feature_configuration |  A feature configuration obtained from `configure_features`.   |  none |
+| <a id="swift_common.compile_module_interface-is_framework"></a>is_framework |  True if this module is a Framework module, false othwerise.   |  `False` |
 | <a id="swift_common.compile_module_interface-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `derive_swift_module_name` to generate a default from the target's label if needed.   |  none |
 | <a id="swift_common.compile_module_interface-swiftinterface_file"></a>swiftinterface_file |  The Swift module interface file to compile.   |  none |
 | <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled.   |  none |

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -136,6 +136,7 @@ def compile_module_interface(
         copts = [],
         exec_group = None,
         feature_configuration,
+        is_framework = False,
         module_name,
         swiftinterface_file,
         swift_infos,
@@ -157,6 +158,7 @@ def compile_module_interface(
             group's context. If `None`, the default execution group is used.
         feature_configuration: A feature configuration obtained from
             `configure_features`.
+        is_framework: True if this module is a Framework module, false othwerise.
         module_name: The name of the Swift module being compiled. This must be
             present and valid; use `derive_swift_module_name` to generate a
             default from the target's label if needed.
@@ -283,6 +285,7 @@ def compile_module_interface(
             compilation_context = merged_compilation_context,
             module_map = None,
         ),
+        is_framework = is_framework,
         is_system = is_feature_enabled(
             feature_configuration = feature_configuration,
             feature_name = SWIFT_FEATURE_SYSTEM_MODULE,

--- a/swift/providers.bzl
+++ b/swift/providers.bzl
@@ -426,6 +426,7 @@ def create_swift_module_context(
         clang = None,
         const_gather_protocols = [],
         compilation_context = None,
+        is_framework = False,
         is_system = False,
         swift = None):
     """Creates a value containing Clang/Swift module artifacts of a dependency.
@@ -459,6 +460,8 @@ def create_swift_module_context(
             `swift_common.create_compilation_context` that contains the
             context needed to compile the module being built. This may be `None`
             if the module wasn't compiled from sources.
+        is_framework: Indictates whether the module is a framework module. The
+            default value is `False`.
         is_system: Indicates whether the module is a system module. The default
             value is `False`. System modules differ slightly from non-system
             modules in the way that they are passed to the compiler. For
@@ -486,6 +489,7 @@ def create_swift_module_context(
         clang = clang,
         const_gather_protocols = tuple(const_gather_protocols),
         compilation_context = compilation_context,
+        is_framework = is_framework,
         is_system = is_system,
         name = name,
         swift = swift,


### PR DESCRIPTION
PiperOrigin-RevId: 542015885
(cherry picked from commit faf98ee8118b385a5a64ba0489e22770c42145d2)