### PR TITLE
Add a feature that enables `-index-include-locals` for Swift compiles

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -74,6 +74,12 @@ SWIFT_FEATURE_DISABLE_SYSTEM_INDEX = "swift.disable_system_index"
 # Index while building - using a global index store cache
 SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE = "swift.use_global_index_store"
 
+# If enabled, indexstore data will contain local definitions and references.
+#
+# NOTE: This is only applicable if `SWIFT_FEATURE_INDEX_WHILE_BUILDING` is also
+# enabled.
+SWIFT_FEATURE_INDEX_INCLUDE_LOCALS = "swift.index_include_locals"
+
 # If enabled, indexing will be completely modular - PCMs and Swift Modules will only
 # be indexed when they are compiled. While indexing a module/PCM, none of its dependencies
 # will be indexed.

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -55,6 +55,7 @@ load(
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
     "SWIFT_FEATURE_FULL_LTO",
     "SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR",
+    "SWIFT_FEATURE_INDEX_INCLUDE_LOCALS",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_LAYERING_CHECK",
     "SWIFT_FEATURE_MODULAR_INDEXING",
@@ -1044,6 +1045,14 @@ def compile_action_configs(
             actions = [SWIFT_ACTION_COMPILE],
             configurators = [_index_while_building_configurator],
             features = [SWIFT_FEATURE_INDEX_WHILE_BUILDING],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [add_arg("-index-include-locals")],
+            features = [
+                SWIFT_FEATURE_INDEX_WHILE_BUILDING,
+                SWIFT_FEATURE_INDEX_INCLUDE_LOCALS,
+            ],
         ),
         ActionConfigInfo(
             actions = [SWIFT_ACTION_COMPILE],


### PR DESCRIPTION
PiperOrigin-RevId: 574234005
(cherry picked from commit c9b81c0e639a90a66c08ec349c860c6e753ffddd)