### PR TITLE
Make sure `swift_import` propagates the `.swiftinterface` file in its `SwiftInfo` if it's given one as an input

### DIFF
--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -126,6 +126,7 @@ def _swift_import_impl(ctx):
             ),
             swift = create_swift_module_inputs(
                 swiftdoc = swiftdoc,
+                swiftinterface = swiftinterface,
                 swiftmodule = swiftmodule,
             ),
         )


### PR DESCRIPTION
PiperOrigin-RevId: 618250957
(cherry picked from commit 6d61c03390a63e3c2edc1241096ee13a6e6c668f)