### PR TITLE
Remove duplicate `-enable-library-evolution` flag

### DIFF
--- a/swift/toolchains/config/compile_module_interface_config.bzl
+++ b/swift/toolchains/config/compile_module_interface_config.bzl
@@ -22,6 +22,9 @@ load(":action_config.bzl", "ActionConfigInfo", "add_arg")
 
 def compile_module_interface_action_configs():
     return [
+        # Library evolution is implied since we've already produced a
+        # .swiftinterface file. So we want to unconditionally enable the flag
+        # for this action.
         ActionConfigInfo(
             actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
             configurators = [add_arg("-enable-library-evolution")],
@@ -37,15 +40,6 @@ def compile_module_interface_action_configs():
             configurators = [
                 add_arg("-compile-module-from-interface"),
             ],
-        ),
-        # Library evolution is implied since we've already produced a
-        # .swiftinterface file. So we want to unconditionally enable the flag
-        # for this action.
-        ActionConfigInfo(
-            actions = [
-                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
-            ],
-            configurators = [add_arg("-enable-library-evolution")],
         ),
     ]
 


### PR DESCRIPTION
PiperOrigin-RevId: 647279184
(cherry picked from commit 0d9db4bfb41e24738bc074b54ef72896add268fc)