### PR TITLE
Remove `swift_common.toolchain_attrs`

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -486,52 +486,6 @@ A struct containing the precompiled module and optional indexstore directory,
   or `None` if the toolchain or target does not support precompiled modules.
 
 
-<a id="swift_common.toolchain_attrs"></a>
-
-## swift_common.toolchain_attrs
-
-<pre>
-swift_common.toolchain_attrs(<a href="#swift_common.toolchain_attrs-toolchain_attr_name">toolchain_attr_name</a>)
-</pre>
-
-Returns an attribute dictionary for toolchain users.
-
-The returned dictionary contains a key with the name specified by the
-argument `toolchain_attr_name` (which defaults to the value `"_toolchain"`),
-the value of which is a BUILD API `attr.label` that references the default
-Swift toolchain. Users who are authoring custom rules can add this
-dictionary to the attributes of their own rule in order to depend on the
-toolchain and access its `SwiftToolchainInfo` provider to pass it to other
-`swift_common` functions.
-
-There is a hierarchy to the attribute sets offered by the `swift_common`
-API:
-
-1.  If you only need access to the toolchain for its tools and libraries but
-    are not doing any compilation, use `toolchain_attrs`.
-2.  If you need to invoke compilation actions but are not making the
-    resulting object files into a static or shared library, use
-    `compilation_attrs`.
-3.  If you want to provide a rule interface that is suitable as a drop-in
-    replacement for `swift_library`, use `library_rule_attrs`.
-
-Each of the attribute functions in the list above also contains the
-attributes from the earlier items in the list.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="swift_common.toolchain_attrs-toolchain_attr_name"></a>toolchain_attr_name |  The name of the attribute that should be created that points to the toolchain. This defaults to `_toolchain`, which is sufficient for most rules; it is customizable for certain aspects where having an attribute with the same name but different values applied to a particular target causes a build crash.   |  `"_toolchain"` |
-
-**RETURNS**
-
-A new attribute dictionary that can be added to the attributes of a
-  custom build rule to provide access to the Swift toolchain.
-
-
 <a id="swift_common.use_toolchain"></a>
 
 ## swift_common.use_toolchain

--- a/mixed_language/internal/library.bzl
+++ b/mixed_language/internal/library.bzl
@@ -25,7 +25,7 @@ load(
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:attrs.bzl", "swift_deps_attr", "swift_toolchain_attrs")
+load("//swift/internal:attrs.bzl", "swift_deps_attr")
 
 # buildifier: disable=bzl-visibility
 load(
@@ -198,7 +198,6 @@ def _mixed_language_library_impl(ctx):
 
 mixed_language_library = rule(
     attrs = dicts.add(
-        swift_toolchain_attrs(),
         {
             "clang_target": attr.label(
                 doc = """

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -56,7 +56,6 @@ bzl_library(
         ":swift_proto_utils",
         "//swift:module_name",
         "//swift:providers",
-        "//swift:swift_common",
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -36,7 +36,6 @@ load(
     "SwiftProtoCompilerInfo",
     "SwiftProtoInfo",
 )
-load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
 load("//swift/internal:toolchain_utils.bzl", "use_swift_toolchain")
@@ -73,7 +72,6 @@ def _swift_proto_library_group_aspect_impl(target, aspect_ctx):
 _swift_proto_library_group_aspect = aspect(
     attr_aspects = ["deps"],
     attrs = dicts.add(
-        swift_common.toolchain_attrs(),
         {
             "_compiler": attr.label(
                 default = Label("//proto:_swift_proto_compiler"),

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -76,7 +76,6 @@ bzl_library(
     deps = [
         ":module_name",
         ":providers",
-        "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
         "//swift/internal:features",
@@ -91,7 +90,6 @@ bzl_library(
     name = "swift_common",
     srcs = ["swift_common.bzl"],
     deps = [
-        "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:features",
         "//swift/internal:linking",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -228,7 +228,6 @@ bzl_library(
     srcs = ["swift_symbol_graph_aspect.bzl"],
     visibility = ["//swift:__subpackages__"],
     deps = [
-        ":attrs",
         ":features",
         ":providers",
         ":symbol_graph_extracting",

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -102,7 +102,6 @@ def swift_compilation_attrs(
             additional_deps_aspects = additional_deps_aspects,
             additional_deps_providers = additional_deps_providers,
         ),
-        swift_toolchain_attrs(),
         {
             "copts": attr.string_list(
                 doc = """\
@@ -368,48 +367,6 @@ potentially avoid a PLT relocation).  Set to `False` to build a `.so` or `.dll`.
             ),
         },
     )
-
-def swift_toolchain_attrs(toolchain_attr_name = "_toolchain"):
-    """Returns an attribute dictionary for toolchain users.
-
-    The returned dictionary contains a key with the name specified by the
-    argument `toolchain_attr_name` (which defaults to the value `"_toolchain"`),
-    the value of which is a BUILD API `attr.label` that references the default
-    Swift toolchain. Users who are authoring custom rules can add this
-    dictionary to the attributes of their own rule in order to depend on the
-    toolchain and access its `SwiftToolchainInfo` provider to pass it to other
-    `swift_common` functions.
-
-    There is a hierarchy to the attribute sets offered by the `swift_common`
-    API:
-
-    1.  If you only need access to the toolchain for its tools and libraries but
-        are not doing any compilation, use `toolchain_attrs`.
-    2.  If you need to invoke compilation actions but are not making the
-        resulting object files into a static or shared library, use
-        `compilation_attrs`.
-    3.  If you want to provide a rule interface that is suitable as a drop-in
-        replacement for `swift_library`, use `library_rule_attrs`.
-
-    Each of the attribute functions in the list above also contains the
-    attributes from the earlier items in the list.
-
-    Args:
-        toolchain_attr_name: The name of the attribute that should be created
-            that points to the toolchain. This defaults to `_toolchain`, which
-            is sufficient for most rules; it is customizable for certain aspects
-            where having an attribute with the same name but different values
-            applied to a particular target causes a build crash.
-
-    Returns:
-        A new attribute dictionary that can be added to the attributes of a
-        custom build rule to provide access to the Swift toolchain.
-    """
-    return {
-        toolchain_attr_name: attr.label(
-            default = Label("@build_bazel_rules_swift_local_config//:toolchain"),
-        ),
-    }
 
 def swift_toolchain_driver_attrs():
     """Returns attributes used to attach custom drivers to toolchains.

--- a/swift/internal/swift_symbol_graph_aspect.bzl
+++ b/swift/internal/swift_symbol_graph_aspect.bzl
@@ -24,7 +24,6 @@ file in the parent directory.
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//swift:providers.bzl", "SwiftInfo", "SwiftSymbolGraphInfo")
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load("//swift/internal:features.bzl", "configure_features")
 load("//swift/internal:symbol_graph_extracting.bzl", "extract_symbol_graph")
 load(
@@ -148,7 +147,6 @@ def make_swift_symbol_graph_aspect(
     return aspect(
         attr_aspects = ["deps"],
         attrs = dicts.add(
-            swift_toolchain_attrs(),
             {
                 # TODO: use `attr.bool` once https://github.com/bazelbuild/bazel/issues/22809 is resolved.
                 "emit_extension_block_symbols": attr.string(

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -15,7 +15,6 @@
 """Propagates unified `SwiftInfo` providers for C/Objective-C targets."""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load("//swift/internal:compiling.bzl", "precompile_clang_module")
 load(
     "//swift/internal:feature_names.bzl",
@@ -561,7 +560,6 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
 
     swift_toolchain = get_swift_toolchain(
         aspect_ctx,
-        attr = "_toolchain_for_aspect",
     )
     feature_configuration = configure_features(
         ctx = aspect_ctx,
@@ -595,9 +593,6 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
 
 swift_clang_module_aspect = aspect(
     attr_aspects = _MULTIPLE_TARGET_ASPECT_ATTRS,
-    attrs = swift_toolchain_attrs(
-        toolchain_attr_name = "_toolchain_for_aspect",
-    ),
     doc = """\
 Propagates unified `SwiftInfo` providers for targets that represent
 C/Objective-C modules.

--- a/swift/swift_common.bzl
+++ b/swift/swift_common.bzl
@@ -20,7 +20,6 @@ example, `swift_proto_library` generates Swift source code from `.proto` files
 and then needs to compile them. This module provides that lower-level interface.
 """
 
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load(
     "//swift/internal:compiling.bzl",
     "compile",
@@ -61,6 +60,5 @@ swift_common = struct(
     get_toolchain = get_swift_toolchain,
     is_enabled = is_feature_enabled,
     precompile_clang_module = precompile_clang_module,
-    toolchain_attrs = swift_toolchain_attrs,
     use_toolchain = use_swift_toolchain,
 )

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -18,7 +18,6 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//swift/internal:attrs.bzl",
     "swift_common_rule_attrs",
-    "swift_toolchain_attrs",
 )
 load("//swift/internal:compiling.bzl", "compile_module_interface")
 load(
@@ -156,7 +155,6 @@ def _swift_import_impl(ctx):
 swift_import = rule(
     attrs = dicts.add(
         swift_common_rule_attrs(),
-        swift_toolchain_attrs(),
         {
             "archives": attr.label_list(
                 allow_empty = True,


### PR DESCRIPTION
PiperOrigin-RevId: 559415879
(cherry picked from commit c7cf7c3c428e719b2d7ade197eb56a618cf09328)

Cherry-pick notes: Other rulesets will need to fully migrate to using toolchains, and `swift_common.get_swift_toolchain` in particular, with this change.