### PR TITLE
Write "isSystem" and "isFramework" in explicit swift module map

### DIFF
--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -45,6 +45,10 @@ def write_explicit_swift_module_map_file(
         }
         if swift_context.swiftmodule:
             module_description["modulePath"] = swift_context.swiftmodule.path
+        if module_context.is_system:
+            module_description["isSystem"] = module_context.is_system
+        if module_context.is_framework:
+            module_description["isFramework"] = module_context.is_framework
         module_descriptions.append(module_description)
 
     actions.write(


### PR DESCRIPTION
Check module_context and write out "isSystem" and "isFramework" attributes to swift explicit module map if present.

PiperOrigin-RevId: 542029509
(cherry picked from commit 1a449995cee878c3f4ca1fcdc947579605e8bd0f)