### PR TITLE
Remove the `emit_swiftinterface` build setting

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load(
     "//swift/internal:build_settings.bzl",
     "per_module_swiftcopt_flag",
@@ -348,19 +348,6 @@ swift_interop_hint(
 per_module_swiftcopt_flag(
     name = "per_module_swiftcopt",
     build_setting_default = "",
-)
-
-# Configuration setting for enabling the generation of swiftinterface files.
-bool_setting(
-    name = "emit_swiftinterface",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
-)
-
-# Configuration setting for enabling the generation of private swiftinterface files (e.g. those for `@_spi`).
-bool_setting(
-    name = "emit_private_swiftinterface",
-    build_setting_default = False,
 )
 
 # NOTE: Enabling this flag will transition --proto_compiler to

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -186,12 +186,6 @@ def swift_config_attrs():
         configuration settings.
     """
     return {
-        "_config_emit_private_swiftinterface": attr.label(
-            default = Label("//swift:emit_private_swiftinterface"),
-        ),
-        "_config_emit_swiftinterface": attr.label(
-            default = Label("//swift:emit_swiftinterface"),
-        ),
         "_per_module_swiftcopt": attr.label(
             default = Label("//swift:per_module_swiftcopt"),
         ),

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -16,7 +16,6 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "//swift/internal:attrs.bzl",
     "swift_deps_attr",
@@ -139,20 +138,9 @@ def _swift_library_impl(ctx):
 
     extra_features = []
 
-    # TODO(b/239957001): Remove the global flag.
-    if (
-        ctx.attr.library_evolution or
-        ctx.attr._config_emit_swiftinterface[BuildSettingInfo].value
-    ):
+    if ctx.attr.library_evolution:
         extra_features.append(SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION)
         extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
-
-    # TODO(b/239957001): Remove the global flag.
-    if (
-        ctx.attr.library_evolution or
-        ctx.attr._config_emit_private_swiftinterface[BuildSettingInfo].value
-    ):
-        extra_features.append(SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION)
         extra_features.append(SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE)
 
     module_name = ctx.attr.module_name


### PR DESCRIPTION
This was only present to support Apple framework rules, but its design was flawed, so they no longer use it. Library evolution shouldn't be enabled for entire dependency subgraphs; authors of SDKs should explicitly enable it on their libraries with the `library_evolution` attribute.

PiperOrigin-RevId: 629786303
(cherry picked from commit 1ee51c8cc980e8e0a9cd7f21e99c5e424fbc3afa)

Cherry-pick notes: Applied the same change to the `emit_private_swiftinterface` build setting.