### PR TITLE
Add `swift.disable_availability_checking` feature

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -339,6 +339,10 @@ SWIFT_FEATURE_DISABLE_CLANG_SPI = "swift.disable_clang_spi"
 # explicitly exported via `-exported_symbols_list`.
 SWIFT_FEATURE_INTERNALIZE_AT_LINK = "swift.internalize_at_link"
 
+# If enabled, requests the `-disable-availability-checking` frontend flag.
+# This disables checking for potentially unavailable APIs.
+SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING = "swift.disable_availability_checking"
+
 # Disables Swift sandbox which prevents issues with nested sandboxing when Swift code contains system-provided macros.
 # If enabled '#Preview' macro provided by SwiftUI fails to build and probably other system-provided macros.
 # Enabled by default for Swift 5.10+ on macOS.

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -40,6 +40,7 @@ load(
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
+    "SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING",
     "SWIFT_FEATURE_DISABLE_CLANG_SPI",
     "SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE_DISABLE_SYSTEM_INDEX",
@@ -1144,6 +1145,15 @@ def compile_action_configs(
             configurators = [add_arg("-Xfrontend", "-disable-clang-spi")],
             features = [
                 SWIFT_FEATURE_DISABLE_CLANG_SPI,
+            ],
+        ),
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+            ],
+            configurators = [add_arg("-Xfrontend", "-disable-availability-checking")],
+            features = [
+                SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING,
             ],
         ),
     ]


### PR DESCRIPTION
PiperOrigin-RevId: 576855740
(cherry picked from commit bdbe2e44c5d2807b4e36fa81ab9d94201ded7dfc)