### PR TITLE
Remove implicit dependencies of `_allowlist_function_transition` in third_party

### DIFF
--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -133,11 +133,6 @@ def _swift_proto_library_group_impl(ctx):
 
 swift_proto_library_group = rule(
     attrs = {
-        "_allowlist_function_transition": attr.label(
-            default = Label(
-                "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
-        ),
         "compiler": attr.label(
             default = Label("//proto/compilers:swift_proto"),
             doc = """\

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -354,11 +354,6 @@ universal_swift_compiler_plugin = rule(
                 mandatory = True,
                 providers = [[SwiftBinaryInfo, SwiftCompilerPluginInfo]],
             ),
-            "_allowlist_function_transition": attr.label(
-                default = Label(
-                    "@bazel_tools//tools/allowlists/function_transition_allowlist",
-                ),
-            ),
             # TODO(b/301253335): Enable AEGs and switch from `swift` exec_group to swift `toolchain` param.
             "_use_auto_exec_groups": attr.bool(default = False),
         },

--- a/test/fixtures/module_mapping/apply_mapping.bzl
+++ b/test/fixtures/module_mapping/apply_mapping.bzl
@@ -32,11 +32,6 @@ apply_mapping = rule(
     attrs = {
         "mapping": attr.label(),
         "target": attr.label(cfg = apply_mapping_transition),
-        "_allowlist_function_transition": attr.label(
-            default = Label(
-                "@bazel_tools//tools/allowlists/function_transition_allowlist",
-            ),
-        ),
     },
     implementation = _apply_mapping_impl,
 )


### PR DESCRIPTION
Rules are not required to have an implicit dependencies on the transition allowlist since Bazel knows where the file is.

PiperOrigin-RevId: 610831569
(cherry picked from commit 589e42ce5c96030ee0970d3d59a6a2ce03362fde)