### PR TITLE
Bless `SwiftBinaryInfo` as a public provider for IDEs and language tooling that need to get at the Swift module of a `swift_binary` or `swift_test` target

### DIFF
--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -15,8 +15,8 @@
 """Common attributes used by multiple Swift build rules."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("//swift:providers.bzl", "SwiftInfo")
-load(":providers.bzl", "SwiftBinaryInfo", "SwiftCompilerPluginInfo")
+load("//swift:providers.bzl", "SwiftBinaryInfo", "SwiftInfo")
+load(":providers.bzl", "SwiftCompilerPluginInfo")
 
 def swift_common_rule_attrs(
         additional_deps_aspects = [],

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -14,34 +14,6 @@
 
 """Internal providers."""
 
-SwiftBinaryInfo = provider(
-    doc = """
-Information about a binary target's module.
-`swift_binary` and `swift_compiler_plugin` propagate this provider that wraps
-`CcInfo` and `SwiftInfo` providers, instead of propagating them directly, so
-that `swift_test` targets can depend on those binaries and test their modules
-(similar to what Swift Package Manager allows) without allowing any
-`swift_library` to depend on an arbitrary binary.
-""",
-    fields = {
-        "cc_info": """\
-A `CcInfo` provider containing the binary's code compiled as a static library,
-which is suitable for linking into a `swift_test` so that unit tests can be
-written against it.
-Notably, this `CcInfo`'s linking context does *not* contain the linker flags
-used to alias the `main` entry point function, because the purpose of this
-provider is to allow it to be linked into another binary that would provide its
-own entry point instead.
-""",
-        "swift_info": """\
-A `SwiftInfo` provider representing the Swift module created by compiling the
-target. This is used specifically by `swift_test` to allow test code to depend
-on the binary's module without making it possible for arbitrary libraries or
-binaries to depend on other binaries.
-""",
-    },
-)
-
 SwiftCompilerPluginInfo = provider(
     doc = """
 Information about compiler plugins (like macros) that is needed by the compiler

--- a/swift/providers.bzl
+++ b/swift/providers.bzl
@@ -20,6 +20,34 @@ to the rule implementations do not unnecessarily cause reanalysis impacting
 users who just load these providers to inspect and/or repropagate them.
 """
 
+SwiftBinaryInfo = provider(
+    doc = """
+Information about a binary target's module.
+`swift_binary` and `swift_compiler_plugin` propagate this provider that wraps
+`CcInfo` and `SwiftInfo` providers, instead of propagating them directly, so
+that `swift_test` targets can depend on those binaries and test their modules
+(similar to what Swift Package Manager allows) without allowing any
+`swift_library` to depend on an arbitrary binary.
+""",
+    fields = {
+        "cc_info": """\
+A `CcInfo` provider containing the binary's code compiled as a static library,
+which is suitable for linking into a `swift_test` so that unit tests can be
+written against it.
+Notably, this `CcInfo`'s linking context does *not* contain the linker flags
+used to alias the `main` entry point function, because the purpose of this
+provider is to allow it to be linked into another binary that would provide its
+own entry point instead.
+""",
+        "swift_info": """\
+A `SwiftInfo` provider representing the Swift module created by compiling the
+target. This is used specifically by `swift_test` to allow test code to depend
+on the binary's module without making it possible for arbitrary libraries or
+binaries to depend on other binaries.
+""",
+    },
+)
+
 SwiftFeatureAllowlistInfo = provider(
     doc = """\
 Describes a set of features and the packages and aspects that are allowed to

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -34,11 +34,7 @@ load(
     "//swift/internal:output_groups.bzl",
     "supplemental_compilation_output_groups",
 )
-load(
-    "//swift/internal:providers.bzl",
-    "SwiftBinaryInfo",
-    "SwiftCompilerPluginInfo",
-)
+load("//swift/internal:providers.bzl", "SwiftCompilerPluginInfo")
 load(
     "//swift/internal:toolchain_utils.bzl",
     "get_swift_toolchain",
@@ -51,7 +47,12 @@ load(
     "include_developer_search_paths",
 )
 load(":module_name.bzl", "derive_swift_module_name")
-load(":providers.bzl", "SwiftInfo", "create_swift_module_context")
+load(
+    ":providers.bzl",
+    "SwiftBinaryInfo",
+    "SwiftInfo",
+    "create_swift_module_context",
+)
 
 def _maybe_parse_as_library_copts(srcs):
     """Returns a list of compiler flags depending on `main.swift`'s presence.

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -39,11 +39,7 @@ load(
     "//swift/internal:output_groups.bzl",
     "supplemental_compilation_output_groups",
 )
-load(
-    "//swift/internal:providers.bzl",
-    "SwiftBinaryInfo",
-    "SwiftCompilerPluginInfo",
-)
+load("//swift/internal:providers.bzl", "SwiftCompilerPluginInfo")
 load(
     "//swift/internal:toolchain_utils.bzl",
     "get_swift_toolchain",
@@ -55,7 +51,7 @@ load(
     "get_providers",
 )
 load(":module_name.bzl", "derive_swift_module_name")
-load(":providers.bzl", "SwiftInfo")
+load(":providers.bzl", "SwiftBinaryInfo", "SwiftInfo")
 
 def _swift_compiler_plugin_impl(ctx):
     swift_toolchain = get_swift_toolchain(ctx)

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -34,11 +34,7 @@ load(
     "//swift/internal:output_groups.bzl",
     "supplemental_compilation_output_groups",
 )
-load(
-    "//swift/internal:providers.bzl",
-    "SwiftBinaryInfo",
-    "SwiftCompilerPluginInfo",
-)
+load("//swift/internal:providers.bzl", "SwiftCompilerPluginInfo")
 load(
     "//swift/internal:swift_symbol_graph_aspect.bzl",
     "make_swift_symbol_graph_aspect",
@@ -58,6 +54,7 @@ load(
 load(":module_name.bzl", "derive_swift_module_name")
 load(
     ":providers.bzl",
+    "SwiftBinaryInfo",
     "SwiftInfo",
     "SwiftSymbolGraphInfo",
     "create_swift_module_context",


### PR DESCRIPTION
PiperOrigin-RevId: 596931309
(cherry picked from commit 33df9a7dc92787664c1ec3d12b44e2817d04bc13)