### PR TITLE
Add the ability to enable upcoming and experimental Swift features via Bazel features

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -63,6 +63,7 @@ load(
     "are_all_features_enabled",
     "get_cc_feature_configuration",
     "is_feature_enabled",
+    "upcoming_and_experimental_features",
 )
 load(":module_maps.bzl", "write_module_map")
 load(
@@ -623,6 +624,9 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
 """)  # buildifier: disable=print
         include_dev_srch_paths_value = is_test
 
+    upcoming_features, experimental_features = upcoming_and_experimental_features(
+        feature_configuration = feature_configuration,
+    )
     prerequisites = struct(
         additional_inputs = additional_inputs,
         always_include_headers = is_feature_enabled(
@@ -634,8 +638,9 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         const_gather_protocols_file = const_gather_protocols_file,
         cc_linking_context = merged_cc_info.linking_context,
         defines = sets.to_list(defines_set),
-        explicit_swift_module_map_file = explicit_swift_module_map_file,
         developer_dirs = swift_toolchain.developer_dirs,
+        experimental_features = experimental_features,
+        explicit_swift_module_map_file = explicit_swift_module_map_file,
         genfiles_dir = feature_configuration._genfiles_dir,
         include_dev_srch_paths = include_dev_srch_paths_value,
         is_swift = True,
@@ -648,6 +653,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
         transitive_swiftmodules = transitive_swiftmodules,
+        upcoming_features = upcoming_features,
         user_compile_flags = copts,
         vfsoverlay_file = vfsoverlay_file,
         vfsoverlay_search_path = _SWIFTMODULES_VFS_ROOT,

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -360,6 +360,11 @@ SWIFT_FEATURE_INTERNALIZE_AT_LINK = "swift.internalize_at_link"
 # This disables checking for potentially unavailable APIs.
 SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING = "swift.disable_availability_checking"
 
+# A private feature that is set by the toolchain if it supports the
+# `-enable-{experimental,upcoming}-feature` flag (Swift 5.8 and above). Users
+# should never manually, enable, disable, or query this feature.
+SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES = "swift._supports_upcoming_features"
+
 # Disables Swift sandbox which prevents issues with nested sandboxing when Swift code contains system-provided macros.
 # If enabled '#Preview' macro provided by SwiftUI fails to build and probably other system-provided macros.
 # Enabled by default for Swift 5.10+ on macOS.

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -281,6 +281,33 @@ def default_features_for_toolchain(ctx, target_triple):
 
     return features
 
+def upcoming_and_experimental_features(feature_configuration):
+    """Extracts the upcoming and experimental feature names from the config.
+
+    Args:
+        feature_configuration: The Swift feature configuration.
+
+    Returns:
+        A tuple containing the following elements:
+
+        1.  The `list` of requested upcoming features (with the
+            `swift.upcoming.` prefix removed).
+        2.  The `list` of requested experimental features (with the
+            `swift.experimental.` prefix removed).
+    """
+    upcoming_prefix = "swift.upcoming."
+    experimental_prefix = "swift.experimental."
+    upcoming = []
+    experimental = []
+
+    for feature in feature_configuration._enabled_features:
+        if feature.startswith(upcoming_prefix):
+            upcoming.append(feature[len(upcoming_prefix):])
+        elif feature.startswith(experimental_prefix):
+            experimental.append(feature[len(experimental_prefix):])
+
+    return (upcoming, experimental)
+
 def _check_allowlists(
         *,
         allowlists,

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -35,6 +35,7 @@ load(
     "SWIFT_FEATURE_NO_EMBED_DEBUG_MODULE",
     "SWIFT_FEATURE_USE_AUTOLINK_EXTRACT",
     "SWIFT_FEATURE_USE_MODULE_WRAP",
+    "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
 )
 load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 
@@ -89,6 +90,16 @@ print("Hello")
         "-z",
         "-Xlinker",
         "nostart-stop-gc",
+    )
+
+def _check_supports_upcoming_features(repository_ctx, swiftc_path, _temp_dir):
+    """Returns True if `swiftc` supports the `-enable-{experimental,upcoming}-feature` flags."""
+    return _swift_succeeds(
+        repository_ctx,
+        swiftc_path,
+        "-version",
+        "-enable-upcoming-feature",
+        "BareRegexLiteralSyntax",
     )
 
 def _write_swift_version(repository_ctx, swiftc_path):
@@ -161,6 +172,9 @@ def _compute_feature_values(repository_ctx, swiftc_path):
 # should return True if the feature is supported.
 _FEATURE_CHECKS = {
     SWIFT_FEATURE_LLD_GC_WORKAROUND: _check_supports_lld_gc_workaround,
+    SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES: (
+        _check_supports_upcoming_features
+    ),
 }
 
 def _normalized_linux_cpu(cpu):

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -80,6 +80,7 @@ load(
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
+    "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
 load(":action_config.bzl", "ActionConfigInfo", "ConfigResultInfo", "add_arg")
@@ -1156,6 +1157,15 @@ def compile_action_configs(
                 SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING,
             ],
         ),
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+            ],
+            configurators = [_upcoming_and_experimental_features_configurator],
+            features = [
+                SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES,
+            ],
+        ),
     ]
 
     # NOTE: The positions of these action configs in the list are important,
@@ -2109,6 +2119,17 @@ def _constant_value_extraction_configurator(prerequisites, args):
     )
     return ConfigResultInfo(
         inputs = [prerequisites.const_gather_protocols_file],
+    )
+
+def _upcoming_and_experimental_features_configurator(prerequisites, args):
+    """Adds upcoming and experimental features to the command line."""
+    args.add_all(
+        prerequisites.upcoming_features,
+        before_each = "-enable-upcoming-feature",
+    )
+    args.add_all(
+        prerequisites.experimental_features,
+        before_each = "-enable-experimental-feature",
     )
 
 def _additional_inputs_configurator(prerequisites, _args):

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -54,6 +54,7 @@ load(
     "SWIFT_FEATURE_FILE_PREFIX_MAP",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
+    "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
 )
 load(
     "//swift/internal:features.bzl",
@@ -620,6 +621,9 @@ def _xcode_swift_toolchain_impl(ctx):
         ctx = ctx,
         target_triple = target_triple,
     ))
+
+    if _is_xcode_at_least_version(xcode_config, "14.3"):
+        requested_features.append(SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES)
 
     if _is_xcode_at_least_version(xcode_config, "15.3"):
         requested_features.append(SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX)


### PR DESCRIPTION
PiperOrigin-RevId: 598844646
(cherry picked from commit f17ec3b27a214ab4557aa83e4d6a10be6c9f8788)