### PR TITLE
Upgrade stardoc to 0.7.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -43,7 +43,7 @@ register_toolchains("@build_bazel_rules_swift_local_config//:all")
 # Dev dependencies
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you run into any problems with these rules, please
 Create a simple CLI that can run on macOS, Linux, or Windows:
 
 ```bzl
-load("@build_bazel_rules_swift//swift:swift_binary.bzl", "swift_binary")
+load("@rules_swift//swift:swift_binary.bzl", "swift_binary")
 
 swift_binary(
     name = "cli",
@@ -29,7 +29,7 @@ Create a single library target that can be used by other targets in your
 build:
 
 ```bzl
-load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
+load("@rules_swift//swift:swift_library.bzl", "swift_library")
 
 swift_library(
     name = "MyLibrary",
@@ -92,7 +92,7 @@ toolchain's Info.plist file.
 To list the available toolchains and their bundle identifiers, you can run:
 
 ```command
-bazel run @build_bazel_rules_swift//tools/dump_toolchains
+bazel run @rules_swift//tools/dump_toolchains
 ```
 
 **Linux hosts:** At this time, Bazel uses whichever `swift` executable is

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,10 +32,10 @@ http_archive(
 # so we declare it in the WORKSPACE
 http_archive(
     name = "io_bazel_stardoc",
-    sha256 = "62bd2e60216b7a6fec3ac79341aa201e0956477e7c8f6ccc286f279ad1d96432",
+    sha256 = "fabb280f6c92a3b55eed89a918ca91e39fb733373c81e87a18ae9e33e75023ec",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.6.2/stardoc-0.6.2.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.7.1/stardoc-0.7.1.tar.gz",
     ],
 )
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -9,6 +9,8 @@ compilation and/or linking as part of their implementation.
 ## swift_common.cc_feature_configuration
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.cc_feature_configuration(<a href="#swift_common.cc_feature_configuration-feature_configuration">feature_configuration</a>)
 </pre>
 
@@ -33,6 +35,8 @@ A C++ `FeatureConfiguration` value (see
 ## swift_common.compile
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-cc_infos">cc_infos</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-exec_group">exec_group</a>,
                      <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>, <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-is_test">is_test</a>,
                      <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-objc_infos">objc_infos</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>,
@@ -118,6 +122,8 @@ A `struct` with the following fields:
 ## swift_common.compile_module_interface
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
                                       <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
                                       <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>)
@@ -158,6 +164,8 @@ A Swift module context (as returned by `create_swift_module_context`)
 ## swift_common.configure_features
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.configure_features(<a href="#swift_common.configure_features-ctx">ctx</a>, <a href="#swift_common.configure_features-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.configure_features-requested_features">requested_features</a>, <a href="#swift_common.configure_features-unsupported_features">unsupported_features</a>)
 </pre>
 
@@ -192,6 +200,8 @@ An opaque value representing the feature configuration that can be
 ## swift_common.create_compilation_context
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.create_compilation_context(<a href="#swift_common.create_compilation_context-defines">defines</a>, <a href="#swift_common.create_compilation_context-srcs">srcs</a>, <a href="#swift_common.create_compilation_context-transitive_modules">transitive_modules</a>)
 </pre>
 
@@ -225,6 +235,8 @@ A `struct` containing four fields:
 ## swift_common.create_linking_context_from_compilation_outputs
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.create_linking_context_from_compilation_outputs(<a href="#swift_common.create_linking_context_from_compilation_outputs-actions">actions</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-additional_inputs">additional_inputs</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-alwayslink">alwayslink</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-compilation_outputs">compilation_outputs</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-feature_configuration">feature_configuration</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-is_test">is_test</a>,
@@ -274,6 +286,8 @@ A tuple of `(CcLinkingContext, CcLinkingOutputs)` containing the linking
 ## swift_common.extract_symbol_graph
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.extract_symbol_graph(<a href="#swift_common.extract_symbol_graph-actions">actions</a>, <a href="#swift_common.extract_symbol_graph-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.extract_symbol_graph-emit_extension_block_symbols">emit_extension_block_symbols</a>,
                                   <a href="#swift_common.extract_symbol_graph-feature_configuration">feature_configuration</a>, <a href="#swift_common.extract_symbol_graph-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.extract_symbol_graph-minimum_access_level">minimum_access_level</a>,
                                   <a href="#swift_common.extract_symbol_graph-module_name">module_name</a>, <a href="#swift_common.extract_symbol_graph-output_dir">output_dir</a>, <a href="#swift_common.extract_symbol_graph-swift_infos">swift_infos</a>, <a href="#swift_common.extract_symbol_graph-swift_toolchain">swift_toolchain</a>)
@@ -303,6 +317,8 @@ Extracts the symbol graph from a Swift module.
 ## swift_common.get_toolchain
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.get_toolchain(<a href="#swift_common.get_toolchain-ctx">ctx</a>, <a href="#swift_common.get_toolchain-exec_group">exec_group</a>, <a href="#swift_common.get_toolchain-mandatory">mandatory</a>, <a href="#swift_common.get_toolchain-attr">attr</a>)
 </pre>
 
@@ -329,6 +345,8 @@ A `SwiftToolchainInfo` provider, or `None` if the toolchain was not
 ## swift_common.is_enabled
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.is_enabled(<a href="#swift_common.is_enabled-feature_configuration">feature_configuration</a>, <a href="#swift_common.is_enabled-feature_name">feature_name</a>)
 </pre>
 
@@ -357,6 +375,8 @@ check it.
 ## swift_common.precompile_clang_module
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.precompile_clang_module(<a href="#swift_common.precompile_clang_module-actions">actions</a>, <a href="#swift_common.precompile_clang_module-cc_compilation_context">cc_compilation_context</a>, <a href="#swift_common.precompile_clang_module-exec_group">exec_group</a>,
                                      <a href="#swift_common.precompile_clang_module-feature_configuration">feature_configuration</a>, <a href="#swift_common.precompile_clang_module-module_map_file">module_map_file</a>, <a href="#swift_common.precompile_clang_module-module_name">module_name</a>,
                                      <a href="#swift_common.precompile_clang_module-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.precompile_clang_module-target_name">target_name</a>, <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>)
@@ -390,6 +410,8 @@ A struct containing the precompiled module and optional indexstore directory,
 ## swift_common.toolchain_attrs
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.toolchain_attrs(<a href="#swift_common.toolchain_attrs-toolchain_attr_name">toolchain_attr_name</a>)
 </pre>
 
@@ -436,6 +458,8 @@ A new attribute dictionary that can be added to the attributes of a
 ## swift_common.use_toolchain
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.use_toolchain(<a href="#swift_common.use_toolchain-mandatory">mandatory</a>)
 </pre>
 

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -17,7 +17,9 @@ On this page:
 ## SwiftInfo
 
 <pre>
-SwiftInfo(<a href="#SwiftInfo-direct_modules">direct_modules</a>, <a href="#SwiftInfo-transitive_modules">transitive_modules</a>)
+load("@rules_swift//doc:doc.bzl", "SwiftInfo")
+
+SwiftInfo(<a href="#SwiftInfo-_init-direct_swift_infos">direct_swift_infos</a>, <a href="#SwiftInfo-_init-modules">modules</a>, <a href="#SwiftInfo-_init-swift_infos">swift_infos</a>)
 </pre>
 
 Contains information about the compiled artifacts of a Swift module.
@@ -48,8 +50,15 @@ where the arguments are:
 When reading an existing `SwiftInfo` provider, it has the two fields described
 below.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="SwiftInfo-_init-direct_swift_infos"></a>direct_swift_infos | <p align="center">-</p> | `[]` |
+| <a id="SwiftInfo-_init-modules"></a>modules | <p align="center">-</p> | `[]` |
+| <a id="SwiftInfo-_init-swift_infos"></a>swift_infos | <p align="center">-</p> | `[]` |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -62,13 +71,14 @@ below.
 ## SwiftProtoCompilerInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftProtoCompilerInfo")
+
 SwiftProtoCompilerInfo(<a href="#SwiftProtoCompilerInfo-bundled_proto_paths">bundled_proto_paths</a>, <a href="#SwiftProtoCompilerInfo-compile">compile</a>, <a href="#SwiftProtoCompilerInfo-compiler_deps">compiler_deps</a>, <a href="#SwiftProtoCompilerInfo-internal">internal</a>)
 </pre>
 
 Provides information needed to generate Swift code from `ProtoInfo` providers
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -83,13 +93,14 @@ Provides information needed to generate Swift code from `ProtoInfo` providers
 ## SwiftProtoInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftProtoInfo")
+
 SwiftProtoInfo(<a href="#SwiftProtoInfo-module_name">module_name</a>, <a href="#SwiftProtoInfo-module_mappings">module_mappings</a>, <a href="#SwiftProtoInfo-direct_pbswift_files">direct_pbswift_files</a>, <a href="#SwiftProtoInfo-pbswift_files">pbswift_files</a>)
 </pre>
 
 Propagates Swift-specific information about a `proto_library`.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -104,6 +115,8 @@ Propagates Swift-specific information about a `proto_library`.
 ## SwiftToolchainInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftToolchainInfo")
+
 SwiftToolchainInfo(<a href="#SwiftToolchainInfo-action_configs">action_configs</a>, <a href="#SwiftToolchainInfo-cc_language">cc_language</a>, <a href="#SwiftToolchainInfo-cc_toolchain_info">cc_toolchain_info</a>, <a href="#SwiftToolchainInfo-clang_implicit_deps_providers">clang_implicit_deps_providers</a>,
                    <a href="#SwiftToolchainInfo-const_protocols_to_gather">const_protocols_to_gather</a>, <a href="#SwiftToolchainInfo-cross_import_overlays">cross_import_overlays</a>, <a href="#SwiftToolchainInfo-debug_outputs_provider">debug_outputs_provider</a>,
                    <a href="#SwiftToolchainInfo-developer_dirs">developer_dirs</a>, <a href="#SwiftToolchainInfo-entry_point_linkopts_provider">entry_point_linkopts_provider</a>, <a href="#SwiftToolchainInfo-feature_allowlists">feature_allowlists</a>,
@@ -116,7 +129,6 @@ Propagates information about a Swift toolchain to compilation and linking rules
 that use the toolchain.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -40,6 +40,8 @@ On this page:
 ## swift_binary
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_binary")
+
 swift_binary(<a href="#swift_binary-name">name</a>, <a href="#swift_binary-deps">deps</a>, <a href="#swift_binary-srcs">srcs</a>, <a href="#swift_binary-data">data</a>, <a href="#swift_binary-copts">copts</a>, <a href="#swift_binary-defines">defines</a>, <a href="#swift_binary-linkopts">linkopts</a>, <a href="#swift_binary-malloc">malloc</a>, <a href="#swift_binary-module_name">module_name</a>, <a href="#swift_binary-package_name">package_name</a>,
              <a href="#swift_binary-plugins">plugins</a>, <a href="#swift_binary-stamp">stamp</a>, <a href="#swift_binary-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -83,6 +85,8 @@ please use one of the platform-specific application rules in
 ## swift_compiler_plugin
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_compiler_plugin")
+
 swift_compiler_plugin(<a href="#swift_compiler_plugin-name">name</a>, <a href="#swift_compiler_plugin-deps">deps</a>, <a href="#swift_compiler_plugin-srcs">srcs</a>, <a href="#swift_compiler_plugin-data">data</a>, <a href="#swift_compiler_plugin-copts">copts</a>, <a href="#swift_compiler_plugin-defines">defines</a>, <a href="#swift_compiler_plugin-linkopts">linkopts</a>, <a href="#swift_compiler_plugin-malloc">malloc</a>, <a href="#swift_compiler_plugin-module_name">module_name</a>,
                       <a href="#swift_compiler_plugin-package_name">package_name</a>, <a href="#swift_compiler_plugin-plugins">plugins</a>, <a href="#swift_compiler_plugin-stamp">stamp</a>, <a href="#swift_compiler_plugin-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -171,6 +175,8 @@ swift_library(
 ## swift_cross_import_overlay
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_cross_import_overlay")
+
 swift_cross_import_overlay(<a href="#swift_cross_import_overlay-name">name</a>, <a href="#swift_cross_import_overlay-deps">deps</a>, <a href="#swift_cross_import_overlay-bystanding_module">bystanding_module</a>, <a href="#swift_cross_import_overlay-declaring_module">declaring_module</a>)
 </pre>
 
@@ -212,6 +218,8 @@ the future, this rule is not recommended for other widespread use.
 ## swift_feature_allowlist
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_feature_allowlist")
+
 swift_feature_allowlist(<a href="#swift_feature_allowlist-name">name</a>, <a href="#swift_feature_allowlist-aspect_ids">aspect_ids</a>, <a href="#swift_feature_allowlist-managed_features">managed_features</a>, <a href="#swift_feature_allowlist-packages">packages</a>)
 </pre>
 
@@ -243,6 +251,8 @@ package.
 ## swift_import
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_import")
+
 swift_import(<a href="#swift_import-name">name</a>, <a href="#swift_import-deps">deps</a>, <a href="#swift_import-data">data</a>, <a href="#swift_import-archives">archives</a>, <a href="#swift_import-module_name">module_name</a>, <a href="#swift_import-swiftdoc">swiftdoc</a>, <a href="#swift_import-swiftinterface">swiftinterface</a>, <a href="#swift_import-swiftmodule">swiftmodule</a>)
 </pre>
 
@@ -281,6 +291,8 @@ the `.private.swiftinterface` files are required in order to build any code that
 ## swift_interop_hint
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_interop_hint")
+
 swift_interop_hint(<a href="#swift_interop_hint-name">name</a>, <a href="#swift_interop_hint-exclude_hdrs">exclude_hdrs</a>, <a href="#swift_interop_hint-module_map">module_map</a>, <a href="#swift_interop_hint-module_name">module_name</a>, <a href="#swift_interop_hint-suppressed">suppressed</a>)
 </pre>
 
@@ -423,6 +435,8 @@ its transitive dependencies be propagated.
 ## swift_library
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_library")
+
 swift_library(<a href="#swift_library-name">name</a>, <a href="#swift_library-deps">deps</a>, <a href="#swift_library-srcs">srcs</a>, <a href="#swift_library-data">data</a>, <a href="#swift_library-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#swift_library-alwayslink">alwayslink</a>, <a href="#swift_library-copts">copts</a>,
               <a href="#swift_library-defines">defines</a>, <a href="#swift_library-generated_header_name">generated_header_name</a>, <a href="#swift_library-generates_header">generates_header</a>, <a href="#swift_library-library_evolution">library_evolution</a>, <a href="#swift_library-linkopts">linkopts</a>,
               <a href="#swift_library-linkstatic">linkstatic</a>, <a href="#swift_library-module_name">module_name</a>, <a href="#swift_library-package_name">package_name</a>, <a href="#swift_library-plugins">plugins</a>, <a href="#swift_library-private_deps">private_deps</a>, <a href="#swift_library-swiftc_inputs">swiftc_inputs</a>)
@@ -460,6 +474,8 @@ Compiles and links Swift code into a static library and Swift module.
 ## swift_library_group
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_library_group")
+
 swift_library_group(<a href="#swift_library_group-name">name</a>, <a href="#swift_library_group-deps">deps</a>)
 </pre>
 
@@ -484,6 +500,8 @@ need to import the grouped libraries directly.
 ## swift_module_alias
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_module_alias")
+
 swift_module_alias(<a href="#swift_module_alias-name">name</a>, <a href="#swift_module_alias-deps">deps</a>, <a href="#swift_module_alias-module_name">module_name</a>)
 </pre>
 
@@ -520,6 +538,8 @@ symbol is defined; it is not repeated by the alias module.)
 ## swift_module_mapping
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_module_mapping")
+
 swift_module_mapping(<a href="#swift_module_mapping-name">name</a>, <a href="#swift_module_mapping-aliases">aliases</a>)
 </pre>
 
@@ -585,6 +605,8 @@ source asked to `import Utils`.
 ## swift_module_mapping_test
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_module_mapping_test")
+
 swift_module_mapping_test(<a href="#swift_module_mapping_test-name">name</a>, <a href="#swift_module_mapping_test-deps">deps</a>, <a href="#swift_module_mapping_test-exclude">exclude</a>, <a href="#swift_module_mapping_test-mapping">mapping</a>)
 </pre>
 
@@ -619,6 +641,8 @@ remaining modules collected are not present in the `aliases` of the
 ## swift_package_configuration
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_package_configuration")
+
 swift_package_configuration(<a href="#swift_package_configuration-name">name</a>, <a href="#swift_package_configuration-configured_features">configured_features</a>, <a href="#swift_package_configuration-packages">packages</a>)
 </pre>
 
@@ -644,6 +668,8 @@ target's label is included by the package specifications in the configuration.
 ## swift_proto_compiler
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_compiler")
+
 swift_proto_compiler(<a href="#swift_proto_compiler-name">name</a>, <a href="#swift_proto_compiler-deps">deps</a>, <a href="#swift_proto_compiler-bundled_proto_paths">bundled_proto_paths</a>, <a href="#swift_proto_compiler-plugin">plugin</a>, <a href="#swift_proto_compiler-plugin_name">plugin_name</a>, <a href="#swift_proto_compiler-plugin_option_allowlist">plugin_option_allowlist</a>,
                      <a href="#swift_proto_compiler-plugin_options">plugin_options</a>, <a href="#swift_proto_compiler-protoc">protoc</a>, <a href="#swift_proto_compiler-suffixes">suffixes</a>)
 </pre>
@@ -671,6 +697,8 @@ swift_proto_compiler(<a href="#swift_proto_compiler-name">name</a>, <a href="#sw
 ## swift_proto_library
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_library")
+
 swift_proto_library(<a href="#swift_proto_library-name">name</a>, <a href="#swift_proto_library-deps">deps</a>, <a href="#swift_proto_library-srcs">srcs</a>, <a href="#swift_proto_library-data">data</a>, <a href="#swift_proto_library-additional_compiler_deps">additional_compiler_deps</a>, <a href="#swift_proto_library-additional_compiler_info">additional_compiler_info</a>,
                     <a href="#swift_proto_library-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#swift_proto_library-alwayslink">alwayslink</a>, <a href="#swift_proto_library-compilers">compilers</a>, <a href="#swift_proto_library-copts">copts</a>, <a href="#swift_proto_library-defines">defines</a>,
                     <a href="#swift_proto_library-generated_header_name">generated_header_name</a>, <a href="#swift_proto_library-generates_header">generates_header</a>, <a href="#swift_proto_library-library_evolution">library_evolution</a>, <a href="#swift_proto_library-linkopts">linkopts</a>, <a href="#swift_proto_library-linkstatic">linkstatic</a>,
@@ -747,6 +775,8 @@ swift_proto_library(
 ## swift_proto_library_group
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_library_group")
+
 swift_proto_library_group(<a href="#swift_proto_library_group-name">name</a>, <a href="#swift_proto_library_group-compiler">compiler</a>, <a href="#swift_proto_library_group-proto">proto</a>)
 </pre>
 
@@ -825,6 +855,8 @@ swift_binary(
 ## swift_test
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_test")
+
 swift_test(<a href="#swift_test-name">name</a>, <a href="#swift_test-deps">deps</a>, <a href="#swift_test-srcs">srcs</a>, <a href="#swift_test-data">data</a>, <a href="#swift_test-copts">copts</a>, <a href="#swift_test-defines">defines</a>, <a href="#swift_test-discover_tests">discover_tests</a>, <a href="#swift_test-env">env</a>, <a href="#swift_test-linkopts">linkopts</a>, <a href="#swift_test-malloc">malloc</a>,
            <a href="#swift_test-module_name">module_name</a>, <a href="#swift_test-package_name">package_name</a>, <a href="#swift_test-plugins">plugins</a>, <a href="#swift_test-stamp">stamp</a>, <a href="#swift_test-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -913,6 +945,8 @@ bazel test --test_filter=AModule,BModule.SomeTests,BModule.OtherTests/testX //my
 ## universal_swift_compiler_plugin
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "universal_swift_compiler_plugin")
+
 universal_swift_compiler_plugin(<a href="#universal_swift_compiler_plugin-name">name</a>, <a href="#universal_swift_compiler_plugin-plugin">plugin</a>)
 </pre>
 
@@ -964,6 +998,8 @@ swift_library(
 ## mixed_language_library
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "mixed_language_library")
+
 mixed_language_library(<a href="#mixed_language_library-name">name</a>, <a href="#mixed_language_library-alwayslink">alwayslink</a>, <a href="#mixed_language_library-clang_copts">clang_copts</a>, <a href="#mixed_language_library-clang_defines">clang_defines</a>, <a href="#mixed_language_library-clang_srcs">clang_srcs</a>, <a href="#mixed_language_library-enable_modules">enable_modules</a>,
                        <a href="#mixed_language_library-hdrs">hdrs</a>, <a href="#mixed_language_library-includes">includes</a>, <a href="#mixed_language_library-linkopts">linkopts</a>, <a href="#mixed_language_library-module_map">module_map</a>, <a href="#mixed_language_library-module_name">module_name</a>, <a href="#mixed_language_library-non_arc_srcs">non_arc_srcs</a>, <a href="#mixed_language_library-private_deps">private_deps</a>,
                        <a href="#mixed_language_library-sdk_dylibs">sdk_dylibs</a>, <a href="#mixed_language_library-sdk_frameworks">sdk_frameworks</a>, <a href="#mixed_language_library-swift_copts">swift_copts</a>, <a href="#mixed_language_library-swift_defines">swift_defines</a>, <a href="#mixed_language_library-swift_srcs">swift_srcs</a>,

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -5,6 +5,8 @@
 ## swift_rules_dependencies
 
 <pre>
+load("@rules_swift//swift:repositories.bzl", "swift_rules_dependencies")
+
 swift_rules_dependencies(<a href="#swift_rules_dependencies-include_bzlmod_ready_dependencies">include_bzlmod_ready_dependencies</a>)
 </pre>
 

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -23,7 +23,7 @@ meant for build rule use only.
 """
 
 load(
-    "@build_bazel_rules_swift//swift:swift_compiler_plugin.bzl",
+    "//swift:swift_compiler_plugin.bzl",
     _swift_compiler_plugin = "swift_compiler_plugin",
     _universal_swift_compiler_plugin = "universal_swift_compiler_plugin",
 )


### PR DESCRIPTION
Needed to support Bazel HEAD.

This changes the generated docs to include load statements with `@rules_swift`. As part of rules_swift 3.0 we can change all references to the new form as well.