### PR TITLE
Enable `AccessLevelOnImport` by default

### DIFF
--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -460,6 +460,14 @@ def _swift_toolchain_impl(ctx):
         target_triple = target_triple,
     ))
 
+    requested_features.extend([
+        # Allow users to start using access levels on `import`s by default. Note
+        # that this does *not* change the default access level for `import`s to
+        # `internal`; that is controlled by the upcoming feature flag
+        # `InternalImportsByDefault`.
+        "swift.experimental.AccessLevelOnImport",
+    ])
+
     requested_features.extend(ctx.features)
 
     # Swift.org toolchains assume everything is just available on the PATH so we

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -622,6 +622,14 @@ def _xcode_swift_toolchain_impl(ctx):
         target_triple = target_triple,
     ))
 
+    requested_features.extend([
+        # Allow users to start using access levels on `import`s by default. Note
+        # that this does *not* change the default access level for `import`s to
+        # `internal`; that is controlled by the upcoming feature flag
+        # `InternalImportsByDefault`.
+        "swift.experimental.AccessLevelOnImport",
+    ])
+
     if _is_xcode_at_least_version(xcode_config, "14.3"):
         requested_features.append(SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES)
 

--- a/test/fixtures/module_interface/Client.swift
+++ b/test/fixtures/module_interface/Client.swift
@@ -18,7 +18,7 @@ import ToyModule
 struct Main {
   static func main() {
     let value = ToyValue(number: 10)
-    print(value.hexString)
+    print(value.stringValue)
     print(value.squared())
   }
 }

--- a/test/fixtures/module_interface/library/ToyModule.swift
+++ b/test/fixtures/module_interface/library/ToyModule.swift
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Foundation
-
 /// A toy value.
 @frozen
 public struct ToyValue {
@@ -21,8 +19,8 @@ public struct ToyValue {
   public var number: Int
 
   /// The hexadecimal value of the numeric value.
-  public var hexString: String {
-    String(format: "0x%x", number)
+  public var stringValue: String {
+    "\(number)"
   }
 
   /// Creates a new toy value with the given numeric value.


### PR DESCRIPTION
This feature also makes it an error for `.swiftinterface` files to publicly import non-resilient modules, so I've updated our `.swiftinterface` test case to stop depending on Foundation, which is not resilient on Linux.

PiperOrigin-RevId: 640123191
(cherry picked from commit b5230b0052adef0f802fafdec8dc618fa5cc6518)