### PR TITLE
Allow `swift_cross_import_overlay` to specify a disambiguating explicit module name for the declaring and/or bystanding module

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -193,7 +193,8 @@ using `swift_compiler_plugin`.
 ## swift_cross_import_overlay
 
 <pre>
-swift_cross_import_overlay(<a href="#swift_cross_import_overlay-name">name</a>, <a href="#swift_cross_import_overlay-deps">deps</a>, <a href="#swift_cross_import_overlay-bystanding_module">bystanding_module</a>, <a href="#swift_cross_import_overlay-declaring_module">declaring_module</a>)
+swift_cross_import_overlay(<a href="#swift_cross_import_overlay-name">name</a>, <a href="#swift_cross_import_overlay-deps">deps</a>, <a href="#swift_cross_import_overlay-bystanding_module">bystanding_module</a>, <a href="#swift_cross_import_overlay-bystanding_module_name">bystanding_module_name</a>, <a href="#swift_cross_import_overlay-declaring_module">declaring_module</a>,
+                           <a href="#swift_cross_import_overlay-declaring_module_name">declaring_module_name</a>)
 </pre>
 
 Declares a cross-import overlay that will be automatically added as a dependency
@@ -226,7 +227,9 @@ the future, this rule is not recommended for other widespread use.
 | <a id="swift_cross_import_overlay-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="swift_cross_import_overlay-deps"></a>deps |  A non-empty list of targets representing modules that should be passed as dependencies when a target depends on both `declaring_module` and `bystanding_module`.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
 | <a id="swift_cross_import_overlay-bystanding_module"></a>bystanding_module |  A label for the target representing the second of the two modules (the other being `declaring_module`) that must be imported for the cross-import overlay modules to be imported. It is completely passive in the cross-import process, having no definition with or other association to either the declaring module or the cross-import modules.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="swift_cross_import_overlay-bystanding_module_name"></a>bystanding_module_name |  The name of the bystanding module from the target specified by the `bystanding_module` attribute. This is inferred if `bystanding_module` only exports a single direct module; this name must be specified if `bystanding_module` exports more than one.   | String | optional |  `""`  |
 | <a id="swift_cross_import_overlay-declaring_module"></a>declaring_module |  A label for the target representing the first of the two modules (the other being `bystanding_module`) that must be imported for the cross-import overlay modules to be imported. This is the module that contains the `.swiftcrossimport` overlay definition that connects it to the bystander and to the overlay modules.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="swift_cross_import_overlay-declaring_module_name"></a>declaring_module_name |  The name of the declaring module from the target specified by the `declaring_module` attribute. This is inferred if `declaring_module` only exports a single direct module; this name must be specified if `declaring_module` exports more than one.   | String | optional |  `""`  |
 
 
 <a id="swift_feature_allowlist"></a>

--- a/swift/swift_cross_import_overlay.bzl
+++ b/swift/swift_cross_import_overlay.bzl
@@ -19,16 +19,17 @@ load(":providers.bzl", "SwiftInfo")
 
 def _get_sole_module_name(swift_info, attr):
     if len(swift_info.direct_modules) != 1:
-        fail(("The target specified by '{}' must define exactly one Swift " +
-              "and/or Clang module.").format(attr))
+        fail(("The target specified by '{attr}' must define exactly one Swift " +
+              "and/or Clang module, or you must specify '{attr}_name' to" +
+              "disambiguate them.").format(attr = attr))
     return swift_info.direct_modules[0].name
 
 def _swift_cross_import_overlay_impl(ctx):
-    bystanding_module = _get_sole_module_name(
+    bystanding_module = ctx.attr.bystanding_module_name or _get_sole_module_name(
         ctx.attr.bystanding_module[SwiftInfo],
         "bystanding_module",
     )
-    declaring_module = _get_sole_module_name(
+    declaring_module = ctx.attr.declaring_module_name or _get_sole_module_name(
         ctx.attr.declaring_module[SwiftInfo],
         "declaring_module",
     )
@@ -53,6 +54,15 @@ the cross-import modules.
             mandatory = True,
             providers = [[SwiftInfo]],
         ),
+        "bystanding_module_name": attr.string(
+            doc = """\
+The name of the bystanding module from the target specified by the
+`bystanding_module` attribute. This is inferred if `bystanding_module` only
+exports a single direct module; this name must be specified if
+`bystanding_module` exports more than one.
+""",
+            mandatory = False,
+        ),
         "declaring_module": attr.label(
             doc = """\
 A label for the target representing the first of the two modules (the other
@@ -62,6 +72,15 @@ overlay definition that connects it to the bystander and to the overlay modules.
 """,
             mandatory = True,
             providers = [[SwiftInfo]],
+        ),
+        "declaring_module_name": attr.string(
+            doc = """\
+The name of the declaring module from the target specified by the
+`declaring_module` attribute. This is inferred if `declaring_module` only
+exports a single direct module; this name must be specified if
+`declaring_module` exports more than one.
+""",
+            mandatory = False,
         ),
         "deps": attr.label_list(
             allow_empty = False,


### PR DESCRIPTION
This can be used if either of those targets exports multiple modules.

PiperOrigin-RevId: 665873940
(cherry picked from commit 8563c97fde773118244ebd987ce44637a4a884ac)