### PR TITLE
Stop running macro tests on BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -24,6 +24,7 @@ tasks:
     - "--action_env=PATH"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
+    - "-@rules_swift//examples/xplatform/macros/..." # Has a dev dependency
     - "-@rules_swift//examples/xplatform/grpc/..." # TODO: Fix grpc on Linux
     - "-@rules_swift//examples/xplatform/proto_library_group/..." # TODO: Fix grpc on Linux
   verify_targets_macos:


### PR DESCRIPTION
We can’t depend on dev dependences in these tests.