### PR TITLE
Fix `build_file` labels

### DIFF
--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -79,7 +79,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
             ],
             sha256 = "69cc88207ce91347ea530b227ff0776db82dcb8de6704e1a3d74f4841bc651cf",
             type = "zip",
-            build_file = "//third_party:com_github_nlohmann_json/BUILD.overlay",
+            build_file = Label(
+                "//third_party:com_github_nlohmann_json/BUILD.overlay",
+            ),
         )
 
         _maybe(
@@ -96,7 +98,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
             urls = ["https://github.com/apple/swift-argument-parser/archive/refs/tags/1.3.0.tar.gz"],
             sha256 = "e5010ff37b542807346927ba68b7f06365a53cf49d36a6df13cef50d86018204",
             strip_prefix = "swift-argument-parser-1.3.0",
-            build_file = "//third_party:com_github_apple_swift_argument_parser/BUILD.overlay",
+            build_file = Label(
+                "//third_party:com_github_apple_swift_argument_parser/BUILD.overlay",
+            ),
         )
 
     _maybe(
@@ -105,7 +109,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-protobuf/archive/1.20.2.tar.gz"],  # pinned to grpc-swift version
         sha256 = "3fb50bd4d293337f202d917b6ada22f9548a0a0aed9d9a4d791e6fbd8a246ebb",
         strip_prefix = "swift-protobuf-1.20.2/",
-        build_file = "//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_protobuf/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -114,7 +120,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/grpc/grpc-swift/archive/1.16.0.tar.gz"],  # latest at time of writing
         sha256 = "58b60431d0064969f9679411264b82e40a217ae6bd34e17096d92cc4e47556a5",
         strip_prefix = "grpc-swift-1.16.0/",
-        build_file = "//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_grpc_grpc_swift/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -123,7 +131,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-docc-symbolkit/archive/refs/tags/swift-5.10-RELEASE.tar.gz"],
         sha256 = "de1d4b6940468ddb53b89df7aa1a81323b9712775b0e33e8254fa0f6f7469a97",
         strip_prefix = "swift-docc-symbolkit-swift-5.10-RELEASE",
-        build_file = "//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_docc_symbolkit/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -132,7 +142,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-nio/archive/2.42.0.tar.gz"],  # pinned to grpc swift version
         sha256 = "e3304bc3fb53aea74a3e54bd005ede11f6dc357117d9b1db642d03aea87194a0",
         strip_prefix = "swift-nio-2.42.0/",
-        build_file = "//third_party:com_github_apple_swift_nio/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_nio/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -141,7 +153,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-nio-http2/archive/1.26.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "f0edfc9d6a7be1d587e5b403f2d04264bdfae59aac1d74f7d974a9022c6d2b25",
         strip_prefix = "swift-nio-http2-1.26.0/",
-        build_file = "//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_nio_http2/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -150,7 +164,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-nio-transport-services/archive/1.15.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "f3498dafa633751a52b9b7f741f7ac30c42bcbeb3b9edca6d447e0da8e693262",
         strip_prefix = "swift-nio-transport-services-1.15.0/",
-        build_file = "//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_nio_transport_services/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -159,7 +175,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-nio-extras/archive/1.4.0.tar.gz"],  # pinned to grpc-swift version
         sha256 = "4684b52951d9d9937bb3e8ccd6b5daedd777021ef2519ea2f18c4c922843b52b",
         strip_prefix = "swift-nio-extras-1.4.0/",
-        build_file = "//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_nio_extras/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -168,7 +186,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-log/archive/1.4.4.tar.gz"],  # pinned to grpc-swift version
         sha256 = "48fe66426c784c0c20031f15dc17faf9f4c9037c192bfac2f643f65cb2321ba0",
         strip_prefix = "swift-log-1.4.4/",
-        build_file = "//third_party:com_github_apple_swift_log/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_log/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -177,7 +197,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-nio-ssl/archive/2.23.0.tar.gz"],  # pinned to grpc swift version
         sha256 = "4787c63f61dd04d99e498adc3d1a628193387e41efddf8de19b8db04544d016d",
         strip_prefix = "swift-nio-ssl-2.23.0/",
-        build_file = "//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_nio_ssl/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -186,7 +208,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-collections/archive/1.0.4.tar.gz"],  # pinned to swift-nio @ grpc-swift version
         sha256 = "d9e4c8a91c60fb9c92a04caccbb10ded42f4cb47b26a212bc6b39cc390a4b096",
         strip_prefix = "swift-collections-1.0.4/",
-        build_file = "//third_party:com_github_apple_swift_collections/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_collections/BUILD.overlay",
+        ),
     )
 
     _maybe(
@@ -195,7 +219,9 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         urls = ["https://github.com/apple/swift-atomics/archive/1.1.0.tar.gz"],  # pinned to swift-nio @ grpc-swift version
         sha256 = "1bee7f469f7e8dc49f11cfa4da07182fbc79eab000ec2c17bfdce468c5d276fb",
         strip_prefix = "swift-atomics-1.1.0/",
-        build_file = "//third_party:com_github_apple_swift_atomics/BUILD.overlay",
+        build_file = Label(
+            "//third_party:com_github_apple_swift_atomics/BUILD.overlay",
+        ),
     )
 
     # It relies on `index-import` to import indexes into Bazel's remote
@@ -204,7 +230,7 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
     _maybe(
         http_archive,
         name = "build_bazel_rules_swift_index_import",
-        build_file = "//third_party:build_bazel_rules_swift_index_import/BUILD.overlay",
+        build_file = Label("//third_party:build_bazel_rules_swift_index_import/BUILD.overlay"),
         canonical_id = "index-import-5.8",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"],
         sha256 = "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",


### PR DESCRIPTION
Regressed for WORKSPACE users in 7fafc9bc47e80ca9fb08affeb44d135818c8c8db.

(cherry picked from commit e831c3a7f80f097bafdd830a57e1a08b9442b675)