### PR TITLE
Remove the `swift.no_generated_module_map` feature

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -145,7 +145,6 @@ bzl_library(
     deps = [
         ":feature_names",
         ":package_specs",
-        ":target_triples",
         "@bazel_skylib//lib:collections",
         "@bazel_skylib//lib:new_sets",
         "@bazel_skylib//rules:common_settings",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -46,7 +46,6 @@ load(
     "SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_MODULAR_INDEXING",
-    "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_PROPAGATE_GENERATED_MODULE_MAP",
@@ -692,10 +691,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
 
     # If a header and module map were generated for this Swift module, attempt
     # to precompile the explicit module for that header as well.
-    if generated_header_name and not is_feature_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
-    ):
+    if generated_header_name:
         compilation_context_to_compile = (
             compilation_context_for_explicit_module_compilation(
                 compilation_contexts = [
@@ -1234,10 +1230,7 @@ def _declare_compile_outputs(
     # trap door lets them escape the module redefinition error, with the
     # caveat that certain import scenarios could lead to incorrect behavior
     # because a header can be imported textually instead of modularly.
-    if generated_header and not is_feature_enabled(
-        feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
-    ):
+    if generated_header:
         # Collect the names of Clang modules that the module being built
         # directly depends on.
         dependent_module_names = sets.make()

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -148,11 +148,6 @@ SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS = (
 # link to any version of the ASAN runtime library.
 SWIFT_FEATURE_NO_ASAN_VERSION_CHECK = "swift.no_asan_version_check"
 
-# If enabled, the compilation action for a library target will not generate a
-# module map for the Objective-C generated header. This feature is ignored if
-# the target is not generating a header.
-SWIFT_FEATURE_NO_GENERATED_MODULE_MAP = "swift.no_generated_module_map"
-
 # If enabled, the parent directory of the generated module map is added to
 # `CcInfo.compilation_context.includes`. This allows `objc_library` to import
 # the Swift module. If you swap this feature between enabled and disabled, and

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -33,7 +33,6 @@ load(
     "SWIFT_FEATURE_FILE_PREFIX_MAP",
     "SWIFT_FEATURE_FULL_DEBUG_INFO",
     "SWIFT_FEATURE_INTERNALIZE_AT_LINK",
-    "SWIFT_FEATURE_NO_GENERATED_MODULE_MAP",
     "SWIFT_FEATURE_OBJC_LINK_FLAGS",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
@@ -41,7 +40,6 @@ load(
     "SWIFT_FEATURE__SUPPORTS_V6",
 )
 load(":package_specs.bzl", "label_matches_package_specs")
-load(":target_triples.bzl", "target_triples")
 
 def are_all_features_enabled(feature_configuration, feature_names):
     """Returns `True` if all features are enabled in the feature configuration.
@@ -265,12 +263,6 @@ def default_features_for_toolchain(target_triple):
         features.extend([
             SWIFT_FEATURE_OBJC_LINK_FLAGS,
             SWIFT_FEATURE_REMAP_XCODE_PATH,
-        ])
-
-    # Linux specific features
-    if target_triples.unversioned_os(target_triple) == "linux":
-        features.extend([
-            SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
         ])
 
     return features


### PR DESCRIPTION
Nobody is using it anymore; furthermore, it's dangerous now that we use explicit modules by default.

PiperOrigin-RevId: 681454702
(cherry picked from commit bcf0703b72b8fc51aad2b3d204b0562cbd14155b)