### PR TITLE
Don't drop compilation contexts for `private_deps` when compiling the target that imports them

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -138,8 +138,9 @@ A C++ `FeatureConfiguration` value (see
 <pre>
 swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-cc_infos">cc_infos</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-exec_group">exec_group</a>,
                      <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>, <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-is_test">is_test</a>,
-                     <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_swift_infos">private_swift_infos</a>,
-                     <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_infos">swift_infos</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile-target_name">target_name</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>)
+                     <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_cc_infos">private_cc_infos</a>,
+                     <a href="#swift_common.compile-private_swift_infos">private_swift_infos</a>, <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_infos">swift_infos</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile-target_name">target_name</a>,
+                     <a href="#swift_common.compile-workspace_name">workspace_name</a>)
 </pre>
 
 Compiles a Swift module.
@@ -163,6 +164,7 @@ Compiles a Swift module.
 | <a id="swift_common.compile-module_name"></a>module_name |  The name of the Swift module being compiled. This must be present and valid; use `derive_swift_module_name` to generate a default from the target's label if needed.   |  none |
 | <a id="swift_common.compile-package_name"></a>package_name |  The semantic package of the name of the Swift module being compiled.   |  none |
 | <a id="swift_common.compile-plugins"></a>plugins |  A list of `SwiftCompilerPluginInfo` providers that represent plugins that should be loaded by the compiler.   |  `[]` |
+| <a id="swift_common.compile-private_cc_infos"></a>private_cc_infos |  A list of `CcInfos`s that represent private (non-propagated) C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from a target's `private_deps`.   |  `[]` |
 | <a id="swift_common.compile-private_swift_infos"></a>private_swift_infos |  A list of `SwiftInfo` providers from private (implementation-only) dependencies of the target being compiled. The modules defined by these providers are used as dependencies of the Swift module being compiled but not of the Clang module for the generated header.   |  `[]` |
 | <a id="swift_common.compile-srcs"></a>srcs |  The Swift source files to compile.   |  none |
 | <a id="swift_common.compile-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from non-private dependencies of the target being compiled. The modules defined by these providers are used as dependencies of both the Swift module being compiled and the Clang module for the generated header.   |  none |

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -314,6 +314,7 @@ def compile(
         module_name,
         package_name,
         plugins = [],
+        private_cc_infos = [],
         private_swift_infos = [],
         srcs,
         swift_infos,
@@ -359,6 +360,11 @@ def compile(
             being compiled.
         plugins: A list of `SwiftCompilerPluginInfo` providers that represent
             plugins that should be loaded by the compiler.
+        private_cc_infos: A list of `CcInfos`s that represent private
+            (non-propagated) C/Objective-C requirements of the target being
+            compiled, such as Swift-compatible preprocessor defines, header
+            search paths, and so forth. These are typically retrieved from a
+            target's `private_deps`.
         private_swift_infos: A list of `SwiftInfo` providers from private
             (implementation-only) dependencies of the target being compiled. The
             modules defined by these providers are used as dependencies of the
@@ -533,7 +539,8 @@ def compile(
         for cc_info in cc_infos
     ]
     merged_cc_info = cc_common.merge_cc_infos(
-        cc_infos = cc_infos + swift_toolchain.implicit_deps_providers.cc_infos,
+        cc_infos = cc_infos + private_cc_infos +
+                   swift_toolchain.implicit_deps_providers.cc_infos,
     )
 
     transitive_swiftmodules = []

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -535,6 +535,7 @@ def _compile_swift_overlay(
         module_name = module_name,
         package_name = None,
         plugins = overlay_info.plugins,
+        private_cc_infos = overlay_info.private_deps.cc_infos,
         srcs = overlay_info.srcs,
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -186,6 +186,7 @@ def _swift_library_impl(ctx):
         module_name = module_name,
         package_name = ctx.attr.package_name,
         plugins = get_providers(ctx.attr.plugins, SwiftCompilerPluginInfo),
+        private_cc_infos = get_providers(ctx.attr.private_deps, CcInfo),
         private_swift_infos = private_swift_infos,
         srcs = srcs,
         swift_infos = swift_infos,


### PR DESCRIPTION
This was rarely caught in practice because it only affects implicit module compilation and only matters when a dependency has includes that depend on custom header search paths provided by one of their C dependencies.

PiperOrigin-RevId: 642596524
(cherry picked from commit 8600c56a7991b9779b0e0761c8be037455a317b4)