### PR TITLE
Put the `swift_overlay`'s deps `SwiftInfo`s into the *transitive* `SwiftInfo`s of the propagated `SwiftInfo` instead of the direct `SwiftInfo`s (which causes them to be merged with the overlay module itself)

### DIFF
--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -442,8 +442,8 @@ def _handle_module(
                         clang = clang_module_context,
                     ),
                 ],
-                direct_swift_infos = direct_swift_infos + overlay_direct_deps,
-                swift_infos = swift_infos,
+                direct_swift_infos = direct_swift_infos,
+                swift_infos = swift_infos + overlay_direct_deps,
             ),
         ]
         overlay_compile_result, overlay_linking_context = _compile_swift_overlay(
@@ -474,8 +474,8 @@ def _handle_module(
                     swift = overlay_swift_module,
                 ),
             ],
-            direct_swift_infos = direct_swift_infos + overlay_direct_deps,
-            swift_infos = swift_infos,
+            direct_swift_infos = direct_swift_infos,
+            swift_infos = swift_infos + overlay_direct_deps,
         ),
     ]
     if overlay_linking_context:


### PR DESCRIPTION
This ensures that the provider relationships are correct; without this, it appears like the overlay's deps are being provided by the overlay target directly.

PiperOrigin-RevId: 657971095
(cherry picked from commit 4633a1fe5d52580685fdf32f98d92556b8d04d58)