### PR TITLE
Don't drop `swift_overlay` linking contexts when an overlay depends on another library that has an overlay

### DIFF
--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -551,7 +551,16 @@ def _compile_swift_overlay(
             label = overlay_info.label,
             linking_contexts = [
                 cc_info.linking_context
-                for cc_info in overlay_info.deps.cc_infos + overlay_info.private_deps.cc_infos
+                for cc_info in (
+                    overlay_info.deps.cc_infos +
+                    overlay_info.private_deps.cc_infos
+                )
+            ] + [
+                overlay_info.linking_context
+                for overlay_info in (
+                    overlay_info.deps.swift_overlay_infos +
+                    overlay_info.private_deps.swift_overlay_infos
+                )
             ],
             module_context = compile_result.module_context,
             swift_toolchain = swift_toolchain,

--- a/swift/swift_overlay.bzl
+++ b/swift/swift_overlay.bzl
@@ -35,7 +35,7 @@ load(
     "get_providers",
     "include_developer_search_paths",
 )
-load(":providers.bzl", "SwiftInfo")
+load(":providers.bzl", "SwiftInfo", "SwiftOverlayInfo")
 load(":swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 
 def _swift_overlay_impl(ctx):
@@ -65,11 +65,13 @@ def _swift_overlay_impl(ctx):
         private_deps = struct(
             cc_infos = get_providers(private_deps, CcInfo),
             swift_infos = get_providers(private_deps, SwiftInfo),
+            swift_overlay_infos = get_providers(private_deps, SwiftOverlayInfo),
         ),
         alwayslink = ctx.attr.alwayslink,
         deps = struct(
             cc_infos = get_providers(deps, CcInfo),
             swift_infos = get_providers(deps, SwiftInfo),
+            swift_overlay_infos = get_providers(deps, SwiftOverlayInfo),
         ),
     )]
 


### PR DESCRIPTION
PiperOrigin-RevId: 665946723
(cherry picked from commit 6d0fc0f4f71a430958a7453d51cf8f8ea70e0520)