### PR TITLE
Make sure that the path to the generated header in the generated module map is workspace-relative when the feature configuration asks for it

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -46,6 +46,7 @@ load(
     "SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS",
     "SWIFT_FEATURE_INDEX_WHILE_BUILDING",
     "SWIFT_FEATURE_MODULAR_INDEXING",
+    "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_OPT",
     "SWIFT_FEATURE_OPT_USES_WMO",
     "SWIFT_FEATURE_PROPAGATE_GENERATED_MODULE_MAP",
@@ -1250,6 +1251,10 @@ def _declare_compile_outputs(
             module_map_file = generated_module_map,
             module_name = module_name,
             public_headers = [generated_header],
+            workspace_relative = is_feature_enabled(
+                feature_configuration = feature_configuration,
+                feature_name = SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,
+            ),
         )
     else:
         generated_module_map = None


### PR DESCRIPTION
PiperOrigin-RevId: 681838149
(cherry picked from commit f2eba62788e1abf31dd4eddcbe443c4e97d9c817)