### PR TITLE
Stop using config.string(allow_multiple = True)

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -367,7 +367,7 @@ swift_interop_hint(
 # User settable flag that specifies additional Swift copts on a per-swiftmodule basis.
 per_module_swiftcopt_flag(
     name = "per_module_swiftcopt",
-    build_setting_default = "",
+    build_setting_default = [],
 )
 
 # NOTE: Enabling this flag will transition --proto_compiler to

--- a/swift/internal/build_settings.bzl
+++ b/swift/internal/build_settings.bzl
@@ -89,9 +89,9 @@ def _per_module_swiftcopt_flag_impl(ctx):
     return PerModuleSwiftCoptSettingInfo(value = value)
 
 per_module_swiftcopt_flag = rule(
-    build_setting = config.string(
+    build_setting = config.string_list(
         flag = True,
-        allow_multiple = True,
+        repeatable = True,
     ),
     # TODO(b/186869451): Support adding swiftcopts by module name in addition
     # to the target label.


### PR DESCRIPTION
According to the Bazel documentation, this option is deprecated. config.string_list(repeatable = True) should be used instead. This PR is similar to this one, which I sent out for rules_rust:

https://github.com/bazelbuild/rules_rust/pull/2983