### PR TITLE
Fix `apple.swizzle_absolute_xcttestsourcelocation` usage

### DIFF
--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -282,17 +282,6 @@ def _swift_test_impl(ctx):
     discover_tests = ctx.attr.discover_tests
     objc_test_discovery = swift_toolchain.test_configuration.objc_test_discovery
 
-    # `is_feature_enabled` isn't used, as it requires the prefix of the feature
-    # to start with `swift.`
-    swizzle_absolute_xcttestsourcelocation = (
-        "apple.swizzle_absolute_xcttestsourcelocation" in
-        feature_configuration._enabled_features
-    )
-
-    extra_link_deps = []
-    if swizzle_absolute_xcttestsourcelocation:
-        extra_link_deps.append(ctx.attr._swizzle_absolute_xcttestsourcelocation)
-
     deps = list(ctx.attr.deps)
     test_runner_deps = list(ctx.attr._test_runner_deps)
 
@@ -304,6 +293,17 @@ def _swift_test_impl(ctx):
         additional_link_deps = test_runner_deps
     else:
         additional_link_deps = []
+
+    # `is_feature_enabled` isn't used, as it requires the prefix of the feature
+    # to start with `swift.`
+    swizzle_absolute_xcttestsourcelocation = (
+        "apple.swizzle_absolute_xcttestsourcelocation" in
+        feature_configuration._enabled_features
+    )
+    if swizzle_absolute_xcttestsourcelocation:
+        additional_link_deps.append(
+            ctx.attr._swizzle_absolute_xcttestsourcelocation,
+        )
 
     # We also need to collect nested providers from `SwiftBinaryInfo` since we
     # support testing those.


### PR DESCRIPTION
Regressed in 43af3816b5bea4e0add6523ee1642d75157f783d.