### PR TITLE
Add example with deps in `swift_import`

### DIFF
--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -13,7 +13,10 @@ swift_binary(
     name = "client",
     srcs = ["Client.swift"],
     tags = FIXTURE_TAGS,
-    deps = [":toy_module"],
+    deps = [
+        ":toy_module",
+        ":toy_module_consumer",
+    ],
 )
 
 swift_import(
@@ -25,4 +28,16 @@ swift_import(
     swiftdoc = "//test/fixtures/module_interface/library:toy_outputs/ToyModule.swiftdoc",
     swiftinterface = "//test/fixtures/module_interface/library:toy_outputs/ToyModule.swiftinterface",
     tags = FIXTURE_TAGS,
+)
+
+swift_import(
+    name = "toy_module_consumer",
+    archives = [
+        "//test/fixtures/module_interface/library_consumer:toy_consumer_outputs/libToyModuleConsumer.a",
+    ],
+    module_name = "ToyModuleConsumer",
+    swiftdoc = "//test/fixtures/module_interface/library_consumer:toy_consumer_outputs/ToyModuleConsumer.swiftdoc",
+    swiftinterface = "//test/fixtures/module_interface/library_consumer:toy_consumer_outputs/ToyModuleConsumer.swiftinterface",
+    tags = FIXTURE_TAGS,
+    deps = [":toy_module"],
 )

--- a/test/fixtures/module_interface/library_consumer/BUILD
+++ b/test/fixtures/module_interface/library_consumer/BUILD
@@ -1,0 +1,52 @@
+load("//swift:swift_library.bzl", "swift_library")
+load(
+    "//test/fixtures:common.bzl",
+    "FIXTURE_TAGS",
+)
+load(
+    "//test/rules:swift_library_artifact_collector.bzl",
+    "swift_library_artifact_collector",
+)
+
+package(
+    default_testonly = True,
+    default_visibility = ["//test:__subpackages__"],
+)
+
+licenses(["notice"])
+
+# Checking in pre-built artifacts like a `.swiftinterface` and static libraries
+# would require different artifacts for every platform the test might run on.
+# Instead, build it on-demand but forward the outputs using the "artifact
+# collector" rule below to make them act as if they were pre-built outputs when
+# referenced by the `swift_import` rule.
+#
+# These must be in a separate package than the `swift_import` target because
+# that rule propagates its pre-built inputs in `DefaultInfo`.
+
+swift_library(
+    name = "toy_module_consumer",
+    srcs = ["ToyConsumer.swift"],
+    library_evolution = True,
+    module_name = "ToyModuleConsumer",
+    tags = FIXTURE_TAGS,
+    deps = ["//test/fixtures/module_interface/library:toy_module_library"],
+)
+
+swift_library_artifact_collector(
+    name = "toy_module_consumer_artifact_collector",
+    static_library = "toy_consumer_outputs/libToyModuleConsumer.a",
+    swiftdoc = "toy_consumer_outputs/ToyModuleConsumer.swiftdoc",
+    swiftinterface = "toy_consumer_outputs/ToyModuleConsumer.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target = ":toy_module_consumer",
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+swift_library(
+    name = "toy_module_consumer_without_library_evolution",
+    srcs = ["ToyConsumer.swift"],
+    library_evolution = False,
+    module_name = "ToyModuleConsumerNoEvolution",
+    tags = FIXTURE_TAGS,
+)

--- a/test/fixtures/module_interface/library_consumer/ToyConsumer.swift
+++ b/test/fixtures/module_interface/library_consumer/ToyConsumer.swift
@@ -1,4 +1,4 @@
-// Copyright 2022 The Bazel Authors. All rights reserved.
+// Copyright 2024 The Bazel Authors. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,14 +13,7 @@
 // limitations under the License.
 
 import ToyModule
-import ToyModuleConsumer
 
-@main
-struct Main {
-  static func main() {
-    let value = ToyValue(number: 10)
-    print(value.stringValue)
-    print(value.squared())
-    printToyValue()
-  }
+public func printToyValue() {
+  print(ToyValue(number: 42))
 }


### PR DESCRIPTION
Show-cases an issue with `swift_import` rules in Xcode 16+ when using `--spawn_strategy=local`.