### PR TITLE
wip: upgrade stardoc and protobuf to restore Bazel HEAD CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -8,8 +8,7 @@ matrix:
   - 7.x
   # TODO: Uncomment once Bazel 8 is released
   # - 8.x
-  # TODO: Uncomment once we support HEAD again
-  # - latest
+  - last_green
   platform:
   - ubuntu2004
 tasks:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,8 +11,7 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.0.2")
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+bazel_dep(name = "protobuf", version = "29.0")
 bazel_dep(name = "nlohmann_json", version = "3.6.1", repo_name = "com_github_nlohmann_json")
 bazel_dep(
     name = "swift_argument_parser",
@@ -43,7 +42,7 @@ register_toolchains("@build_bazel_rules_swift_local_config//:all")
 # Dev dependencies
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.33.0", dev_dependency = True, repo_name = "bazel_gazelle")
-bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "stardoc", version = "0.7.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
 
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
@@ -53,21 +52,4 @@ http_archive(
     sha256 = "527a5c6d19987acbb5019efa067b0fbd127e06187a0689c3f1098fd22c1a7d43",
     strip_prefix = "swift-syntax-01fc3e3ed4d26121c06790abf8fe5ddaa22a4cc5",
     url = "https://github.com/apple/swift-syntax/archive/01fc3e3ed4d26121c06790abf8fe5ddaa22a4cc5.tar.gz",
-)
-
-# TODO: Remove override when a protobuf release is available that supports
-# Bazel 8
-archive_override(
-    module_name = "protobuf",
-    integrity = "sha256-+dloYVexGlGsxKLTARuU4KXZ5ORo/BWPR6obFk73d+Q=",
-    strip_prefix = "protobuf-b93b8e5f64ed922d101759380d7c6a2bbe474e26",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/b93b8e5f64ed922d101759380d7c6a2bbe474e26.zip"],
-)
-
-# TODO: Remove override when a protobuf release that marks `stardoc` as a
-# dev_dependency is available, until then it's upgrading our stardoc version
-# so override it here.
-single_version_override(
-    module_name = "stardoc",
-    version = "0.6.2",
 )

--- a/doc/api.md
+++ b/doc/api.md
@@ -13,8 +13,10 @@ module.
 ## create_swift_interop_info
 
 <pre>
-create_swift_interop_info(<a href="#create_swift_interop_info-exclude_headers">exclude_headers</a>, <a href="#create_swift_interop_info-module_map">module_map</a>, <a href="#create_swift_interop_info-module_name">module_name</a>, <a href="#create_swift_interop_info-requested_features">requested_features</a>, <a href="#create_swift_interop_info-suppressed">suppressed</a>,
-                          <a href="#create_swift_interop_info-swift_infos">swift_infos</a>, <a href="#create_swift_interop_info-unsupported_features">unsupported_features</a>)
+load("@rules_swift//doc:doc.bzl", "create_swift_interop_info")
+
+create_swift_interop_info(*, <a href="#create_swift_interop_info-exclude_headers">exclude_headers</a>, <a href="#create_swift_interop_info-module_map">module_map</a>, <a href="#create_swift_interop_info-module_name">module_name</a>, <a href="#create_swift_interop_info-requested_features">requested_features</a>,
+                          <a href="#create_swift_interop_info-suppressed">suppressed</a>, <a href="#create_swift_interop_info-swift_infos">swift_infos</a>, <a href="#create_swift_interop_info-unsupported_features">unsupported_features</a>)
 </pre>
 
 Returns a provider that lets a target expose C/Objective-C APIs to Swift.
@@ -74,7 +76,9 @@ A provider whose type/layout is an implementation detail and should not
 ## derive_swift_module_name
 
 <pre>
-derive_swift_module_name(<a href="#derive_swift_module_name-args">args</a>)
+load("@rules_swift//doc:doc.bzl", "derive_swift_module_name")
+
+derive_swift_module_name(<a href="#derive_swift_module_name-args">*args</a>)
 </pre>
 
 Returns a derived module name from the given build label.
@@ -112,6 +116,8 @@ The module name derived from the label.
 ## is_swift_overlay
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "is_swift_overlay")
+
 is_swift_overlay(<a href="#is_swift_overlay-target">target</a>)
 </pre>
 
@@ -140,6 +146,8 @@ True if the target is a `swift_overlay`, otherwise False.
 ## swift_common.cc_feature_configuration
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.cc_feature_configuration(<a href="#swift_common.cc_feature_configuration-feature_configuration">feature_configuration</a>)
 </pre>
 
@@ -164,7 +172,9 @@ A C++ `FeatureConfiguration` value (see
 ## swift_common.compile
 
 <pre>
-swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-cc_infos">cc_infos</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-exec_group">exec_group</a>,
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.compile(*, <a href="#swift_common.compile-actions">actions</a>, <a href="#swift_common.compile-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile-cc_infos">cc_infos</a>, <a href="#swift_common.compile-copts">copts</a>, <a href="#swift_common.compile-defines">defines</a>, <a href="#swift_common.compile-exec_group">exec_group</a>,
                      <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>, <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-is_test">is_test</a>,
                      <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_cc_infos">private_cc_infos</a>,
                      <a href="#swift_common.compile-private_swift_infos">private_swift_infos</a>, <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_infos">swift_infos</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile-target_name">target_name</a>,
@@ -249,7 +259,9 @@ A `struct` with the following fields:
 ## swift_common.compile_module_interface
 
 <pre>
-swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.compile_module_interface(*, <a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
                                       <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
                                       <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>)
 </pre>
@@ -289,7 +301,9 @@ A Swift module context (as returned by `create_swift_module_context`)
 ## swift_common.configure_features
 
 <pre>
-swift_common.configure_features(<a href="#swift_common.configure_features-ctx">ctx</a>, <a href="#swift_common.configure_features-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.configure_features-requested_features">requested_features</a>, <a href="#swift_common.configure_features-unsupported_features">unsupported_features</a>)
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.configure_features(<a href="#swift_common.configure_features-ctx">ctx</a>, <a href="#swift_common.configure_features-swift_toolchain">swift_toolchain</a>, *, <a href="#swift_common.configure_features-requested_features">requested_features</a>, <a href="#swift_common.configure_features-unsupported_features">unsupported_features</a>)
 </pre>
 
 Creates a feature configuration to be passed to Swift build APIs.
@@ -323,6 +337,8 @@ An opaque value representing the feature configuration that can be
 ## swift_common.create_compilation_context
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.create_compilation_context(<a href="#swift_common.create_compilation_context-defines">defines</a>, <a href="#swift_common.create_compilation_context-srcs">srcs</a>, <a href="#swift_common.create_compilation_context-transitive_modules">transitive_modules</a>)
 </pre>
 
@@ -356,8 +372,10 @@ A `struct` containing four fields:
 ## swift_common.create_linking_context_from_compilation_outputs
 
 <pre>
-swift_common.create_linking_context_from_compilation_outputs(<a href="#swift_common.create_linking_context_from_compilation_outputs-actions">actions</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-additional_inputs">additional_inputs</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-alwayslink">alwayslink</a>,
-                                                             <a href="#swift_common.create_linking_context_from_compilation_outputs-compilation_outputs">compilation_outputs</a>,
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.create_linking_context_from_compilation_outputs(*, <a href="#swift_common.create_linking_context_from_compilation_outputs-actions">actions</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-additional_inputs">additional_inputs</a>,
+                                                             <a href="#swift_common.create_linking_context_from_compilation_outputs-alwayslink">alwayslink</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-compilation_outputs">compilation_outputs</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-feature_configuration">feature_configuration</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-is_test">is_test</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-label">label</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-linking_contexts">linking_contexts</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-module_context">module_context</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-name">name</a>,
@@ -405,7 +423,9 @@ A tuple of `(CcLinkingContext, CcLinkingOutputs)` containing the linking
 ## swift_common.extract_symbol_graph
 
 <pre>
-swift_common.extract_symbol_graph(<a href="#swift_common.extract_symbol_graph-actions">actions</a>, <a href="#swift_common.extract_symbol_graph-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.extract_symbol_graph-emit_extension_block_symbols">emit_extension_block_symbols</a>,
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.extract_symbol_graph(*, <a href="#swift_common.extract_symbol_graph-actions">actions</a>, <a href="#swift_common.extract_symbol_graph-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.extract_symbol_graph-emit_extension_block_symbols">emit_extension_block_symbols</a>,
                                   <a href="#swift_common.extract_symbol_graph-feature_configuration">feature_configuration</a>, <a href="#swift_common.extract_symbol_graph-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.extract_symbol_graph-minimum_access_level">minimum_access_level</a>,
                                   <a href="#swift_common.extract_symbol_graph-module_name">module_name</a>, <a href="#swift_common.extract_symbol_graph-output_dir">output_dir</a>, <a href="#swift_common.extract_symbol_graph-swift_infos">swift_infos</a>, <a href="#swift_common.extract_symbol_graph-swift_toolchain">swift_toolchain</a>)
 </pre>
@@ -434,7 +454,9 @@ Extracts the symbol graph from a Swift module.
 ## swift_common.get_toolchain
 
 <pre>
-swift_common.get_toolchain(<a href="#swift_common.get_toolchain-ctx">ctx</a>, <a href="#swift_common.get_toolchain-exec_group">exec_group</a>, <a href="#swift_common.get_toolchain-mandatory">mandatory</a>, <a href="#swift_common.get_toolchain-attr">attr</a>)
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.get_toolchain(<a href="#swift_common.get_toolchain-ctx">ctx</a>, *, <a href="#swift_common.get_toolchain-exec_group">exec_group</a>, <a href="#swift_common.get_toolchain-mandatory">mandatory</a>, <a href="#swift_common.get_toolchain-attr">attr</a>)
 </pre>
 
 Gets the Swift toolchain associated with the rule or aspect.
@@ -460,6 +482,8 @@ A `SwiftToolchainInfo` provider, or `None` if the toolchain was not
 ## swift_common.is_enabled
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
 swift_common.is_enabled(<a href="#swift_common.is_enabled-feature_configuration">feature_configuration</a>, <a href="#swift_common.is_enabled-feature_name">feature_name</a>)
 </pre>
 
@@ -488,7 +512,9 @@ check it.
 ## swift_common.precompile_clang_module
 
 <pre>
-swift_common.precompile_clang_module(<a href="#swift_common.precompile_clang_module-actions">actions</a>, <a href="#swift_common.precompile_clang_module-cc_compilation_context">cc_compilation_context</a>, <a href="#swift_common.precompile_clang_module-exec_group">exec_group</a>,
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.precompile_clang_module(*, <a href="#swift_common.precompile_clang_module-actions">actions</a>, <a href="#swift_common.precompile_clang_module-cc_compilation_context">cc_compilation_context</a>, <a href="#swift_common.precompile_clang_module-exec_group">exec_group</a>,
                                      <a href="#swift_common.precompile_clang_module-feature_configuration">feature_configuration</a>, <a href="#swift_common.precompile_clang_module-module_map_file">module_map_file</a>, <a href="#swift_common.precompile_clang_module-module_name">module_name</a>,
                                      <a href="#swift_common.precompile_clang_module-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.precompile_clang_module-target_name">target_name</a>, <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>)
 </pre>
@@ -521,7 +547,9 @@ A struct containing the precompiled module and optional indexstore directory,
 ## swift_common.use_toolchain
 
 <pre>
-swift_common.use_toolchain(<a href="#swift_common.use_toolchain-mandatory">mandatory</a>)
+load("@rules_swift//doc:doc.bzl", "swift_common")
+
+swift_common.use_toolchain(*, <a href="#swift_common.use_toolchain-mandatory">mandatory</a>)
 </pre>
 
 Returns a list of toolchain types needed to use the Swift toolchain.

--- a/doc/proto_migration.md
+++ b/doc/proto_migration.md
@@ -116,7 +116,7 @@ proto_library(
     name = "bar_proto",
     srcs = ["bar.proto"],
     deps = [
-        "@com_google_protobuf//:api_proto",
+        "@protobuf//:api_proto",
         ":foo_proto",
     ],
 )

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -17,7 +17,9 @@ On this page:
 ## SwiftInfo
 
 <pre>
-SwiftInfo(<a href="#SwiftInfo-direct_modules">direct_modules</a>, <a href="#SwiftInfo-transitive_modules">transitive_modules</a>)
+load("@rules_swift//doc:doc.bzl", "SwiftInfo")
+
+SwiftInfo(*, <a href="#SwiftInfo-_init-direct_swift_infos">direct_swift_infos</a>, <a href="#SwiftInfo-_init-modules">modules</a>, <a href="#SwiftInfo-_init-swift_infos">swift_infos</a>)
 </pre>
 
 Contains information about the compiled artifacts of a Swift module.
@@ -48,8 +50,15 @@ where the arguments are:
 When reading an existing `SwiftInfo` provider, it has the two fields described
 below.
 
-**FIELDS**
+**CONSTRUCTOR PARAMETERS**
 
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="SwiftInfo-_init-direct_swift_infos"></a>direct_swift_infos | <p align="center">-</p> | `[]` |
+| <a id="SwiftInfo-_init-modules"></a>modules | <p align="center">-</p> | `[]` |
+| <a id="SwiftInfo-_init-swift_infos"></a>swift_infos | <p align="center">-</p> | `[]` |
+
+**FIELDS**
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -62,13 +71,14 @@ below.
 ## SwiftProtoCompilerInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftProtoCompilerInfo")
+
 SwiftProtoCompilerInfo(<a href="#SwiftProtoCompilerInfo-bundled_proto_paths">bundled_proto_paths</a>, <a href="#SwiftProtoCompilerInfo-compile">compile</a>, <a href="#SwiftProtoCompilerInfo-compiler_deps">compiler_deps</a>, <a href="#SwiftProtoCompilerInfo-internal">internal</a>)
 </pre>
 
 Provides information needed to generate Swift code from `ProtoInfo` providers
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -83,13 +93,14 @@ Provides information needed to generate Swift code from `ProtoInfo` providers
 ## SwiftProtoInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftProtoInfo")
+
 SwiftProtoInfo(<a href="#SwiftProtoInfo-module_name">module_name</a>, <a href="#SwiftProtoInfo-module_mappings">module_mappings</a>, <a href="#SwiftProtoInfo-direct_pbswift_files">direct_pbswift_files</a>, <a href="#SwiftProtoInfo-pbswift_files">pbswift_files</a>)
 </pre>
 
 Propagates Swift-specific information about a `proto_library`.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |
@@ -104,6 +115,8 @@ Propagates Swift-specific information about a `proto_library`.
 ## SwiftToolchainInfo
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "SwiftToolchainInfo")
+
 SwiftToolchainInfo(<a href="#SwiftToolchainInfo-action_configs">action_configs</a>, <a href="#SwiftToolchainInfo-cc_language">cc_language</a>, <a href="#SwiftToolchainInfo-cc_toolchain_info">cc_toolchain_info</a>, <a href="#SwiftToolchainInfo-clang_implicit_deps_providers">clang_implicit_deps_providers</a>,
                    <a href="#SwiftToolchainInfo-const_protocols_to_gather">const_protocols_to_gather</a>, <a href="#SwiftToolchainInfo-cross_import_overlays">cross_import_overlays</a>, <a href="#SwiftToolchainInfo-debug_outputs_provider">debug_outputs_provider</a>,
                    <a href="#SwiftToolchainInfo-developer_dirs">developer_dirs</a>, <a href="#SwiftToolchainInfo-entry_point_linkopts_provider">entry_point_linkopts_provider</a>, <a href="#SwiftToolchainInfo-feature_allowlists">feature_allowlists</a>,
@@ -116,7 +129,6 @@ Propagates information about a Swift toolchain to compilation and linking rules
 that use the toolchain.
 
 **FIELDS**
-
 
 | Name  | Description |
 | :------------- | :------------- |

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -41,6 +41,8 @@ On this page:
 ## swift_binary
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_binary")
+
 swift_binary(<a href="#swift_binary-name">name</a>, <a href="#swift_binary-deps">deps</a>, <a href="#swift_binary-srcs">srcs</a>, <a href="#swift_binary-data">data</a>, <a href="#swift_binary-copts">copts</a>, <a href="#swift_binary-defines">defines</a>, <a href="#swift_binary-linkopts">linkopts</a>, <a href="#swift_binary-malloc">malloc</a>, <a href="#swift_binary-module_name">module_name</a>, <a href="#swift_binary-package_name">package_name</a>,
              <a href="#swift_binary-plugins">plugins</a>, <a href="#swift_binary-stamp">stamp</a>, <a href="#swift_binary-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -84,6 +86,8 @@ please use one of the platform-specific application rules in
 ## swift_compiler_plugin
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_compiler_plugin")
+
 swift_compiler_plugin(<a href="#swift_compiler_plugin-name">name</a>, <a href="#swift_compiler_plugin-deps">deps</a>, <a href="#swift_compiler_plugin-srcs">srcs</a>, <a href="#swift_compiler_plugin-data">data</a>, <a href="#swift_compiler_plugin-copts">copts</a>, <a href="#swift_compiler_plugin-defines">defines</a>, <a href="#swift_compiler_plugin-linkopts">linkopts</a>, <a href="#swift_compiler_plugin-malloc">malloc</a>, <a href="#swift_compiler_plugin-module_name">module_name</a>,
                       <a href="#swift_compiler_plugin-package_name">package_name</a>, <a href="#swift_compiler_plugin-plugins">plugins</a>, <a href="#swift_compiler_plugin-stamp">stamp</a>, <a href="#swift_compiler_plugin-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -172,6 +176,8 @@ swift_library(
 ## swift_compiler_plugin_import
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_compiler_plugin_import")
+
 swift_compiler_plugin_import(<a href="#swift_compiler_plugin_import-name">name</a>, <a href="#swift_compiler_plugin_import-executable">executable</a>, <a href="#swift_compiler_plugin_import-module_names">module_names</a>)
 </pre>
 
@@ -194,6 +200,8 @@ using `swift_compiler_plugin`.
 ## swift_cross_import_overlay
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_cross_import_overlay")
+
 swift_cross_import_overlay(<a href="#swift_cross_import_overlay-name">name</a>, <a href="#swift_cross_import_overlay-deps">deps</a>, <a href="#swift_cross_import_overlay-bystanding_module">bystanding_module</a>, <a href="#swift_cross_import_overlay-bystanding_module_name">bystanding_module_name</a>, <a href="#swift_cross_import_overlay-declaring_module">declaring_module</a>,
                            <a href="#swift_cross_import_overlay-declaring_module_name">declaring_module_name</a>)
 </pre>
@@ -238,6 +246,8 @@ the future, this rule is not recommended for other widespread use.
 ## swift_feature_allowlist
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_feature_allowlist")
+
 swift_feature_allowlist(<a href="#swift_feature_allowlist-name">name</a>, <a href="#swift_feature_allowlist-aspect_ids">aspect_ids</a>, <a href="#swift_feature_allowlist-managed_features">managed_features</a>, <a href="#swift_feature_allowlist-packages">packages</a>)
 </pre>
 
@@ -269,6 +279,8 @@ package.
 ## swift_import
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_import")
+
 swift_import(<a href="#swift_import-name">name</a>, <a href="#swift_import-deps">deps</a>, <a href="#swift_import-data">data</a>, <a href="#swift_import-archives">archives</a>, <a href="#swift_import-module_name">module_name</a>, <a href="#swift_import-plugins">plugins</a>, <a href="#swift_import-swiftdoc">swiftdoc</a>, <a href="#swift_import-swiftinterface">swiftinterface</a>,
              <a href="#swift_import-swiftmodule">swiftmodule</a>)
 </pre>
@@ -311,6 +323,8 @@ uses the API marked with `@_spi`.
 ## swift_interop_hint
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_interop_hint")
+
 swift_interop_hint(<a href="#swift_interop_hint-name">name</a>, <a href="#swift_interop_hint-exclude_hdrs">exclude_hdrs</a>, <a href="#swift_interop_hint-module_map">module_map</a>, <a href="#swift_interop_hint-module_name">module_name</a>, <a href="#swift_interop_hint-suppressed">suppressed</a>)
 </pre>
 
@@ -453,6 +467,8 @@ its transitive dependencies be propagated.
 ## swift_library
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_library")
+
 swift_library(<a href="#swift_library-name">name</a>, <a href="#swift_library-deps">deps</a>, <a href="#swift_library-srcs">srcs</a>, <a href="#swift_library-data">data</a>, <a href="#swift_library-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#swift_library-alwayslink">alwayslink</a>, <a href="#swift_library-copts">copts</a>,
               <a href="#swift_library-defines">defines</a>, <a href="#swift_library-generated_header_name">generated_header_name</a>, <a href="#swift_library-generates_header">generates_header</a>, <a href="#swift_library-library_evolution">library_evolution</a>, <a href="#swift_library-linkopts">linkopts</a>,
               <a href="#swift_library-linkstatic">linkstatic</a>, <a href="#swift_library-module_name">module_name</a>, <a href="#swift_library-package_name">package_name</a>, <a href="#swift_library-plugins">plugins</a>, <a href="#swift_library-private_deps">private_deps</a>, <a href="#swift_library-swiftc_inputs">swiftc_inputs</a>)
@@ -490,6 +506,8 @@ Compiles and links Swift code into a static library and Swift module.
 ## swift_library_group
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_library_group")
+
 swift_library_group(<a href="#swift_library_group-name">name</a>, <a href="#swift_library_group-deps">deps</a>)
 </pre>
 
@@ -514,6 +532,8 @@ libraries directly.
 ## swift_module_mapping
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_module_mapping")
+
 swift_module_mapping(<a href="#swift_module_mapping-name">name</a>, <a href="#swift_module_mapping-aliases">aliases</a>)
 </pre>
 
@@ -579,6 +599,8 @@ source asked to `import Utils`.
 ## swift_module_mapping_test
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_module_mapping_test")
+
 swift_module_mapping_test(<a href="#swift_module_mapping_test-name">name</a>, <a href="#swift_module_mapping_test-deps">deps</a>, <a href="#swift_module_mapping_test-exclude">exclude</a>, <a href="#swift_module_mapping_test-mapping">mapping</a>)
 </pre>
 
@@ -613,6 +635,8 @@ remaining modules collected are not present in the `aliases` of the
 ## swift_overlay
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_overlay")
+
 swift_overlay(<a href="#swift_overlay-name">name</a>, <a href="#swift_overlay-deps">deps</a>, <a href="#swift_overlay-srcs">srcs</a>, <a href="#swift_overlay-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#swift_overlay-alwayslink">alwayslink</a>, <a href="#swift_overlay-copts">copts</a>, <a href="#swift_overlay-defines">defines</a>,
               <a href="#swift_overlay-library_evolution">library_evolution</a>, <a href="#swift_overlay-linkopts">linkopts</a>, <a href="#swift_overlay-linkstatic">linkstatic</a>, <a href="#swift_overlay-package_name">package_name</a>, <a href="#swift_overlay-plugins">plugins</a>, <a href="#swift_overlay-private_deps">private_deps</a>,
               <a href="#swift_overlay-swiftc_inputs">swiftc_inputs</a>)
@@ -714,6 +738,8 @@ almost always an anti-pattern.
 ## swift_package_configuration
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_package_configuration")
+
 swift_package_configuration(<a href="#swift_package_configuration-name">name</a>, <a href="#swift_package_configuration-configured_features">configured_features</a>, <a href="#swift_package_configuration-packages">packages</a>)
 </pre>
 
@@ -739,6 +765,8 @@ target's label is included by the package specifications in the configuration.
 ## swift_proto_compiler
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_compiler")
+
 swift_proto_compiler(<a href="#swift_proto_compiler-name">name</a>, <a href="#swift_proto_compiler-deps">deps</a>, <a href="#swift_proto_compiler-bundled_proto_paths">bundled_proto_paths</a>, <a href="#swift_proto_compiler-plugin">plugin</a>, <a href="#swift_proto_compiler-plugin_name">plugin_name</a>, <a href="#swift_proto_compiler-plugin_option_allowlist">plugin_option_allowlist</a>,
                      <a href="#swift_proto_compiler-plugin_options">plugin_options</a>, <a href="#swift_proto_compiler-protoc">protoc</a>, <a href="#swift_proto_compiler-suffixes">suffixes</a>)
 </pre>
@@ -766,6 +794,8 @@ swift_proto_compiler(<a href="#swift_proto_compiler-name">name</a>, <a href="#sw
 ## swift_proto_library
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_library")
+
 swift_proto_library(<a href="#swift_proto_library-name">name</a>, <a href="#swift_proto_library-deps">deps</a>, <a href="#swift_proto_library-srcs">srcs</a>, <a href="#swift_proto_library-data">data</a>, <a href="#swift_proto_library-additional_compiler_deps">additional_compiler_deps</a>, <a href="#swift_proto_library-additional_compiler_info">additional_compiler_info</a>,
                     <a href="#swift_proto_library-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#swift_proto_library-alwayslink">alwayslink</a>, <a href="#swift_proto_library-compilers">compilers</a>, <a href="#swift_proto_library-copts">copts</a>, <a href="#swift_proto_library-defines">defines</a>,
                     <a href="#swift_proto_library-generated_header_name">generated_header_name</a>, <a href="#swift_proto_library-generates_header">generates_header</a>, <a href="#swift_proto_library-library_evolution">library_evolution</a>, <a href="#swift_proto_library-linkopts">linkopts</a>, <a href="#swift_proto_library-linkstatic">linkstatic</a>,
@@ -775,7 +805,7 @@ swift_proto_library(<a href="#swift_proto_library-name">name</a>, <a href="#swif
 Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -793,7 +823,7 @@ If your protos depend on protos from other targets, add dependencies between the
 swift_proto_library targets which mirror the dependencies between the proto targets.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -842,6 +872,8 @@ swift_proto_library(
 ## swift_proto_library_group
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_proto_library_group")
+
 swift_proto_library_group(<a href="#swift_proto_library_group-name">name</a>, <a href="#swift_proto_library_group-compiler">compiler</a>, <a href="#swift_proto_library_group-proto">proto</a>)
 </pre>
 
@@ -920,6 +952,8 @@ swift_binary(
 ## swift_test
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "swift_test")
+
 swift_test(<a href="#swift_test-name">name</a>, <a href="#swift_test-deps">deps</a>, <a href="#swift_test-srcs">srcs</a>, <a href="#swift_test-data">data</a>, <a href="#swift_test-copts">copts</a>, <a href="#swift_test-defines">defines</a>, <a href="#swift_test-discover_tests">discover_tests</a>, <a href="#swift_test-env">env</a>, <a href="#swift_test-linkopts">linkopts</a>, <a href="#swift_test-malloc">malloc</a>,
            <a href="#swift_test-module_name">module_name</a>, <a href="#swift_test-package_name">package_name</a>, <a href="#swift_test-plugins">plugins</a>, <a href="#swift_test-stamp">stamp</a>, <a href="#swift_test-swiftc_inputs">swiftc_inputs</a>)
 </pre>
@@ -1013,6 +1047,8 @@ root of your workspace (i.e. `$(SRCROOT)`).
 ## universal_swift_compiler_plugin
 
 <pre>
+load("@rules_swift//doc:doc.bzl", "universal_swift_compiler_plugin")
+
 universal_swift_compiler_plugin(<a href="#universal_swift_compiler_plugin-name">name</a>, <a href="#universal_swift_compiler_plugin-plugin">plugin</a>)
 </pre>
 
@@ -1064,11 +1100,13 @@ swift_library(
 ## mixed_language_library
 
 <pre>
-mixed_language_library(<a href="#mixed_language_library-name">name</a>, <a href="#mixed_language_library-alwayslink">alwayslink</a>, <a href="#mixed_language_library-clang_copts">clang_copts</a>, <a href="#mixed_language_library-clang_defines">clang_defines</a>, <a href="#mixed_language_library-clang_srcs">clang_srcs</a>, <a href="#mixed_language_library-data">data</a>,
+load("@rules_swift//doc:doc.bzl", "mixed_language_library")
+
+mixed_language_library(*, <a href="#mixed_language_library-name">name</a>, <a href="#mixed_language_library-alwayslink">alwayslink</a>, <a href="#mixed_language_library-clang_copts">clang_copts</a>, <a href="#mixed_language_library-clang_defines">clang_defines</a>, <a href="#mixed_language_library-clang_srcs">clang_srcs</a>, <a href="#mixed_language_library-data">data</a>,
                        <a href="#mixed_language_library-enable_modules">enable_modules</a>, <a href="#mixed_language_library-hdrs">hdrs</a>, <a href="#mixed_language_library-includes">includes</a>, <a href="#mixed_language_library-linkopts">linkopts</a>, <a href="#mixed_language_library-module_map">module_map</a>, <a href="#mixed_language_library-module_name">module_name</a>,
                        <a href="#mixed_language_library-non_arc_srcs">non_arc_srcs</a>, <a href="#mixed_language_library-package_name">package_name</a>, <a href="#mixed_language_library-private_deps">private_deps</a>, <a href="#mixed_language_library-sdk_dylibs">sdk_dylibs</a>, <a href="#mixed_language_library-sdk_frameworks">sdk_frameworks</a>,
                        <a href="#mixed_language_library-swift_copts">swift_copts</a>, <a href="#mixed_language_library-swift_defines">swift_defines</a>, <a href="#mixed_language_library-swift_srcs">swift_srcs</a>, <a href="#mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#mixed_language_library-textual_hdrs">textual_hdrs</a>,
-                       <a href="#mixed_language_library-umbrella_header">umbrella_header</a>, <a href="#mixed_language_library-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#mixed_language_library-deps">deps</a>, <a href="#mixed_language_library-kwargs">kwargs</a>)
+                       <a href="#mixed_language_library-umbrella_header">umbrella_header</a>, <a href="#mixed_language_library-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#mixed_language_library-deps">deps</a>, <a href="#mixed_language_library-kwargs">**kwargs</a>)
 </pre>
 
 Creates a mixed language library from a Clang and Swift library target     pair.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -5,6 +5,8 @@
 ## swift_rules_dependencies
 
 <pre>
+load("@rules_swift//swift:repositories.bzl", "swift_rules_dependencies")
+
 swift_rules_dependencies(<a href="#swift_rules_dependencies-include_bzlmod_ready_dependencies">include_bzlmod_ready_dependencies</a>)
 </pre>
 

--- a/examples/xplatform/custom_swift_proto_compiler/protos/BUILD
+++ b/examples/xplatform/custom_swift_proto_compiler/protos/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "example_proto",

--- a/examples/xplatform/grpc/service/BUILD
+++ b/examples/xplatform/grpc/service/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -8,7 +8,7 @@ proto_library(
         "service_messages.proto",
     ],
     deps = [
-        "@com_google_protobuf//:any_proto",
+        "@protobuf//:any_proto",
     ],
 )
 

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 
@@ -8,7 +8,7 @@ proto_library(
     name = "example_proto",
     srcs = ["example.proto"],
     deps = [
-        "@com_google_protobuf//:api_proto",
+        "@protobuf//:api_proto",
     ],
 )
 

--- a/examples/xplatform/proto_files/BUILD
+++ b/examples/xplatform/proto_files/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 

--- a/examples/xplatform/proto_glob/BUILD
+++ b/examples/xplatform/proto_glob/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 

--- a/examples/xplatform/proto_library_group/request/BUILD
+++ b/examples/xplatform/proto_library_group/request/BUILD
@@ -1,13 +1,10 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "request_proto",
     srcs = glob(["*.proto"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_protobuf//:any_proto",
+        "@protobuf//:any_proto",
     ],
 )

--- a/examples/xplatform/proto_library_group/response/BUILD
+++ b/examples/xplatform/proto_library_group/response/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "response_proto",

--- a/examples/xplatform/proto_library_group/service/BUILD
+++ b/examples/xplatform/proto_library_group/service/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//proto:swift_proto_library_group.bzl", "swift_proto_library_group")
 

--- a/examples/xplatform/proto_path/protos/package_1/BUILD
+++ b/examples/xplatform/proto_path/protos/package_1/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/examples/xplatform/proto_path/protos/package_2/BUILD
+++ b/examples/xplatform/proto_path/protos/package_2/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -39,7 +39,7 @@ bzl_library(
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
-        "@rules_proto//proto:defs",
+        "@protobuf//bazel/common:proto_info_bzl",
     ],
 )
 
@@ -59,7 +59,7 @@ bzl_library(
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
-        "@rules_proto//proto:defs",
+        "@protobuf//bazel/common:proto_info_bzl",
     ],
 )
 

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -20,10 +20,7 @@ load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
-load(
-    "@rules_proto//proto:defs.bzl",
-    "ProtoInfo",
-)
+load("@protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//swift:module_name.bzl", "derive_swift_module_name")
 load("//swift:providers.bzl", "SwiftProtoCompilerInfo")
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
@@ -154,7 +151,7 @@ on which fields are accepted and how they are used.
 Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -172,7 +169,7 @@ If your protos depend on protos from other targets, add dependencies between the
 swift_proto_library targets which mirror the dependencies between the proto targets.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -20,10 +20,7 @@ load(
     "@bazel_skylib//lib:dicts.bzl",
     "dicts",
 )
-load(
-    "@rules_proto//proto:defs.bzl",
-    "ProtoInfo",
-)
+load("@protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load(
     "//proto:swift_proto_utils.bzl",
     "SwiftProtoCcInfo",

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -23,7 +23,6 @@ bzl_library(
     srcs = ["extras.bzl"],
     deps = [
         "@build_bazel_apple_support//lib:repositories",
-        "@rules_proto//proto:repositories",
     ],
 )
 
@@ -331,7 +330,7 @@ bzl_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//swift/internal:for_bazel_tests",
         "//swift/toolchains:for_bazel_tests",

--- a/swift/extras.bzl
+++ b/swift/extras.bzl
@@ -18,11 +18,7 @@ dependencies of the Swift rules.
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-load(
-    "@rules_proto//proto:repositories.bzl",
-    "rules_proto_dependencies",
-    "rules_proto_toolchains",
-)
+load("@protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 def swift_rules_extra_dependencies():
     """Fetches transitive repositories of the dependencies of `rules_swift`.
@@ -35,8 +31,6 @@ def swift_rules_extra_dependencies():
 
     apple_support_dependencies()
 
-    rules_proto_dependencies()
-
-    rules_proto_toolchains()
+    protobuf_deps()
 
     bazel_features_deps()

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -63,16 +63,6 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
 
         _maybe(
             http_archive,
-            name = "rules_proto",
-            urls = [
-                "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-            ],
-            sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-            strip_prefix = "rules_proto-5.3.0-21.7",
-        )
-
-        _maybe(
-            http_archive,
             name = "com_github_nlohmann_json",
             urls = [
                 "https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,10 +1,9 @@
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//third_party/bazel_protos:for_bazel_tests",
-        "//third_party/rules_proto:for_bazel_tests",
     ],
     visibility = [
         "//:__pkg__",

--- a/third_party/bazel_protos/BUILD
+++ b/third_party/bazel_protos/BUILD
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 licenses(["notice"])
 
@@ -17,7 +17,7 @@ cc_proto_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//third_party:__pkg__",

--- a/third_party/rules_proto/BUILD
+++ b/third_party/rules_proto/BUILD
@@ -1,9 +1,0 @@
-# Consumed by Bazel integration tests.
-filegroup(
-    name = "for_bazel_tests",
-    testonly = 1,
-    srcs = glob(["**"]),
-    visibility = [
-        "//third_party:__pkg__",
-    ],
-)

--- a/tools/protoc_wrapper/BUILD
+++ b/tools/protoc_wrapper/BUILD
@@ -6,7 +6,7 @@ package(default_visibility = ["//visibility:public"])
 
 universal_binary(
     name = "universal_protoc",
-    binary = "@com_google_protobuf//:protoc",
+    binary = "@protobuf//:protoc",
     tags = ["manual"],
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
@@ -18,7 +18,7 @@ alias(
     name = "protoc",
     actual = select({
         "//swift:universal_tools_config": ":universal_protoc",
-        "//conditions:default": "@com_google_protobuf//:protoc",
+        "//conditions:default": "@protobuf//:protoc",
     }),
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],


### PR DESCRIPTION
Trying my hand at this, to improve personal competency. This updates the minimum protobuf to 29.0, removes the dependency on rules_proto, and updates stardoc to 0.7.2. Some or all of this may be an overreach, but I'm unfamiliar with the constraints.
