### PR TITLE
Apply -enable-bare-slash-regex action config to SWIFT_ACTION_DERIVE_F…

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1137,6 +1137,7 @@ def compile_action_configs(
             actions = [
                 SWIFT_ACTION_COMPILE,
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                SWIFT_ACTION_DERIVE_FILES,
             ],
             configurators = [add_arg("-enable-bare-slash-regex")],
             features = [SWIFT_FEATURE_ENABLE_BARE_SLASH_REGEX],


### PR DESCRIPTION
…ILES

This action name was dropped when the declaration of this `ActionConfigInfo` was moved:
https://github.com/bazelbuild/rules_swift/commit/407becabb204c20a82e12f62818a1793ff36d853#diff-535d0dbea9614c6905a30dfdb0e708df3b16fc68f8930d6aba519342509dc657L347-L359

https://github.com/bazelbuild/rules_swift/commit/407becabb204c20a82e12f62818a1793ff36d853#diff-2785fcfbf39fcb0e5f53eb796c9711765273e1895af7213f7bdcbdcf6ed8a18eR1050-R1059