### PR TITLE
Add back emit swiftinterface feature

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "bool_setting")
 load(
     "//swift/internal:build_settings.bzl",
     "per_module_swiftcopt_flag",
@@ -378,6 +378,13 @@ swift_interop_hint(
 per_module_swiftcopt_flag(
     name = "per_module_swiftcopt",
     build_setting_default = [],
+)
+
+# Configuration setting for enabling the generation of swiftinterface files.
+bool_setting(
+    name = "emit_swiftinterface",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
 )
 
 # NOTE: Enabling this flag will transition --proto_compiler to

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -192,6 +192,9 @@ def swift_config_attrs():
         configuration settings.
     """
     return {
+        "_config_emit_swiftinterface": attr.label(
+            default = Label("//swift:emit_swiftinterface"),
+        ),
         "_per_module_swiftcopt": attr.label(
             default = Label("//swift:per_module_swiftcopt"),
         ),

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -144,7 +144,6 @@ def _swift_library_impl(ctx):
         extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
         extra_features.append(SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE)
     elif ctx.attr._config_emit_swiftinterface[BuildSettingInfo].value:
-        # TODO(b/239957001): Remove the global flag.
         extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
 
     module_name = ctx.attr.module_name

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "//swift/internal:attrs.bzl",
     "swift_deps_attr",
@@ -142,6 +143,9 @@ def _swift_library_impl(ctx):
         extra_features.append(SWIFT_FEATURE_ENABLE_LIBRARY_EVOLUTION)
         extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
         extra_features.append(SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE)
+    elif ctx.attr._config_emit_swiftinterface[BuildSettingInfo].value:
+        # TODO(b/239957001): Remove the global flag.
+        extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
 
     module_name = ctx.attr.module_name
     if not module_name:


### PR DESCRIPTION
This feature was removed recently in:
https://github.com/bazelbuild/rules_swift/pull/1393

At Snap, we were using this feature in our dependency injection system, without library evolution enabled.
We had to revert this PR in our internal rules_swift fork, and it would be nice to avoid having to keep rebasing that patch.

In the long term, I'll evaluate some other alternatives to parsing .swiftinterface files (potentially by parsing symbol graph files), or ask the swift team if it's possible to make this a supported configuration.