### PR TITLE
Introduce a Swift wrapper of the C++ runfiles library

### DIFF
--- a/examples/runfiles/BUILD
+++ b/examples/runfiles/BUILD
@@ -1,0 +1,13 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+
+swift_binary(
+    name = "runfiles",
+    srcs = ["main.swift"],
+    data = [
+        "data/sample.txt",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//swift/runfiles",
+    ],
+)

--- a/examples/runfiles/data/sample.txt
+++ b/examples/runfiles/data/sample.txt
@@ -1,0 +1,1 @@
+Hello runfiles

--- a/examples/runfiles/main.swift
+++ b/examples/runfiles/main.swift
@@ -1,3 +1,17 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import BazelRunfiles
 
 let runfiles = try Runfiles.create()

--- a/examples/runfiles/main.swift
+++ b/examples/runfiles/main.swift
@@ -18,7 +18,7 @@ let runfiles = try Runfiles.create()
 
 // Runfiles lookup paths have the form `my_workspace/package/file`.
 // Runfiles path lookup may return nil.
-guard let runFile = runfiles.rlocation("__main__/examples/runfiles/data/sample.txt") else {
+guard let runFile = runfiles.rlocation("build_bazel_rules_swift/examples/runfiles/data/sample.txt") else {
     fatalError("couldn't resolve runfile")
 }
 

--- a/examples/runfiles/main.swift
+++ b/examples/runfiles/main.swift
@@ -1,0 +1,17 @@
+import BazelRunfiles
+
+let runfiles = try Runfiles.create()
+
+// Runfiles lookup paths have the form `my_workspace/package/file`.
+// Runfiles path lookup may return nil.
+guard let runFile = runfiles.rlocation("runfiles/examples/runfiles/data/sample.txt") else {
+    fatalError("couldn't resolve runfile")
+}
+
+print(runFile)
+
+// Runfiles path lookup may return a non-existent path.
+let content = try String(contentsOfFile: runFile, encoding: .utf8)
+
+assert(content == "Hello runfiles")
+print(content)

--- a/examples/runfiles/main.swift
+++ b/examples/runfiles/main.swift
@@ -18,7 +18,7 @@ let runfiles = try Runfiles.create()
 
 // Runfiles lookup paths have the form `my_workspace/package/file`.
 // Runfiles path lookup may return nil.
-guard let runFile = runfiles.rlocation("runfiles/examples/runfiles/data/sample.txt") else {
+guard let runFile = runfiles.rlocation("__main__/examples/runfiles/data/sample.txt") else {
     fatalError("couldn't resolve runfile")
 }
 

--- a/swift/runfiles/BUILD
+++ b/swift/runfiles/BUILD
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@build_bazel_rules_swift//swift:swift_interop_hint.bzl", "swift_interop_hint")
+load("@build_bazel_rules_swift//swift:swift_library.bzl", "swift_library")
+
+cc_library(
+    name = "rules_cc_runfiles_wrapper",
+    srcs = ["runfiles.cc"],
+    hdrs = ["runfiles.h"],
+    deps = [
+        "@rules_cc//cc/runfiles",
+    ],
+    aspect_hints = [
+        ":swift_hint",
+    ],
+)
+
+swift_interop_hint(
+    name = "swift_hint",
+    module_name = "BazelCxxRunfiles",
+)
+
+swift_library(
+    name = "runfiles",
+    srcs = ["Runfiles.swift"],
+    deps = [
+        ":rules_cc_runfiles_wrapper",
+    ],
+    module_name = "BazelRunfiles",
+    visibility = ["//visibility:public"],
+)

--- a/swift/runfiles/BUILD
+++ b/swift/runfiles/BUILD
@@ -6,11 +6,11 @@ cc_library(
     name = "rules_cc_runfiles_wrapper",
     srcs = ["runfiles.cc"],
     hdrs = ["runfiles.h"],
-    deps = [
-        "@rules_cc//cc/runfiles",
-    ],
     aspect_hints = [
         ":swift_hint",
+    ],
+    deps = [
+        "@rules_cc//cc/runfiles",
     ],
 )
 
@@ -22,9 +22,9 @@ swift_interop_hint(
 swift_library(
     name = "runfiles",
     srcs = ["Runfiles.swift"],
+    module_name = "BazelRunfiles",
+    visibility = ["//visibility:public"],
     deps = [
         ":rules_cc_runfiles_wrapper",
     ],
-    module_name = "BazelRunfiles",
-    visibility = ["//visibility:public"],
 )

--- a/swift/runfiles/BUILD
+++ b/swift/runfiles/BUILD
@@ -10,7 +10,7 @@ cc_library(
         ":swift_hint",
     ],
     deps = [
-        "@rules_cc//cc/runfiles",
+        "@bazel_tools//tools/cpp/runfiles",
     ],
 )
 

--- a/swift/runfiles/README.md
+++ b/swift/runfiles/README.md
@@ -39,9 +39,9 @@ let filePath = runfiles?.rlocation("my_workspace/path/to/my/data.txt")
   variables. If not present, the function looks for the manifest and directory
   near CommandLine.arguments.first (argv[0]), the path of the main program.
 
-If you want to start subprocesses, and the subprocess can't automatically
-find the correct runfiles directory, you can explicitly set the right
-environment variables for them:
+If you want to start subprocesses, and those subprocesses need to resolve
+runfiles themselves, you need to explicitly set the right environment variables
+for them:
 
 ```swift
 import Foundation

--- a/swift/runfiles/README.md
+++ b/swift/runfiles/README.md
@@ -1,0 +1,67 @@
+# Swift BazelRunfiles library
+
+This is a Bazel Runfiles lookup library for Bazel-built Swift binaries and tests.
+
+Learn about runfiles: read [Runfiles guide](https://bazel.build/extending/rules#runfiles)
+or watch [Fabian's BazelCon talk](https://www.youtube.com/watch?v=5NbgUMH1OGo).
+
+## Usage
+
+1.  Depend on this runfiles library from your build rule:
+
+```python
+swift_binary(
+    name = "my_binary",
+    ...
+    data = ["//path/to/my/data.txt"],
+    deps = ["@build_bazel_rules_swift//swift/runfiles"],
+)
+```
+
+2.  Include the runfiles library:
+
+```swift
+import BazelRunfiles
+```
+
+3.  Create a Runfiles instance and use `rlocation` to look up runfile urls:
+
+```swift
+import BazelRunfiles
+
+let runfiles = try? Runfiles.create()
+
+let filePath = runfiles?.rlocation("my_workspace/path/to/my/data.txt")
+```
+
+> The Runfiles.create function uses the runfiles manifest and the runfiles
+  directory from the RUNFILES_MANIFEST_FILE and RUNFILES_DIR environment
+  variables. If not present, the function looks for the manifest and directory
+  near CommandLine.arguments.first (argv[0]), the path of the main program.
+
+If you want to start subprocesses, and the subprocess can't automatically
+find the correct runfiles directory, you can explicitly set the right
+environment variables for them:
+
+```swift
+import Foundation
+import BazelRunfiles
+
+let runfiles = try? Runfiles.create()
+
+guard let executable = runfiles.rlocation("my_workspace/path/to/binary") else {
+    return
+}
+
+let process = Process()
+process.executableURL = URL(string: executable)
+process.environment = runfiles.envVars()
+
+do {
+    // Launch the process
+    try process.run()
+    process.waitUntilExit()
+} catch {
+    // ...
+}
+```

--- a/swift/runfiles/Runfiles.swift
+++ b/swift/runfiles/Runfiles.swift
@@ -100,8 +100,6 @@ public final class Runfiles {
   /// manifest or directory using the other environment variable, or using
   /// CommandLine.arguments[0] under the hood.
   ///
-  /// - Important: Use `createForTest` inside tests.
-  ///
   /// - Parameters:
   ///   - sourceRepository: the canonical name of the repository whose
   ///     repository mapping should be used to resolve apparent to canonical

--- a/swift/runfiles/Runfiles.swift
+++ b/swift/runfiles/Runfiles.swift
@@ -93,22 +93,6 @@ public final class Runfiles {
 
   // MARK: Factory methods
 
-  /// Returns a new `Runfiles` instance.
-  ///
-  /// Use this from within `swift_test` rules.
-  ///
-  /// This method looks at the RUNFILES_MANIFEST_FILE and TEST_SRCDIR
-  /// environment variables.
-  public static func createForTest(
-    sourceRepository: String? = nil,
-    _ callerFilePath: String = #filePath
-  )
-    throws -> Runfiles {
-    try createInternal { error in
-      Runfiles_CreateForTest(sourceRepository ?? Self.repository(from: callerFilePath), error)
-    }
-  }
-
   /// Returns a new `Runfiles`` instance.
   ///
   /// This method looks at the RUNFILES_MANIFEST_FILE and RUNFILES_DIR

--- a/swift/runfiles/Runfiles.swift
+++ b/swift/runfiles/Runfiles.swift
@@ -1,0 +1,209 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import BazelCxxRunfiles
+import Foundation
+
+enum RunfilesError: Error {
+  case runtimeError(String)
+  case unknown
+}
+
+typealias RunfilesHandle = UnsafeMutableRawPointer
+
+/// Returns the runtime location of runfiles.
+///
+/// Runfiles are data-dependencies of Bazel-built binaries and tests.
+public final class Runfiles {
+
+  private var handle: RunfilesHandle
+
+  private init(handle: RunfilesHandle) {
+    self.handle = handle
+  }
+
+  // MARK: API
+
+  /// Returns the runtime path of a runfile.
+  ///
+  /// Runfiles are data-dependencies of Bazel-built binaries and tests.
+  ///
+  /// The returned path may not exist. The caller should verify the path's
+  /// validity and existence.
+  ///
+  /// - Parameters:
+  ///   - path: runfiles-root-relative path of the runfile
+  ///   - sourceRepository: the canonical name of the repository whose
+  ///     repository mapping should be used to resolve apparent to canonical
+  ///     repository names in `path`. If not provided (default), the
+  ///     repository mapping of the repository containing the caller of this
+  ///     method is used.
+  public func rlocation(_ path: String, sourceRepository: String? = nil) -> String? {
+    let result: UnsafeMutablePointer<CChar> = if let sourceRepository {
+      Runfiles_RlocationFrom(handle, path, sourceRepository)
+    } else {
+      Runfiles_Rlocation(handle, path)
+    }
+    return result.pointee == 0 ? nil : String(cString: result)
+  }
+
+  /// Returns additional environment variables to pass to subprocesses.
+  ///
+  /// Pass these variables to Bazel-built binaries so they can find their
+  /// runfiles as well.
+  public func envVars() -> [String: String] {
+    var size = 0
+    guard let cPairs = Runfiles_EnvVars(handle, &size) else {
+      return [:]
+    }
+
+    var result: [String: String] = [:]
+    // Process the char **: even = key, odd = value
+    for i in stride(from: 0, to: size, by: 2) {
+      guard let keyPointer = cPairs[i], let valuePointer = cPairs[i + 1] else {
+        break
+      }
+      result[String(cString: keyPointer)] = String(cString: valuePointer)
+
+      free(keyPointer)
+      free(valuePointer)
+    }
+    free(cPairs)
+
+    return result
+  }
+
+  /// Returns a Runfiles instance identical to the current one, except that it
+  /// uses the given repository's repository mapping when resolving runfiles
+  /// paths.
+  public func with(sourceRepository: String) -> Runfiles {
+    Runfiles(handle: Runfiles_WithSourceRepository(handle, sourceRepository))
+  }
+
+  // MARK: Factory methods
+
+  /// Returns a new `Runfiles` instance.
+  ///
+  /// Use this from within `swift_test` rules.
+  ///
+  /// This method looks at the RUNFILES_MANIFEST_FILE and TEST_SRCDIR
+  /// environment variables.
+  public static func createForTest(
+    sourceRepository: String? = nil,
+    _ callerFilePath: String = #filePath
+  )
+    throws -> Runfiles {
+    try createInternal { error in
+      Runfiles_CreateForTest(sourceRepository ?? Self.repository(from: callerFilePath), error)
+    }
+  }
+
+  /// Returns a new `Runfiles`` instance.
+  ///
+  /// This method looks at the RUNFILES_MANIFEST_FILE and RUNFILES_DIR
+  /// environment variables. If either is empty, the method looks for the
+  /// manifest or directory using the other environment variable, or using
+  /// CommandLine.arguments[0] under the hood.
+  ///
+  /// - Important: Use `createForTest` inside tests.
+  ///
+  /// - Parameters:
+  ///   - sourceRepository: the canonical name of the repository whose
+  ///     repository mapping should be used to resolve apparent to canonical
+  ///     repository names in `path` provided to `rlocation`.
+  ///     Should be left unset unless you need to pass down a runfiles instance
+  ///     into a separate library that needs to do its own lookups with it.
+  ///   - callerFilePath: This parameter should never be set as it relies on
+  ///     Swift callsite built-in macro expansion to retrieve the file path of
+  ///     the caller function that called this factory method and auto deduce
+  ///     the canonical repository name of the repository of that calling
+  ///     function.
+  public static func create(
+    sourceRepository: String? = nil,
+    _ callerFilePath: String = #filePath
+  )
+    throws -> Runfiles {
+    try createInternal { error in
+      Runfiles_Create(CommandLine.arguments[0], sourceRepository ?? Self.repository(from: callerFilePath), error)
+    }
+  }
+
+  /// Returns a new `Runfiles` instance.
+  ///
+  /// Use this from any `swift_*` rule if you want to manually specify the paths
+  /// to the runfiles manifest and/or runfiles directory.
+  ///
+  /// This method is the same as `Runfiles.create(sourceRepository:_)`, except
+  /// it uses `runfilesManifestFile` and `runfilesDir` as the corresponding
+  /// environment variable values, instead of looking up the actual environment
+  /// variables.
+  public static func create(
+    runfilesManifestFile: String,
+    runfilesDir: String,
+    sourceRepository: String? = nil,
+    _ callerFilePath: String = #filePath
+  )
+    throws -> Runfiles {
+    try createInternal { error in
+      Runfiles_Create2(
+        CommandLine.arguments[0],
+        runfilesManifestFile,
+        runfilesDir,
+        sourceRepository ?? Self.repository(from: callerFilePath),
+        error
+      )
+    }
+  }
+
+  // MARK: Helper
+
+  private static func createInternal(
+    _ createHandle: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) -> UnsafeMutableRawPointer?
+  )
+    throws -> Runfiles {
+    var error: UnsafeMutablePointer<CChar>? = nil
+    guard let handle = createHandle(&error) else {
+      if let error {
+        let errorStr = String(cString: error)
+        free(error)
+        throw RunfilesError.runtimeError(errorStr)
+      }
+      throw RunfilesError.unknown
+    }
+    return Runfiles(handle: handle)
+  }
+
+  // https://github.com/bazel-contrib/rules_go/blob/6505cf2e4f0a768497b123a74363f47b711e1d02/go/runfiles/global.go#L53-L54
+  private static let legacyExternalGeneratedFile = /bazel-out\/[^\/]+\/bin\/external\/([^\/]+)/
+  private static let legacyExternalFile = /external\/([^\/]+)/
+
+  // Extracts the canonical name of the repository containing the file
+  // located at `path`.
+  private static func repository(from path: String) -> String {
+    if let match = path.prefixMatch(of: legacyExternalGeneratedFile) {
+      return String(match.1)
+    }
+    if let match = path.prefixMatch(of: legacyExternalFile) {
+      return String(match.1)
+    }
+    // If a file is not in an external repository, return an empty string
+    return ""
+  }
+
+  // MARK: deinit
+
+  deinit {
+    Runfiles_Destroy(handle)
+  }
+}

--- a/swift/runfiles/runfiles.cc
+++ b/swift/runfiles/runfiles.cc
@@ -1,0 +1,105 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rules_cc/cc/runfiles/runfiles.h"
+
+static char *CopyStringToC(const std::string &str) {
+  char *cstr = static_cast<char *>(std::malloc(str.size() + 1));
+  std::memcpy(cstr, str.data(), str.size());
+  cstr[str.size()] = '\0';
+  return cstr;
+}
+
+extern "C" {
+
+void *Runfiles_CreateForTest(const char *source_repository, char **error) {
+  std::string err;
+  auto *runfiles = rules_cc::cc::runfiles::Runfiles::CreateForTest(
+      std::string(source_repository), &err);
+  if (!runfiles && error) {
+    *error = CopyStringToC(err);
+    return nullptr;
+  }
+  return runfiles;
+}
+
+void *Runfiles_Create(const char *argv0, const char *source_repository,
+                      char **error) {
+  std::string err;
+  auto *runfiles = rules_cc::cc::runfiles::Runfiles::Create(
+      std::string(argv0), std::string(source_repository), &err);
+  if (!runfiles && error) {
+    *error = CopyStringToC(err);
+    return nullptr;
+  }
+  return runfiles;
+}
+
+void *Runfiles_Create2(const char *argv0, const char *runfiles_manifest_file,
+                       const char *runfiles_dir, const char *source_repository,
+                       char **error) {
+  std::string err;
+  auto *runfiles = rules_cc::cc::runfiles::Runfiles::Create(
+      std::string(argv0), std::string(runfiles_manifest_file),
+      std::string(runfiles_dir), std::string(source_repository), &err);
+  if (!runfiles && error) {
+    *error = CopyStringToC(err);
+    return nullptr;
+  }
+  return runfiles;
+}
+
+char *Runfiles_Rlocation(void *handle, const char *path) {
+  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  std::string result = runfiles->Rlocation(std::string(path));
+  return CopyStringToC(result);
+}
+
+char *Runfiles_RlocationFrom(void *handle, const char *path,
+                             const char *source_repository) {
+  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  std::string result =
+      runfiles->Rlocation(std::string(path), std::string(source_repository));
+  return CopyStringToC(result);
+}
+
+char **Runfiles_EnvVars(void *handle, size_t *size) {
+  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto &envVars = runfiles->EnvVars();
+  char **cArray =
+      static_cast<char **>(std::malloc(envVars.size() * 2 * sizeof(char *)));
+
+  size_t index = 0;
+  for (const auto &pair : envVars) {
+    cArray[index++] = CopyStringToC(pair.first);   // Copy key
+    cArray[index++] = CopyStringToC(pair.second);  // Copy value
+  }
+
+  *size = envVars.size() * 2;
+  return cArray;
+}
+
+void *Runfiles_WithSourceRepository(void *handle,
+                                    const char *source_repository) {
+  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto runfiles_new = runfiles->WithSourceRepository(source_repository);
+  return runfiles_new.release();
+}
+
+void Runfiles_Destroy(void *handle) {
+  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  delete runfiles;
+}
+
+}  // extern "C"

--- a/swift/runfiles/runfiles.cc
+++ b/swift/runfiles/runfiles.cc
@@ -23,17 +23,6 @@ static char *CopyStringToC(const std::string &str) {
 
 extern "C" {
 
-void *Runfiles_CreateForTest(const char *source_repository, char **error) {
-  std::string err;
-  auto *runfiles = rules_cc::cc::runfiles::Runfiles::CreateForTest(
-      std::string(source_repository), &err);
-  if (!runfiles && error) {
-    *error = CopyStringToC(err);
-    return nullptr;
-  }
-  return runfiles;
-}
-
 void *Runfiles_Create(const char *argv0, const char *source_repository,
                       char **error) {
   std::string err;

--- a/swift/runfiles/runfiles.cc
+++ b/swift/runfiles/runfiles.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tools/cpp/runfiles/runfiles.h"
+#include <cstring>
 
 static char *CopyStringToC(const std::string &str) {
   char *cstr = static_cast<char *>(std::malloc(str.size() + 1));

--- a/swift/runfiles/runfiles.cc
+++ b/swift/runfiles/runfiles.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tools/cpp/runfiles/runfiles.h"
+
 #include <cstring>
 
 static char *CopyStringToC(const std::string &str) {

--- a/swift/runfiles/runfiles.cc
+++ b/swift/runfiles/runfiles.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rules_cc/cc/runfiles/runfiles.h"
+#include "tools/cpp/runfiles/runfiles.h"
 
 static char *CopyStringToC(const std::string &str) {
   char *cstr = static_cast<char *>(std::malloc(str.size() + 1));
@@ -26,7 +26,7 @@ extern "C" {
 void *Runfiles_Create(const char *argv0, const char *source_repository,
                       char **error) {
   std::string err;
-  auto *runfiles = rules_cc::cc::runfiles::Runfiles::Create(
+  auto *runfiles = bazel::tools::cpp::runfiles::Runfiles::Create(
       std::string(argv0), std::string(source_repository), &err);
   if (!runfiles && error) {
     *error = CopyStringToC(err);
@@ -39,7 +39,7 @@ void *Runfiles_Create2(const char *argv0, const char *runfiles_manifest_file,
                        const char *runfiles_dir, const char *source_repository,
                        char **error) {
   std::string err;
-  auto *runfiles = rules_cc::cc::runfiles::Runfiles::Create(
+  auto *runfiles = bazel::tools::cpp::runfiles::Runfiles::Create(
       std::string(argv0), std::string(runfiles_manifest_file),
       std::string(runfiles_dir), std::string(source_repository), &err);
   if (!runfiles && error) {
@@ -50,21 +50,21 @@ void *Runfiles_Create2(const char *argv0, const char *runfiles_manifest_file,
 }
 
 char *Runfiles_Rlocation(void *handle, const char *path) {
-  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto *runfiles = static_cast<bazel::tools::cpp::runfiles::Runfiles *>(handle);
   std::string result = runfiles->Rlocation(std::string(path));
   return CopyStringToC(result);
 }
 
 char *Runfiles_RlocationFrom(void *handle, const char *path,
                              const char *source_repository) {
-  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto *runfiles = static_cast<bazel::tools::cpp::runfiles::Runfiles *>(handle);
   std::string result =
       runfiles->Rlocation(std::string(path), std::string(source_repository));
   return CopyStringToC(result);
 }
 
 char **Runfiles_EnvVars(void *handle, size_t *size) {
-  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto *runfiles = static_cast<bazel::tools::cpp::runfiles::Runfiles *>(handle);
   auto &envVars = runfiles->EnvVars();
   char **cArray =
       static_cast<char **>(std::malloc(envVars.size() * 2 * sizeof(char *)));
@@ -81,13 +81,13 @@ char **Runfiles_EnvVars(void *handle, size_t *size) {
 
 void *Runfiles_WithSourceRepository(void *handle,
                                     const char *source_repository) {
-  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto *runfiles = static_cast<bazel::tools::cpp::runfiles::Runfiles *>(handle);
   auto runfiles_new = runfiles->WithSourceRepository(source_repository);
   return runfiles_new.release();
 }
 
 void Runfiles_Destroy(void *handle) {
-  auto *runfiles = static_cast<rules_cc::cc::runfiles::Runfiles *>(handle);
+  auto *runfiles = static_cast<bazel::tools::cpp::runfiles::Runfiles *>(handle);
   delete runfiles;
 }
 

--- a/swift/runfiles/runfiles.h
+++ b/swift/runfiles/runfiles.h
@@ -43,6 +43,4 @@ void *Runfiles_WithSourceRepository(void *handle,
 
 void Runfiles_Destroy(void *handle);
 
-// } // namespace swiftrunfiles
-
 #endif

--- a/swift/runfiles/runfiles.h
+++ b/swift/runfiles/runfiles.h
@@ -1,0 +1,48 @@
+// Copyright 2024 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This header file defines a C API wrapper for the C++ Runfiles lookup library.
+// The original C++ library was not directly compatible with Swift C++ interop
+// (std::vector, std::unique_ptr, no copy ctors), hence the need for a wrapper.
+// 
+// Additionally, using a C++ API would have required users to manually set
+// `-cxx-interoperability-mode=default`, hence the decision to use a C API which
+// makes that transparent.
+
+#ifndef _RULES_SWIFT_RUNFILES_H_
+#define _RULES_SWIFT_RUNFILES_H_ 1
+
+#include <stddef.h>
+
+void *Runfiles_CreateForTest(const char *source_repository, char **error);
+void *Runfiles_Create(const char *argv0, const char *source_repository,
+                      char **error);
+void *Runfiles_Create2(const char *argv0, const char *runfiles_manifest_file,
+                       const char *runfiles_dir, const char *source_repository,
+                       char **error);
+
+char *Runfiles_Rlocation(void *handle, const char *path);
+char *Runfiles_RlocationFrom(void *handle, const char *path,
+                             const char *source_repository);
+
+char **Runfiles_EnvVars(void *handle, size_t *size);
+
+void *Runfiles_WithSourceRepository(void *handle,
+                                    const char *source_repository);
+
+void Runfiles_Destroy(void *handle);
+
+// } // namespace swiftrunfiles
+
+#endif

--- a/swift/runfiles/runfiles.h
+++ b/swift/runfiles/runfiles.h
@@ -25,7 +25,6 @@
 
 #include <stddef.h>
 
-void *Runfiles_CreateForTest(const char *source_repository, char **error);
 void *Runfiles_Create(const char *argv0, const char *source_repository,
                       char **error);
 void *Runfiles_Create2(const char *argv0, const char *runfiles_manifest_file,


### PR DESCRIPTION
Second shot at implementing #890 

This PR introduces a Swift runfiles lookup library.

After discussion, it was decided to give a go to wrapping the C++ runfiles library instead of writing one in pure Swift.

# Implementation

This implementation is done in 2 parts:
1. A C++ wrapper to the original C++ library, exposed as a C API.
2. A Swift wrapper to the C API.

## C++ wrapper as C API

I took the decision to expose the C++ runfiles library to Swift via a C API for the following reasons:

The original C++ runfiles library was not compatible with Swift C++ interop out of the box:
1. References to types such as `std::unique_ptr` in the public API (https://www.swift.org/documentation/cxx-interop/#unique-reference-types)
2. Swift considers C++ classes as value types and requires them to have a copy constructor unless the type itself is annotated accordingly which is not possible when wrapping (https://www.swift.org/documentation/cxx-interop/#mapping-c-types-to-swift-reference-types)
It would fail with an error like this: ```note: record 'Runfiles' is not automatically available: does not have a copy constructor or destructor; does this type have reference semantics?```

Using C++ interop currently forces users to provide `-cxx-interoperability-mode=default` down the line, otherwise the header from the generted module map is treated as C and not C++.

For those reasons, I chose the C API approach which makes everything invisible to users of the library.

## Swift Wrapper

The Swift wrapper is _just_ a wrapper around around the C API with 3 exceptions:
1. We use `CommandLine.arguments[0]` automatically instead of requiring users to pass `argv0` like it is the case in the C++ library.
2. We automatically compute the caller's canonical repository name if it is not provided (See explanation below).
3. `rlocation` returns `nil` instead of an empty string if repository mappings fail.

### Source Repository 

The runfiles library needs to know the canonical name of the repository that is trying to resolve a particular runfile path.
This is required to map apparent repository names used in the runfile path, to its canonical repo name on the filesystem.

Every ruleset has its own way of making this transparent to the users of the runfiles library (Except C++ and Java), most of them rely on runtime accessors or language specific features that do not exist in Swift.

Here, we rely on the built-in #filePath magic identifier which has the property to be expanded at callsite when used as a default argument, the same way `assert` and `fatalError` work.

I couldn't find the specification for this behavior except the below mention in an accepted Swift proposal:
https://github.com/swiftlang/swift-evolution/blob/80c3616bb23e7bf751f886aaf178acb3df09abe5/proposals/0274-magic-file.md#provide-separate-modulename-and-filename-magic-identifiers:
> Magic identifiers only give you the caller's location if they are the only thing in the default argument

From that #filePath, we deduce the canonical repository name the same way `rules_go` does (thanks @fmeum).
See https://github.com/bazel-contrib/rules_go/blob/6505cf2e4f0a768497b123a74363f47b711e1d02/go/runfiles/global.go#L53-L80

# Additional notes

1. I didn't include tests at this stage on purpose before we settle on the API. Also, because this is a wrapper reusing a battle tested C++ library, I would like to discuss which tests make sense to write :)

2. Because we always compute the source canonical repository name, I didn't expose variants of the C++ API that do not require it.

3. In the original pure Swift implementation, I had `rlocation` return a `URL` instead of a `String`, let me know if I should use that instead.

4. Finally, all rulesets providing a runfiles library provide a `env` and `args` attributes to `*_binary` that are subject to Make Variable substitution (for `$(rlocationpath //target) most notably)` , let me know this is something we want and if I should submit a PR for that.

# TODO

- [ ] Discuss test strategy
- [ ] Implement tests

# Links

* [C++ runfiles libray](https://github.com/bazelbuild/rules_cc/tree/8c94e11c2b05b5f25ced5f23cd07d0cdd36edc1a/cc/runfiles)
* [Slack Discussion](https://bazelbuild.slack.com/archives/CD3QY5C2X/p1734366224530039)