### PR TITLE
Map const-values in output file map for incremental

### DIFF
--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -99,8 +99,8 @@ void OutputFileMap::UpdateForIncremental(
       auto kind = output.key();
       auto path = output.value().get<std::string>();
 
-      if (kind == "object") {
-        // If the file kind is "object", we want to update the path to point to
+      if (kind == "object" || kind == "const-values") {
+        // If the file kind is "object" or "const-values", we want to update the path to point to
         // the incremental storage area and then add a "swift-dependencies"
         // in the same location.
         auto new_path = MakeIncrementalOutputPath(path, derived);


### PR DESCRIPTION
Since we extracting `swiftconstvalues` from https://github.com/bazelbuild/rules_swift/pull/1170
But we forgot to update the path for swiftconstvalues in the incremental output file map.
It leads to the incremental feature not working.

For example, demo: https://github.com/vikage/DemoBazelSwiftIncremental
When I change file B.swift (No other file uses struct B) but log shows build A.swift and C.swift as well

I used `-driver-show-job-lifecycle` and `-driver-show-incremental` flags to show debug log
```
WARNING: Build option --swiftcopt has changed, discarding analysis cache (this can be expensive, see https://bazel.build/advanced/performance/iteration-speed).
INFO: Analyzed target //:Demo (99 packages loaded, 1088 targets configured).
INFO: From Compiling Swift module //:Demo:
remark: Incremental compilation: Read dependency graph '/private/var/tmp/_bazel_elliotvu/e512a8189164dd2ae5386a6bdb0cc34e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/_swift_incremental/Demo.output_file_map.priors'
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: May skip current input:  {compile: B.swift.o <= B.swift}
remark: Incremental compilation: May skip current input:  {compile: C.swift.o <= C.swift}
remark: Incremental compilation: Missing an output; will queue  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Missing an output; will queue  {compile: B.swift.o <= B.swift}
remark: Incremental compilation: Missing an output; will queue  {compile: C.swift.o <= C.swift}
remark: Incremental compilation: Queuing (initial):  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Queuing (initial):  {compile: B.swift.o <= B.swift}
remark: Incremental compilation: Queuing (initial):  {compile: C.swift.o <= C.swift}
remark: Found 3 batchable jobs
remark: Forming into 1 batch
remark: Adding {compile: A.swift} to batch 0
remark: Adding {compile: B.swift} to batch 0
remark: Adding {compile: C.swift} to batch 0
remark: Forming batch job from 3 constituents: A.swift, B.swift, C.swift
remark: Starting Emitting module for Demo
remark: Finished Emitting module for Demo
remark: Starting Compiling A.swift, B.swift, C.swift
remark: Finished Compiling A.swift, B.swift, C.swift
remark: Incremental compilation: Reading dependencies from A.swift
remark: Incremental compilation: Reading dependencies from B.swift
remark: Incremental compilation: Reading dependencies from C.swift
remark: Incremental compilation: Scheduling all post-compile jobs because something was compiled
```

These are logs after fix. As you can see, only B.swift will be compile
```
INFO: Analyzed target //:Demo (0 packages loaded, 0 targets configured).
INFO: From Compiling Swift module //:Demo:
remark: Incremental compilation: Read dependency graph '/private/var/tmp/_bazel_elliotvu/e512a8189164dd2ae5386a6bdb0cc34e/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/_swift_incremental/Demo.output_file_map.priors'
remark: Incremental compilation: Enabling incremental cross-module building
remark: Incremental compilation: May skip current input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Scheduling changed input  {compile: B.swift.o <= B.swift}
remark: Incremental compilation: May skip current input:  {compile: C.swift.o <= C.swift}
remark: Incremental compilation: Queuing (initial):  {compile: B.swift.o <= B.swift}
remark: Incremental compilation: not scheduling dependents of B.swift; unknown changes
remark: Incremental compilation: Skipping input:  {compile: A.swift.o <= A.swift}
remark: Incremental compilation: Skipping input:  {compile: C.swift.o <= C.swift}
remark: Found 1 batchable job
remark: Forming into 1 batch
remark: Adding {compile: B.swift} to batch 0
remark: Forming batch job from 1 constituents: B.swift
remark: Starting Emitting module for Demo
remark: Finished Emitting module for Demo
remark: Starting Compiling B.swift
remark: Finished Compiling B.swift
remark: Incremental compilation: Reading dependencies from B.swift
remark: Incremental compilation: Fingerprint changed for existing interface of top-level name 'B' in B.swift
remark: Incremental compilation: Fingerprint changed for existing implementation of top-level name 'B' in B.swift
remark: Incremental compilation: Fingerprint changed for existing interface of type '4Demo1BV' in B.swift
remark: Incremental compilation: Fingerprint changed for existing implementation of type '4Demo1BV' in B.swift
remark: Incremental compilation: Fingerprint changed for existing interface of potential members of '4Demo1BV' in B.swift
remark: Incremental compilation: Fingerprint changed for existing implementation of potential members of '4Demo1BV' in B.swift
remark: Incremental compilation: Scheduling all post-compile jobs because something was compiled
remark: Skipped Compiling A.swift
remark: Skipped Compiling C.swift
```

The solution here should be to remap swiftconstvalues path to `_swift_incremental` directory 
Related issue: https://github.com/bazelbuild/rules_swift/issues/1291