### PR TITLE
Include swift_proto_library attrs in compilation

### DIFF
--- a/proto/swift_proto_utils.bzl
+++ b/proto/swift_proto_utils.bzl
@@ -263,11 +263,11 @@ def compile_swift_protos_for_target(
     compile_result = swift_common.compile(
         actions = ctx.actions,
         cc_infos = get_providers(compiler_deps, CcInfo),
-        copts = ["-parse-as-library"],
+        copts = ["-parse-as-library"] + getattr(attr, "copts", []),
         feature_configuration = feature_configuration,
         include_dev_srch_paths = include_dev_srch_paths,
         module_name = module_name,
-        package_name = None,
+        package_name = getattr(attr, "package_name", None),
         srcs = generated_swift_srcs,
         swift_toolchain = swift_toolchain,
         swift_infos = get_providers(compiler_deps, SwiftInfo),


### PR DESCRIPTION
Using `package_name` or `copt` attributes weren't being propogated down into the actual swiftc compilation.