### PR TITLE
Mark non_module_deps extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     repo_name = "build_bazel_rules_swift",
 )
 
-bazel_dep(name = "bazel_features", version = "1.3.0")
+bazel_dep(name = "bazel_features", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.0.2")

--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -14,9 +14,18 @@
 
 """Definitions for bzlmod module extensions."""
 
+load("@bazel_features//:features.bzl", "bazel_features")
 load("//swift:repositories.bzl", "swift_rules_dependencies")
 
-def _non_module_deps_impl(_):
+def _non_module_deps_impl(module_ctx):
     swift_rules_dependencies(include_bzlmod_ready_dependencies = False)
+
+    metadata_kwargs = {}
+    if bazel_features.external_deps.extension_metadata_has_reproducible:
+        metadata_kwargs["reproducible"] = True
+
+    return module_ctx.extension_metadata(
+        **metadata_kwargs,
+    )
 
 non_module_deps = module_extension(implementation = _non_module_deps_impl)

--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -25,7 +25,7 @@ def _non_module_deps_impl(module_ctx):
         metadata_kwargs["reproducible"] = True
 
     return module_ctx.extension_metadata(
-        **metadata_kwargs,
+        **metadata_kwargs
     )
 
 non_module_deps = module_extension(implementation = _non_module_deps_impl)


### PR DESCRIPTION
As per https://bazelbuild.slack.com/archives/C04DFUBQGSU/p1737756347358239

I was curious about the "reproducibility" of `swift_autoconfiguration` but from a `MODULE.bazel.lock` it seems it is.

I had to bump `bazel_features` to `1.9.0` to check the availability of the `reproducible` field on `extension_metadata`.