### PR TITLE
Print a warning, instead of an error, when not finding `swiftc.exe`

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -352,7 +352,18 @@ def _get_python_bin(repository_ctx):
 def _create_windows_toolchain(repository_ctx):
     path_to_swiftc = repository_ctx.which("swiftc.exe")
     if not path_to_swiftc:
-        fail("No 'swiftc.exe' executable found in Path")
+        print("""\
+No 'swiftc.exe' executable found in $PATH. Not auto-generating a Windows Swift \
+toolchain.
+""")  # buildifier: disable=print
+        repository_ctx.file(
+            "BUILD",
+            """\
+# No 'swiftc.exe' executable found in $PATH. Not auto-generating a Windows \
+Swift toolchain.
+""",
+        )
+        return
 
     root = path_to_swiftc.dirname.dirname
     enabled_features = [


### PR DESCRIPTION
Similar to bd0e6e009165b8826f51f682bd9bd55b9f969a0e.