### PR TITLE
Remove `swift_toolchain_attrs` usage

### DIFF
--- a/mixed_language/internal/library.bzl
+++ b/mixed_language/internal/library.bzl
@@ -25,7 +25,7 @@ load(
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:attrs.bzl", "swift_deps_attr", "swift_toolchain_attrs")
+load("//swift/internal:attrs.bzl", "swift_deps_attr")
 
 # buildifier: disable=bzl-visibility
 load(
@@ -216,7 +216,6 @@ def _mixed_language_library_impl(ctx):
 
 mixed_language_library = rule(
     attrs = dicts.add(
-        swift_toolchain_attrs(),
         {
             "clang_target": attr.label(
                 doc = """

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -76,7 +76,6 @@ bzl_library(
     deps = [
         ":module_name",
         ":providers",
-        "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
         "//swift/internal:features",
@@ -229,7 +228,6 @@ bzl_library(
     deps = [
         ":module_name",
         ":providers",
-        "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:features",
         "//swift/internal:linking",

--- a/swift/internal/attrs.bzl
+++ b/swift/internal/attrs.bzl
@@ -102,7 +102,6 @@ def swift_compilation_attrs(
             additional_deps_aspects = additional_deps_aspects,
             additional_deps_providers = additional_deps_providers,
         ),
-        swift_toolchain_attrs(),
         {
             "copts": attr.string_list(
                 doc = """\

--- a/swift/internal/swift_symbol_graph_aspect.bzl
+++ b/swift/internal/swift_symbol_graph_aspect.bzl
@@ -24,7 +24,6 @@ file in the parent directory.
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("//swift:providers.bzl", "SwiftInfo", "SwiftSymbolGraphInfo")
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load("//swift/internal:features.bzl", "configure_features")
 load("//swift/internal:symbol_graph_extracting.bzl", "extract_symbol_graph")
 load(
@@ -148,7 +147,6 @@ def make_swift_symbol_graph_aspect(
     return aspect(
         attr_aspects = ["deps"],
         attrs = dicts.add(
-            swift_toolchain_attrs(),
             {
                 # TODO: use `attr.bool` once https://github.com/bazelbuild/bazel/issues/22809 is resolved.
                 "emit_extension_block_symbols": attr.string(

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -15,7 +15,6 @@
 """Propagates unified `SwiftInfo` providers for C/Objective-C targets."""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load("//swift/internal:compiling.bzl", "precompile_clang_module")
 load(
     "//swift/internal:feature_names.bzl",
@@ -562,10 +561,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
         module_map_file = None
         module_name = None
 
-    swift_toolchain = get_swift_toolchain(
-        aspect_ctx,
-        attr = "_toolchain_for_aspect",
-    )
+    swift_toolchain = get_swift_toolchain(aspect_ctx)
     feature_configuration = configure_features(
         ctx = aspect_ctx,
         requested_features = requested_features,
@@ -598,9 +594,6 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
 
 swift_clang_module_aspect = aspect(
     attr_aspects = _MULTIPLE_TARGET_ASPECT_ATTRS,
-    attrs = swift_toolchain_attrs(
-        toolchain_attr_name = "_toolchain_for_aspect",
-    ),
     doc = """\
 Propagates unified `SwiftInfo` providers for targets that represent
 C/Objective-C modules.

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -15,11 +15,7 @@
 """Implementation of the `swift_import` rule."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load(
-    "//swift/internal:attrs.bzl",
-    "swift_common_rule_attrs",
-    "swift_toolchain_attrs",
-)
+load("//swift/internal:attrs.bzl", "swift_common_rule_attrs")
 load("//swift/internal:compiling.bzl", "compile_module_interface")
 load(
     "//swift/internal:features.bzl",
@@ -165,7 +161,6 @@ def _swift_import_impl(ctx):
 swift_import = rule(
     attrs = dicts.add(
         swift_common_rule_attrs(),
-        swift_toolchain_attrs(),
         {
             "archives": attr.label_list(
                 allow_empty = True,

--- a/swift/swift_module_alias.bzl
+++ b/swift/swift_module_alias.bzl
@@ -15,7 +15,6 @@
 """Implementation of the `swift_module_alias` rule."""
 
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
-load("//swift/internal:attrs.bzl", "swift_toolchain_attrs")
 load("//swift/internal:compiling.bzl", "compile")
 load("//swift/internal:features.bzl", "configure_features")
 load(
@@ -152,7 +151,6 @@ def _swift_module_alias_impl(ctx):
 
 swift_module_alias = rule(
     attrs = dicts.add(
-        swift_toolchain_attrs(),
         {
             "deps": attr.label_list(
                 doc = """\


### PR DESCRIPTION
Partial 2.x based cherry-pick of eb2a7ff8312a0b37837836314e372af357b4764a.