### PR TITLE
Remove another `swift_toolchain_attrs` usage

### DIFF
--- a/proto/BUILD
+++ b/proto/BUILD
@@ -35,7 +35,6 @@ bzl_library(
         ":swift_proto_utils",
         "//swift:module_name",
         "//swift:swift_clang_module_aspect",
-        "//swift:swift_common",
         "//swift/internal:attrs",
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -36,7 +36,6 @@ load(
     "SwiftProtoCompilerInfo",
     "SwiftProtoInfo",
 )
-load("//swift:swift_common.bzl", "swift_common")
 
 # buildifier: disable=bzl-visibility
 load("//swift/internal:toolchain_utils.bzl", "use_swift_toolchain")
@@ -73,7 +72,6 @@ def _swift_proto_library_group_aspect_impl(target, aspect_ctx):
 _swift_proto_library_group_aspect = aspect(
     attr_aspects = ["deps"],
     attrs = dicts.add(
-        swift_common.toolchain_attrs(),
         {
             "_compiler": attr.label(
                 default = Label("//proto:_swift_proto_compiler"),


### PR DESCRIPTION
Missed in c90092e7ff332ee3a6fef35386080336ed368555.