### PR TITLE
Stop using `plugins` from transitive dependencies 

### DIFF
--- a/examples/xplatform/macros/BUILD
+++ b/examples/xplatform/macros/BUILD
@@ -42,12 +42,14 @@ universal_swift_compiler_plugin(
 swift_binary(
     name = "stringify_client",
     srcs = ["StringifyClient.swift"],
+    plugins = [":stringify_macro"],
     deps = [":stringify"],
 )
 
 swift_binary(
     name = "stringify_universal_client",
     srcs = ["StringifyUniversalClient.swift"],
+    plugins = [":stringify_macro_universal"],
     deps = [":stringify_universal"],
 )
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -603,9 +603,6 @@ def compile(
     # passed; the compiler does not attempt to load them when deserializing
     # modules.
     used_plugins = list(plugins)
-    for module_context in transitive_modules:
-        if module_context.swift and module_context.swift.plugins:
-            used_plugins.extend(module_context.swift.plugins)
 
     if include_dev_srch_paths != None and is_test != None:
         fail("""\


### PR DESCRIPTION
Currently, if we have the following setup,
```
swift_library (
    name = "LibA"
    plugins = ["//:Macros"],
)

swift_library (
    name = "LibB"
    plugins = ["//:Macros"],
    deps = [":LibA"],
)
```
We would see `-load-plugin-executable /path/to/Macros#Macros` twice while compiling LibB. With a more complicated dependency graph, we are seeing hundreds of  `-load-plugin-executable` of the same plugin on some modules.

Actually, we don't need the plugins from the transitive dependencies. This is already explained the code comment, but the actual code behaves differently. This PR fixes it.