### PR TITLE
Deduplicate plugin arguments

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -14,6 +14,7 @@
 
 """Implementation of compilation logic for Swift."""
 
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
@@ -645,7 +646,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         module_name = module_name,
         original_module_name = original_module_name,
         package_name = package_name,
-        plugins = used_plugins,
+        plugins = collections.uniq(used_plugins),
         source_files = srcs,
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,


### PR DESCRIPTION
Currently, if we have the following setup,
```
swift_library (
    name = "LibA"
    plugins = ["//:Macros"],
)

swift_library (
    name = "LibB"
    plugins = ["//:Macros"],
    deps = [":LibA"],
)
```
We would see `-load-plugin-executable /path/to/Macros#Macros` twice while compiling LibB. With a more complicated dependency graph, we are seeing hundreds of -load-plugin-executable of the same plugin on some modules.

This PR deduplicates the plugins arguments. 