### PR TITLE
Support index-import on all Xcode 16.x versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,7 +23,8 @@ bazel_dep(
 non_module_deps = use_extension("//swift:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
-    "build_bazel_rules_swift_index_import",
+    "build_bazel_rules_swift_index_import_5_8",
+    "build_bazel_rules_swift_index_import_6_1",
     "build_bazel_rules_swift_local_config",
     "com_github_apple_swift_docc_symbolkit",
     "com_github_apple_swift_log",

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -224,16 +224,26 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
         ),
     )
 
-    # It relies on `index-import` to import indexes into Bazel's remote
-    # cache and allow using a global index internally in workers.
-    # Note: this is only loaded if swift.index_while_building_v2 is enabled
+    # When using the "global index store" feature we rely on `index-import` to allow
+    # using a global index.
+    # TODO: we must depend on two versions of index-import to support backwards
+    # compatibility between Xcode 16.3+ and older versions, we can remove the older
+    # version once we drop support for Xcode 16.x.
     _maybe(
         http_archive,
-        name = "build_bazel_rules_swift_index_import",
+        name = "build_bazel_rules_swift_index_import_5_8",
         build_file = Label("//third_party:build_bazel_rules_swift_index_import/BUILD.overlay"),
         canonical_id = "index-import-5.8",
         urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/5.8.0.1/index-import.tar.gz"],
         sha256 = "28c1ffa39d99e74ed70623899b207b41f79214c498c603915aef55972a851a15",
+    )
+    _maybe(
+        http_archive,
+        name = "build_bazel_rules_swift_index_import_6_1",
+        build_file = Label("//third_party:build_bazel_rules_swift_index_import/BUILD.overlay"),
+        canonical_id = "index-import-6.1",
+        urls = ["https://github.com/MobileNativeFoundation/index-import/releases/download/6.1.0/index-import.tar.gz"],
+        sha256 = "54d0477526bba0dc1560189dfc4f02d90aea536e9cb329e911f32b2a564b66f1",
     )
 
     _maybe(

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -688,6 +688,14 @@ def _xcode_swift_toolchain_impl(ctx):
         requested_features.append(SWIFT_FEATURE__SUPPORTS_V6)
 
     env = _xcode_env(target_triple = target_triple, xcode_config = xcode_config)
+
+    # TODO: Remove once we drop support for Xcode 16.x.
+    # We set a private environment variable when using a version older than Xcode 16.3
+    # which comes with Swift 6.1 which changes the hash algorithm for the index-import tool.
+    # When using an older version we switch to the older version of index-import.
+    if not _is_xcode_at_least_version(xcode_config, "16.3"):
+        env["__RULES_SWIFT_USE_LEGACY_INDEX_IMPORT"] = "1"
+
     execution_requirements = xcode_config.execution_info()
     generated_header_rewriter = ctx.executable.generated_header_rewriter
 

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -76,7 +76,8 @@ cc_library(
     }),
     data = select({
         "@build_bazel_apple_support//configs:apple": [
-            "@build_bazel_rules_swift_index_import//:index_import",
+            "@build_bazel_rules_swift_index_import_5_8//:index_import",
+            "@build_bazel_rules_swift_index_import_6_1//:index_import",
         ],
         "//conditions:default": [],
     }),

--- a/tools/worker/worker_main.cc
+++ b/tools/worker/worker_main.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "tools/common/process.h"
 #include "tools/cpp/runfiles/runfiles.h"
 #include "tools/worker/compile_with_worker.h"
 #include "tools/worker/compile_without_worker.h"
@@ -31,10 +32,16 @@ int main(int argc, char *argv[]) {
     std::unique_ptr<Runfiles> runfiles(Runfiles::Create(argv[0]));
   #endif  // BAZEL_CURRENT_REPOSITORY
   if (runfiles != nullptr) {
-    // We silently ignore errors here, we will report an error later if this
-    // path is accessed
-    index_import_path =
-      runfiles->Rlocation("build_bazel_rules_swift_index_import/index-import");
+    // TODO: Remove once we drop support for Xcode 16.x.
+    // Determine which version of index-import to use based on the environment
+    auto env = GetCurrentEnvironment();
+    if (env.find("__RULES_SWIFT_USE_LEGACY_INDEX_IMPORT") != env.end()) {
+      index_import_path = runfiles->Rlocation(
+          "build_bazel_rules_swift_index_import_5_8/index-import");
+    } else {
+      index_import_path = runfiles->Rlocation(
+          "build_bazel_rules_swift_index_import_6_1/index-import");
+    }
   }
 
   auto args = std::vector<std::string>(argv + 1, argv + argc);


### PR DESCRIPTION
This PR updates the index-import dependency to include both version 5.8 and 6.1 as the hash algorithm changed in Swift 6.1.
To make this change backwards compatible we switch to the 5.8 version on Xcode 16.2 and under.