### PR TITLE
Use `exec_group` for `SWIFT_ACTION_DERIVE_FILES` and `SWIFT_ACTION_DUMP_AST`

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -664,6 +664,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         run_toolchain_action(
             actions = actions,
             action_name = SWIFT_ACTION_DERIVE_FILES,
+            exec_group = exec_group,
             feature_configuration = feature_configuration,
             outputs = all_derived_outputs,
             prerequisites = prerequisites,
@@ -691,6 +692,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
     run_toolchain_action(
         actions = actions,
         action_name = SWIFT_ACTION_DUMP_AST,
+        exec_group = exec_group,
         feature_configuration = feature_configuration,
         outputs = compile_outputs.ast_files,
         prerequisites = prerequisites,


### PR DESCRIPTION
Missed when cherry-picking from upstream as they don’t have these actions.