### PR TITLE
Add instrumented files info to `swift_binary` and `swift_compiler_plugin`

### DIFF
--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -204,6 +204,12 @@ def _swift_binary_impl(ctx):
                 files = ctx.files.data,
             ),
         ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["deps"],
+            extensions = ["swift"],
+            source_attributes = ["srcs"],
+        ),
         OutputGroupInfo(**output_groups),
         SwiftInfo(
             modules = [

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -199,6 +199,12 @@ def _swift_compiler_plugin_impl(ctx):
         OutputGroupInfo(
             **supplemental_compilation_output_groups(supplemental_outputs)
         ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["deps"],
+            extensions = ["swift"],
+            source_attributes = ["srcs"],
+        ),
         SwiftBinaryInfo(
             cc_info = CcInfo(
                 compilation_context = module_context.clang.compilation_context,


### PR DESCRIPTION
When using a `macos_unit_test` target whose test sources depend on a `swift_compiler_plugin` or `swift_binary` target, its sources are missing from the coverage manifest `COVERAGE_MANIFEST` env var that's passed to lcov.

This change mirrors what the other targets do to add coverage instrumentation info so that they are available in the resulting coverage file.