### PR TITLE
Upstream: Only pass the strict Obj-C include paths from _direct_ dependencies to compilation actions

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -975,7 +975,10 @@ def _precompile_clang_module(
 
     prerequisites = struct(
         bin_dir = feature_configuration._bin_dir,
-        cc_compilation_context = cc_compilation_context,
+        cc_compilation_context = compilation_context_for_explicit_module_compilation(
+            compilation_contexts = [cc_compilation_context],
+            swift_infos = swift_infos,
+        ),
         genfiles_dir = feature_configuration._genfiles_dir,
         include_dev_srch_paths = False,
         indexstore_directory = indexstore_directory,

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1486,28 +1486,12 @@ def _c_layering_check_configurator(prerequisites, args):
         args.add("-Xcc", "-fmodules-strict-decluse")
     return None
 
-def _clang_module_strict_includes(module_context):
-    """Returns the strict Clang include paths for a module context."""
-    if not module_context.clang:
-        return None
-    strict_includes = module_context.clang.strict_includes
-    if not strict_includes:
-        return None
-    return strict_includes.to_list()
-
 def _clang_search_paths_configurator(prerequisites, args):
     """Adds Clang search paths to the command line."""
     args.add_all(
         prerequisites.cc_compilation_context.includes,
         before_each = "-Xcc",
         format_each = "-I%s",
-    )
-    args.add_all(
-        prerequisites.transitive_modules,
-        before_each = "-Xcc",
-        format_each = "-I%s",
-        map_each = _clang_module_strict_includes,
-        uniquify = True,
     )
 
     # Add Clang search paths for the workspace root and Bazel output roots. The


### PR DESCRIPTION
The `compilation_context_for_explicit_module_compilation` function handles collecting the strict includes from `SwiftInfo`s and we're already using that function when compiling the header module for a mixed-language `swift_library`, so we can simply reuse that logic here.

Upstreams: https://github.com/bazelbuild/rules_swift/commit/f08dc0cbe302f907935b71a50d1263c29b8bec08