### PR TITLE
Upstream: Add a feature to allow certain targets to ignore the implicit dependencies from the toolchain.

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -161,10 +161,11 @@ bzl_library(
     srcs = ["swift_import.bzl"],
     deps = [
         ":providers",
+        ":swift_clang_module_aspect",
         "//swift/internal:attrs",
         "//swift/internal:compiling",
         "//swift/internal:features",
-        "//swift/internal:linking",
+        "//swift/internal:providers",
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -177,6 +177,7 @@ bzl_library(
         ":developer_dirs",
         ":feature_names",
         ":features",
+        ":utils",
         "//swift:providers",
     ],
 )

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -38,6 +38,11 @@ SWIFT_FEATURE_OPT = "swift.opt"
 # Swift 6 features even before switching to a Swift 6 compiler.
 SWIFT_FEATURE_ENABLE_V6 = "swift.enable_v6"
 
+# If enabled, the toolchain's implicit dependencies will not be used when
+# compiling Swift or Clang modules. This should only be used when building the
+# toolchain itself.
+SWIFT_FEATURE_NO_IMPLICIT_DEPS = "swift.no_implicit_deps"
+
 # If True, transitive C headers will be always be passed as inputs to Swift
 # compilation actions, even when building with explicit modules.
 SWIFT_FEATURE_HEADERS_ALWAYS_ACTION_INPUTS = "swift.headers_always_action_inputs"

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -35,6 +35,7 @@ load(
     "get_cc_feature_configuration",
     "is_feature_enabled",
 )
+load(":utils.bzl", "get_swift_implicit_deps")
 
 def configure_features_for_binary(
         *,
@@ -244,9 +245,13 @@ def create_linking_context_from_compilation_outputs(
         context to be propagated by the caller's `CcInfo` provider and the
         artifact representing the library that was linked, respectively.
     """
+    _, implicit_cc_infos = get_swift_implicit_deps(
+        feature_configuration = feature_configuration,
+        swift_toolchain = swift_toolchain,
+    )
     extra_linking_contexts = [
         cc_info.linking_context
-        for cc_info in swift_toolchain.implicit_deps_providers.cc_infos
+        for cc_info in implicit_cc_infos
     ]
 
     debugging_linking_context = _create_embedded_debugging_linking_context(
@@ -481,9 +486,13 @@ def register_link_binary_action(
 
     # Collect linking contexts from any of the toolchain's implicit
     # dependencies.
+    _, implicit_cc_infos = get_swift_implicit_deps(
+        feature_configuration = feature_configuration,
+        swift_toolchain = swift_toolchain,
+    )
     linking_contexts.extend([
         cc_info.linking_context
-        for cc_info in swift_toolchain.implicit_deps_providers.cc_infos
+        for cc_info in implicit_cc_infos
     ])
 
     return cc_common.link(

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -16,6 +16,8 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("//swift:providers.bzl", "SwiftInfo")
+load(":feature_names.bzl", "SWIFT_FEATURE_NO_IMPLICIT_DEPS")
+load(":features.bzl", "is_feature_enabled")
 
 def collect_implicit_deps_providers(targets, additional_cc_infos = []):
     """Returns a struct with important providers from a list of implicit deps.
@@ -393,3 +395,51 @@ def include_developer_search_paths(attr):
         "always_include_developer_search_paths",
         False,
     )
+
+def get_swift_implicit_deps(*, feature_configuration, swift_toolchain):
+    """Returns the Swift and C++ providers for implicit Swift dependencies.
+
+    Args:
+        feature_configuration: A feature configuration obtained from
+            `swift_common.configure_features`. If this feature configuration is
+            such that implicit dependencies should be ignored, this function
+            returns an empty list for both providers.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+
+    Returns:
+        A tuple `(list[SwiftInfo], list[CcInfo])`.
+    """
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_NO_IMPLICIT_DEPS,
+    ):
+        return [], []
+    else:
+        return (
+            swift_toolchain.implicit_deps_providers.swift_infos,
+            swift_toolchain.implicit_deps_providers.cc_infos,
+        )
+
+def get_clang_implicit_deps(*, feature_configuration, swift_toolchain):
+    """Returns the Swift and C++ providers for implicit Clang dependencies.
+
+    Args:
+        feature_configuration: A feature configuration obtained from
+            `swift_common.configure_features`. If this feature configuration is
+            such that implicit dependencies should be ignored, this function
+            returns an empty list for both providers.
+        swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+
+    Returns:
+        A tuple `(list[SwiftInfo], list[CcInfo])`.
+    """
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_NO_IMPLICIT_DEPS,
+    ):
+        return [], []
+    else:
+        return (
+            swift_toolchain.clang_implicit_deps_providers.swift_infos,
+            swift_toolchain.clang_implicit_deps_providers.cc_infos,
+        )


### PR DESCRIPTION
If enabled, the toolchain's implicit dependencies will not be used when compiling Swift or Clang modules. This should only be used when building the toolchain itself.

Upstreams: https://github.com/bazelbuild/rules_swift/commit/c29e0ab6b49d3812a07bede821f8f746878eb7d0