### PR TITLE
Upstream: Use a new provider to wrap symbol graph extraction used for test discovery

### DIFF
--- a/swift/internal/swift_symbol_graph_aspect.bzl
+++ b/swift/internal/swift_symbol_graph_aspect.bzl
@@ -34,81 +34,152 @@ load(
 )
 load("//swift/internal:utils.bzl", "include_developer_search_paths")
 
-def _swift_symbol_graph_aspect_impl(target, aspect_ctx):
-    symbol_graphs = []
+def _make_swift_symbol_graph_aspect_impl(
+        output_distinguisher = None,
+        wrapper_provider = None):
+    """Creates the implementation function for a symbol graph aspect.
 
-    if SwiftInfo in target:
-        swift_toolchain = get_swift_toolchain(aspect_ctx)
-        feature_configuration = configure_features(
-            ctx = aspect_ctx,
-            swift_toolchain = swift_toolchain,
-            requested_features = aspect_ctx.features,
-            unsupported_features = aspect_ctx.disabled_features,
-        )
+    Args:
+        output_distinguisher: If set, a string that will be appended to the
+            output directory name for each target. This allows multiple
+            instances of the aspect to be used on the same target without their
+            outputs colliding.
+        wrapper_provider: If set, the provider to use to wrap the symbol graph
+            provider. If not set, the symbol graph provider will be used
+            directly. If set, the provider must have a single field named
+            `symbol_graph_info` that will be set to the underlying symbol graph
+            provider.
+    Returns:
+        The aspect implementation function.
+    """
 
-        swift_info = target[SwiftInfo]
-        if CcInfo in target:
-            compilation_context = target[CcInfo].compilation_context
-        else:
-            compilation_context = cc_common.create_compilation_context()
+    def _wrap(provider):
+        """Wraps the symbol graph provider if necessary."""
+        if wrapper_provider:
+            return wrapper_provider(symbol_graph_info = provider)
+        return provider
 
-        emit_extension_block_symbols = aspect_ctx.attr.emit_extension_block_symbols
-        minimum_access_level = aspect_ctx.attr.minimum_access_level
+    def _unwrap(target):
+        """Unwraps the symbol graph provider if necessary."""
+        if wrapper_provider:
+            if wrapper_provider in target:
+                return target[wrapper_provider].symbol_graph_info
+            return None
 
-        # Only extract the symbol graphs of modules when the target compiles Swift or ObjC code
-        compiles_code = [
-            action
-            for action in target.actions
-            if action.mnemonic in ("SwiftCompile", "SwiftCompileModule", "SwiftPrecompileCModule")
-        ]
-        if compiles_code:
-            for module in swift_info.direct_modules:
-                if module.is_system:
-                    continue
-                output_dir = aspect_ctx.actions.declare_directory(
-                    "{}.symbolgraphs".format(target.label.name),
-                )
-                extract_symbol_graph(
-                    actions = aspect_ctx.actions,
-                    compilation_contexts = [compilation_context],
-                    emit_extension_block_symbols = emit_extension_block_symbols,
-                    feature_configuration = feature_configuration,
-                    include_dev_srch_paths = include_developer_search_paths(
-                        aspect_ctx.rule.attr,
-                    ),
-                    minimum_access_level = minimum_access_level,
-                    module_name = module.name,
-                    output_dir = output_dir,
-                    swift_infos = [swift_info],
-                    swift_toolchain = swift_toolchain,
-                )
-                symbol_graphs.append(
-                    struct(
-                        module_name = module.name,
-                        symbol_graph_dir = output_dir,
-                    ),
-                )
+        if SwiftSymbolGraphInfo in target:
+            return target[SwiftSymbolGraphInfo]
+        return None
 
-    # TODO(b/204480390): We intentionally don't propagate symbol graphs from
-    # private deps at this time, since the main use case for them is
-    # documentation. Are there use cases where we should consider this?
-    transitive_symbol_graphs = []
-    for dep in getattr(aspect_ctx.rule.attr, "deps", []):
-        if SwiftSymbolGraphInfo in dep:
-            symbol_graph_info = dep[SwiftSymbolGraphInfo]
-            transitive_symbol_graphs.append(
-                symbol_graph_info.transitive_symbol_graphs,
+    def _impl(target, aspect_ctx):
+        """The actual aspect implementation function that will be returned."""
+        symbol_graphs = []
+
+        if SwiftInfo in target:
+            swift_toolchain = get_swift_toolchain(aspect_ctx)
+            feature_configuration = configure_features(
+                ctx = aspect_ctx,
+                swift_toolchain = swift_toolchain,
+                requested_features = aspect_ctx.features,
+                unsupported_features = aspect_ctx.disabled_features,
             )
 
-    return [
-        SwiftSymbolGraphInfo(
-            direct_symbol_graphs = symbol_graphs,
-            transitive_symbol_graphs = depset(
-                symbol_graphs,
-                transitive = transitive_symbol_graphs,
+            swift_info = target[SwiftInfo]
+            if CcInfo in target:
+                compilation_context = target[CcInfo].compilation_context
+            else:
+                compilation_context = cc_common.create_compilation_context()
+
+            emit_extension_block_symbols = aspect_ctx.attr.emit_extension_block_symbols
+            minimum_access_level = aspect_ctx.attr.minimum_access_level
+
+            # Only extract the symbol graphs of modules when the target compiles
+            # Swift or Objective-C code.
+            compiles_code = [
+                action
+                for action in target.actions
+                if action.mnemonic in (
+                    "SwiftCompile",
+                    "SwiftCompileModule",
+                    "SwiftPrecompileCModule",
+                )
+            ]
+            if compiles_code:
+                for module in swift_info.direct_modules:
+                    if module.is_system:
+                        continue
+
+                    if output_distinguisher:
+                        output_name = "{}.{}.symbolgraphs".format(
+                            target.label.name,
+                            output_distinguisher,
+                        )
+                    else:
+                        output_name = "{}.symbolgraphs".format(
+                            target.label.name,
+                        )
+                    output_dir = aspect_ctx.actions.declare_directory(
+                        output_name,
+                    )
+                    extract_symbol_graph(
+                        actions = aspect_ctx.actions,
+                        compilation_contexts = [compilation_context],
+                        emit_extension_block_symbols = emit_extension_block_symbols,
+                        feature_configuration = feature_configuration,
+                        include_dev_srch_paths = include_developer_search_paths(
+                            aspect_ctx.rule.attr,
+                        ),
+                        minimum_access_level = minimum_access_level,
+                        module_name = module.name,
+                        output_dir = output_dir,
+                        swift_infos = [swift_info],
+                        swift_toolchain = swift_toolchain,
+                    )
+                    symbol_graphs.append(
+                        struct(
+                            module_name = module.name,
+                            symbol_graph_dir = output_dir,
+                        ),
+                    )
+
+        # TODO(b/204480390): We intentionally don't propagate symbol graphs from
+        # private deps at this time, since the main use case for them is
+        # documentation. Are there use cases where we should consider this?
+        transitive_symbol_graphs = []
+        for dep in getattr(aspect_ctx.rule.attr, "deps", []):
+            symbol_graph_info = _unwrap(dep)
+            if symbol_graph_info:
+                transitive_symbol_graphs.append(
+                    symbol_graph_info.transitive_symbol_graphs,
+                )
+
+        return [
+            _wrap(
+                SwiftSymbolGraphInfo(
+                    direct_symbol_graphs = symbol_graphs,
+                    transitive_symbol_graphs = depset(
+                        symbol_graphs,
+                        transitive = transitive_symbol_graphs,
+                    ),
+                ),
             ),
-        ),
-    ]
+        ]
+
+    return _impl
+
+SwiftTestDiscoverySymbolGraphInfo = provider(
+    doc = "Wraps the symbol graph info for test discovery.",
+    fields = {
+        "symbol_graph_info": """\
+The underlying `SwiftSymbolGraphInfo` provider for the target.
+""",
+    },
+)
+
+# Used only by `_testonly_symbol_graph_aspect_impl` below.
+_test_discovery_swift_symbol_graph_aspect_impl = _make_swift_symbol_graph_aspect_impl(
+    output_distinguisher = "test_discovery",
+    wrapper_provider = SwiftTestDiscoverySymbolGraphInfo,
+)
 
 def _testonly_symbol_graph_aspect_impl(target, aspect_ctx):
     ignored = not getattr(aspect_ctx.rule.attr, "testonly", False)
@@ -118,20 +189,24 @@ def _testonly_symbol_graph_aspect_impl(target, aspect_ctx):
         # a non-`testonly` target can't depend on a `testonly` target, so there
         # is no possibility of losing anything we'd want to keep.
         return [
-            SwiftSymbolGraphInfo(
-                direct_symbol_graphs = [],
-                transitive_symbol_graphs = depset(),
+            SwiftTestDiscoverySymbolGraphInfo(
+                symbol_graph_info = SwiftSymbolGraphInfo(
+                    direct_symbol_graphs = [],
+                    transitive_symbol_graphs = depset(),
+                ),
             ),
         ]
 
-    return _swift_symbol_graph_aspect_impl(target, aspect_ctx)
+    return _test_discovery_swift_symbol_graph_aspect_impl(target, aspect_ctx)
 
 def make_swift_symbol_graph_aspect(
         *,
         default_emit_extension_block_symbols,
         default_minimum_access_level,
         doc = "",
-        testonly_targets):
+        testonly_targets,
+        output_distinguisher = None,
+        wrapper_provider = None):
     """Creates an aspect that extracts Swift symbol graphs from dependencies.
 
     Args:
@@ -143,16 +218,33 @@ def make_swift_symbol_graph_aspect(
             that applies this aspect can let users override this value if it
             also provides an attribute named `minimum_access_level`.
         doc: The documentation string for the aspect.
+        output_distinguisher: If set, a string that will be appended to the
+            output directory name for each target. This allows multiple
+            instances of the aspect to be used on the same target without their
+            outputs colliding.
         testonly_targets: If True, symbol graphs will only be extracted from
             targets that have the `testonly` attribute set.
+        wrapper_provider: If set, the provider to use to wrap the symbol graph
+            provider. If not set, the symbol graph provider will be used
+            directly. If set, the provider must have a single field named
+            `symbol_graph_info` that will be set to the underlying symbol graph
+            provider.
 
     Returns:
         An `aspect` that can be applied to a rule's dependencies.
     """
     if testonly_targets:
         aspect_impl = _testonly_symbol_graph_aspect_impl
+        provides = [SwiftTestDiscoverySymbolGraphInfo]
     else:
-        aspect_impl = _swift_symbol_graph_aspect_impl
+        aspect_impl = _make_swift_symbol_graph_aspect_impl(
+            output_distinguisher = output_distinguisher,
+            wrapper_provider = wrapper_provider,
+        )
+        if wrapper_provider:
+            provides = [wrapper_provider]
+        else:
+            provides = [SwiftSymbolGraphInfo]
 
     return aspect(
         attr_aspects = ["deps"],
@@ -199,7 +291,7 @@ default value is {default_value}.
         doc = doc,
         fragments = ["cpp"],
         implementation = aspect_impl,
-        provides = [SwiftSymbolGraphInfo],
+        provides = provides,
         requires = [swift_clang_module_aspect],
         toolchains = use_swift_toolchain(),
     )

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -37,6 +37,7 @@ load(
 load("//swift/internal:providers.bzl", "SwiftCompilerPluginInfo")
 load(
     "//swift/internal:swift_symbol_graph_aspect.bzl",
+    "SwiftTestDiscoverySymbolGraphInfo",
     "make_swift_symbol_graph_aspect",
 )
 load("//swift/internal:symbol_graph_extracting.bzl", "extract_symbol_graph")
@@ -56,7 +57,6 @@ load(
     ":providers.bzl",
     "SwiftBinaryInfo",
     "SwiftInfo",
-    "SwiftSymbolGraphInfo",
     "create_swift_module_context",
 )
 
@@ -135,10 +135,12 @@ def _generate_test_discovery_srcs(
             modules_to_scan.append(owner_module_name)
 
         for dep in deps:
-            if SwiftSymbolGraphInfo not in dep:
+            if SwiftTestDiscoverySymbolGraphInfo not in dep:
                 continue
 
-            symbol_graph_info = dep[SwiftSymbolGraphInfo]
+            symbol_graph_info = (
+                dep[SwiftTestDiscoverySymbolGraphInfo].symbol_graph_info
+            )
 
             # Only include the direct symbol graphs if the owner didn't have any
             # sources.


### PR DESCRIPTION
Upstreams: 

- https://github.com/bazelbuild/rules_swift/commit/be9220c8feb6fc5f107e4054588c86cc172e7f24
- https://github.com/bazelbuild/rules_swift/commit/a2b9db5dbd56a77327f175b674aee1935cd43f82

>Since symbol graph extraction is an implementation detail of `swift_test`, it shouldn't squat on the provider exclusively. Any other aspect invocation trying to extract symbol graphs on the same target will run into the "provider was provided twice" error.

> To remedy this, introduce the ability for someone creating their own symbol graph aspect to automatically wrap the `SwiftSymbolGraphInfo` provider in one of their own choosing, and to add a distinguishing string to the output directory name so that outputs likewise don't collide. (In the future, we may want to do this automatically by hashing the active aspect IDs, but at this time I prefer not to introduce that complexity here.)