### PR TITLE
Upstream: Add an advanced API to create a custom instance of swift_clang_module_aspect with a different toolchain type than the default

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -168,7 +168,7 @@ swift_common.compile(<a href="#swift_common.compile-actions">actions</a>, <a hre
                      <a href="#swift_common.compile-extra_swift_infos">extra_swift_infos</a>, <a href="#swift_common.compile-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile-generated_header_name">generated_header_name</a>, <a href="#swift_common.compile-is_test">is_test</a>,
                      <a href="#swift_common.compile-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.compile-module_name">module_name</a>, <a href="#swift_common.compile-package_name">package_name</a>, <a href="#swift_common.compile-plugins">plugins</a>, <a href="#swift_common.compile-private_cc_infos">private_cc_infos</a>,
                      <a href="#swift_common.compile-private_swift_infos">private_swift_infos</a>, <a href="#swift_common.compile-srcs">srcs</a>, <a href="#swift_common.compile-swift_infos">swift_infos</a>, <a href="#swift_common.compile-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile-target_name">target_name</a>,
-                     <a href="#swift_common.compile-workspace_name">workspace_name</a>)
+                     <a href="#swift_common.compile-toolchain_type">toolchain_type</a>, <a href="#swift_common.compile-workspace_name">workspace_name</a>)
 </pre>
 
 Compiles a Swift module.
@@ -198,6 +198,7 @@ Compiles a Swift module.
 | <a id="swift_common.compile-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from non-private dependencies of the target being compiled. The modules defined by these providers are used as dependencies of both the Swift module being compiled and the Clang module for the generated header.   |  none |
 | <a id="swift_common.compile-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 | <a id="swift_common.compile-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
+| <a id="swift_common.compile-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `"@build_bazel_rules_swift//toolchains:toolchain_type"` |
 | <a id="swift_common.compile-workspace_name"></a>workspace_name |  The name of the workspace for which the code is being compiled, which is used to determine unique file paths for some outputs.   |  none |
 
 **RETURNS**
@@ -251,7 +252,8 @@ A `struct` with the following fields:
 <pre>
 swift_common.compile_module_interface(<a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
                                       <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
-                                      <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>)
+                                      <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>,
+                                      <a href="#swift_common.compile_module_interface-toolchain_type">toolchain_type</a>)
 </pre>
 
 Compiles a Swift module interface.
@@ -273,6 +275,7 @@ Compiles a Swift module interface.
 | <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled.   |  none |
 | <a id="swift_common.compile_module_interface-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 | <a id="swift_common.compile_module_interface-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
+| <a id="swift_common.compile_module_interface-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `"@build_bazel_rules_swift//toolchains:toolchain_type"` |
 
 **RETURNS**
 
@@ -361,7 +364,8 @@ swift_common.create_linking_context_from_compilation_outputs(<a href="#swift_com
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-feature_configuration">feature_configuration</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-is_test">is_test</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-label">label</a>,
                                                              <a href="#swift_common.create_linking_context_from_compilation_outputs-linking_contexts">linking_contexts</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-module_context">module_context</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-name">name</a>,
-                                                             <a href="#swift_common.create_linking_context_from_compilation_outputs-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-user_link_flags">user_link_flags</a>)
+                                                             <a href="#swift_common.create_linking_context_from_compilation_outputs-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.create_linking_context_from_compilation_outputs-toolchain_type">toolchain_type</a>,
+                                                             <a href="#swift_common.create_linking_context_from_compilation_outputs-user_link_flags">user_link_flags</a>)
 </pre>
 
 Creates a linking context from the outputs of a Swift compilation.
@@ -391,6 +395,7 @@ command line parameters file, those actions will be created here.
 | <a id="swift_common.create_linking_context_from_compilation_outputs-module_context"></a>module_context |  The module context returned by `compile` containing information about the Swift module that was compiled. Typically, this is the first tuple element in the value returned by `compile`.   |  none |
 | <a id="swift_common.create_linking_context_from_compilation_outputs-name"></a>name |  A string that is used to derive the name of the library or libraries linked by this function. If this is not provided or is a falsy value, the name component of the `label` argument is used.   |  `None` |
 | <a id="swift_common.create_linking_context_from_compilation_outputs-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
+| <a id="swift_common.create_linking_context_from_compilation_outputs-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `"@build_bazel_rules_swift//toolchains:toolchain_type"` |
 | <a id="swift_common.create_linking_context_from_compilation_outputs-user_link_flags"></a>user_link_flags |  A `list` of strings containing additional flags that will be passed to the linker for any binary that links with the returned linking context.   |  `[]` |
 
 **RETURNS**
@@ -407,7 +412,8 @@ A tuple of `(CcLinkingContext, CcLinkingOutputs)` containing the linking
 <pre>
 swift_common.extract_symbol_graph(<a href="#swift_common.extract_symbol_graph-actions">actions</a>, <a href="#swift_common.extract_symbol_graph-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.extract_symbol_graph-emit_extension_block_symbols">emit_extension_block_symbols</a>,
                                   <a href="#swift_common.extract_symbol_graph-feature_configuration">feature_configuration</a>, <a href="#swift_common.extract_symbol_graph-include_dev_srch_paths">include_dev_srch_paths</a>, <a href="#swift_common.extract_symbol_graph-minimum_access_level">minimum_access_level</a>,
-                                  <a href="#swift_common.extract_symbol_graph-module_name">module_name</a>, <a href="#swift_common.extract_symbol_graph-output_dir">output_dir</a>, <a href="#swift_common.extract_symbol_graph-swift_infos">swift_infos</a>, <a href="#swift_common.extract_symbol_graph-swift_toolchain">swift_toolchain</a>)
+                                  <a href="#swift_common.extract_symbol_graph-module_name">module_name</a>, <a href="#swift_common.extract_symbol_graph-output_dir">output_dir</a>, <a href="#swift_common.extract_symbol_graph-swift_infos">swift_infos</a>, <a href="#swift_common.extract_symbol_graph-swift_toolchain">swift_toolchain</a>,
+                                  <a href="#swift_common.extract_symbol_graph-toolchain_type">toolchain_type</a>)
 </pre>
 
 Extracts the symbol graph from a Swift module.
@@ -427,6 +433,7 @@ Extracts the symbol graph from a Swift module.
 | <a id="swift_common.extract_symbol_graph-output_dir"></a>output_dir |  A directory-type `File` into which `.symbols.json` files representing the module's symbol graph will be extracted. If extraction is successful, this directory will contain a file named `${MODULE_NAME}.symbols.json`. Optionally, if the module contains extensions to types in other modules, then there will also be files named `${MODULE_NAME}@${EXTENDED_MODULE}.symbols.json`.   |  none |
 | <a id="swift_common.extract_symbol_graph-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled. This should include both propagated and non-propagated (implementation-only) dependencies.   |  none |
 | <a id="swift_common.extract_symbol_graph-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
+| <a id="swift_common.extract_symbol_graph-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `"@build_bazel_rules_swift//toolchains:toolchain_type"` |
 
 
 <a id="swift_common.get_toolchain"></a>
@@ -491,7 +498,7 @@ check it.
 <pre>
 swift_common.precompile_clang_module(<a href="#swift_common.precompile_clang_module-actions">actions</a>, <a href="#swift_common.precompile_clang_module-cc_compilation_context">cc_compilation_context</a>, <a href="#swift_common.precompile_clang_module-exec_group">exec_group</a>,
                                      <a href="#swift_common.precompile_clang_module-feature_configuration">feature_configuration</a>, <a href="#swift_common.precompile_clang_module-module_map_file">module_map_file</a>, <a href="#swift_common.precompile_clang_module-module_name">module_name</a>,
-                                     <a href="#swift_common.precompile_clang_module-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.precompile_clang_module-target_name">target_name</a>, <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>)
+                                     <a href="#swift_common.precompile_clang_module-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.precompile_clang_module-target_name">target_name</a>, <a href="#swift_common.precompile_clang_module-toolchain_type">toolchain_type</a>, <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>)
 </pre>
 
 Precompiles an explicit Clang module that is compatible with Swift.
@@ -509,6 +516,7 @@ Precompiles an explicit Clang module that is compatible with Swift.
 | <a id="swift_common.precompile_clang_module-module_name"></a>module_name |  The name of the top-level module in the module map that will be compiled.   |  none |
 | <a id="swift_common.precompile_clang_module-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
 | <a id="swift_common.precompile_clang_module-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
+| <a id="swift_common.precompile_clang_module-toolchain_type"></a>toolchain_type |  The toolchain type of the Swift toolchain.   |  none |
 | <a id="swift_common.precompile_clang_module-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers representing dependencies required to compile this module.   |  `[]` |
 
 **RETURNS**
@@ -523,7 +531,7 @@ A struct containing the precompiled module and optional indexstore directory,
 
 <pre>
 swift_common.synthesize_interface(<a href="#swift_common.synthesize_interface-actions">actions</a>, <a href="#swift_common.synthesize_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.synthesize_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.synthesize_interface-module_name">module_name</a>,
-                                  <a href="#swift_common.synthesize_interface-output_file">output_file</a>, <a href="#swift_common.synthesize_interface-swift_infos">swift_infos</a>, <a href="#swift_common.synthesize_interface-swift_toolchain">swift_toolchain</a>)
+                                  <a href="#swift_common.synthesize_interface-output_file">output_file</a>, <a href="#swift_common.synthesize_interface-swift_infos">swift_infos</a>, <a href="#swift_common.synthesize_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.synthesize_interface-toolchain_type">toolchain_type</a>)
 </pre>
 
 Extracts the symbol graph from a Swift module.
@@ -540,6 +548,7 @@ Extracts the symbol graph from a Swift module.
 | <a id="swift_common.synthesize_interface-output_file"></a>output_file |  A `File` into which the synthesized interface will be written.   |  none |
 | <a id="swift_common.synthesize_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled. This should include both propagated and non-propagated (implementation-only) dependencies.   |  none |
 | <a id="swift_common.synthesize_interface-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  none |
+| <a id="swift_common.synthesize_interface-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `"@build_bazel_rules_swift//toolchains:toolchain_type"` |
 
 
 <a id="swift_common.use_toolchain"></a>

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -169,6 +169,7 @@ bzl_library(
     deps = [
         ":action_names",
         ":actions",
+        ":toolchain_utils",
         ":utils",
         "//swift:providers",
     ],
@@ -189,6 +190,7 @@ bzl_library(
         ":developer_dirs",
         ":feature_names",
         ":features",
+        ":toolchain_utils",
         ":utils",
         "//swift:providers",
     ],
@@ -272,6 +274,7 @@ bzl_library(
     deps = [
         ":action_names",
         ":actions",
+        ":toolchain_utils",
         ":utils",
         "//swift:providers",
     ],

--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -135,6 +135,7 @@ def run_toolchain_action(
         prerequisites,
         swift_toolchain,
         mnemonic = None,
+        toolchain_type,
         **kwargs):
     """Runs an action using the toolchain's tool and action configurations.
 
@@ -152,6 +153,9 @@ def run_toolchain_action(
             by the action configurators to add files and other dependent data to
             the command line.
         swift_toolchain: The Swift toolchain being used to build.
+        toolchain_type: A toolchain type of the `swift_toolchain` which is used
+            for the proper selection of the execution platform inside
+            `run_toolchain_action`.
         **kwargs: Additional arguments passed directly to `actions.run`.
     """
     tool_config = swift_toolchain.tool_configs.get(action_name)
@@ -219,6 +223,7 @@ def run_toolchain_action(
         env = tool_config.env,
         exec_group = exec_group,
         executable = executable,
+        toolchain = toolchain_type,
         execution_requirements = execution_requirements,
         inputs = depset(
             action_inputs.inputs,

--- a/swift/internal/autolinking.bzl
+++ b/swift/internal/autolinking.bzl
@@ -21,6 +21,7 @@ load(
 )
 load(":action_names.bzl", "SWIFT_ACTION_AUTOLINK_EXTRACT")
 load(":actions.bzl", "run_toolchain_action")
+load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 
 def _autolink_extract_input_configurator(prerequisites, args):
     """Configures the inputs of the autolink-extract action."""
@@ -57,7 +58,8 @@ def register_autolink_extract_action(
         autolink_file,
         feature_configuration,
         object_files,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE):
     """Extracts autolink information from Swift `.o` files.
 
     For some platforms (such as Linux), autolinking of imported frameworks is
@@ -74,6 +76,9 @@ def register_autolink_extract_action(
         object_files: The list of object files whose autolink information will
             be extracted.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
     """
     prerequisites = struct(
         autolink_file = autolink_file,
@@ -88,4 +93,5 @@ def register_autolink_extract_action(
         prerequisites = prerequisites,
         progress_message = "Extracting autolink data for Swift module %{label}",
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -67,6 +67,7 @@ load(
     "upcoming_and_experimental_features",
 )
 load(":module_maps.bzl", "write_module_map")
+load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(
     ":utils.bzl",
     "compact",
@@ -145,7 +146,8 @@ def compile_module_interface(
         swiftinterface_file,
         swift_infos,
         swift_toolchain,
-        target_name):
+        target_name,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE):
     """Compiles a Swift module interface.
 
     Args:
@@ -173,6 +175,9 @@ def compile_module_interface(
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
 
     Returns:
         A Swift module context (as returned by `create_swift_module_context`)
@@ -282,6 +287,7 @@ def compile_module_interface(
         prerequisites = prerequisites,
         progress_message = "Compiling Swift module {} from textual interface".format(module_name),
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )
 
     module_context = create_swift_module_context(
@@ -326,7 +332,7 @@ def compile(
         swift_infos,
         swift_toolchain,
         target_name,
-        toolchain_type,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE,
         workspace_name):
     """Compiles a Swift module.
 
@@ -383,6 +389,9 @@ def compile(
             these providers are used as dependencies of both the Swift module
             being compiled and the Clang module for the generated header.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: A toolchain type of the `swift_toolchain` which is used
+            for the proper selection of the execution platform inside
+            `run_toolchain_action`.
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
@@ -741,6 +750,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             swift_infos = generated_module_deps_swift_infos,
             swift_toolchain = swift_toolchain,
             target_name = target_name,
+            toolchain_type = toolchain_type,
         )
         if pcm_outputs:
             precompiled_module = pcm_outputs.pcm_file

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -326,6 +326,7 @@ def compile(
         swift_infos,
         swift_toolchain,
         target_name,
+        toolchain_type,
         workspace_name):
     """Compiles a Swift module.
 
@@ -385,6 +386,9 @@ def compile(
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
         workspace_name: The name of the workspace for which the code is being
              compiled, which is used to determine unique file paths for some
              outputs.
@@ -676,6 +680,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             prerequisites = prerequisites,
             progress_message = "Generating derived files for Swift module %{label}",
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
         )
 
     run_toolchain_action(
@@ -687,6 +692,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         prerequisites = prerequisites,
         progress_message = "Compiling Swift module %{label}",
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )
 
     # Dump AST has to run in its own action because `-dump-ast` is incompatible
@@ -704,6 +710,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         prerequisites = prerequisites,
         progress_message = "Dumping Swift AST for %{label}",
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )
 
     # If a header and module map were generated for this Swift module, attempt
@@ -826,6 +833,7 @@ def precompile_clang_module(
         module_name,
         swift_toolchain,
         target_name,
+        toolchain_type,
         swift_infos = []):
     """Precompiles an explicit Clang module that is compatible with Swift.
 
@@ -852,6 +860,7 @@ def precompile_clang_module(
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
+        toolchain_type: The toolchain type of the Swift toolchain.
         swift_infos: A list of `SwiftInfo` providers representing dependencies
             required to compile this module.
 
@@ -870,6 +879,7 @@ def precompile_clang_module(
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = target_name,
+        toolchain_type = toolchain_type,
     )
 
 def _precompile_clang_module(
@@ -883,7 +893,8 @@ def _precompile_clang_module(
         module_name,
         swift_infos = [],
         swift_toolchain,
-        target_name):
+        target_name,
+        toolchain_type):
     """Precompiles an explicit Clang module that is compatible with Swift.
 
     Args:
@@ -913,6 +924,7 @@ def _precompile_clang_module(
         target_name: The name of the target for which the code is being
             compiled, which is used to determine unique file paths for the
             outputs.
+        toolchain_type: The toolchain type of the Swift toolchain.
 
     Returns:
         A struct containing the precompiled module and optional indexstore directory,
@@ -1009,6 +1021,7 @@ def _precompile_clang_module(
         prerequisites = prerequisites,
         progress_message = "Precompiling C module %{label}",
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )
 
     return struct(

--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -34,7 +34,8 @@ def ensure_swiftmodule_is_embedded(
         feature_configuration,
         label,
         swiftmodule,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type):
     """Ensures that a `.swiftmodule` file is embedded in a library or binary.
 
     This function handles the distinctions between how different object file
@@ -47,6 +48,9 @@ def ensure_swiftmodule_is_embedded(
         label: The `Label` of the target being built.
         swiftmodule: The `.swiftmodule` file to be wrapped.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
 
     Returns:
         A `LinkerInput` containing any flags and/or input files that should be
@@ -78,6 +82,7 @@ def ensure_swiftmodule_is_embedded(
                 "Wrapping {} for debugging".format(swiftmodule.short_path)
             ),
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
         )
 
         # Passing the `.o` file directly to the linker ensures that it links to

--- a/swift/internal/interface_synthesizing.bzl
+++ b/swift/internal/interface_synthesizing.bzl
@@ -17,6 +17,7 @@
 load("//swift:providers.bzl", "SwiftInfo")
 load(":action_names.bzl", "SWIFT_ACTION_SYNTHESIZE_INTERFACE")
 load(":actions.bzl", "run_toolchain_action")
+load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(":utils.bzl", "merge_compilation_contexts")
 
 def synthesize_interface(
@@ -27,7 +28,8 @@ def synthesize_interface(
         module_name,
         output_file,
         swift_infos,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE):
     """Extracts the symbol graph from a Swift module.
 
     Args:
@@ -46,6 +48,9 @@ def synthesize_interface(
             target being compiled. This should include both propagated and
             non-propagated (implementation-only) dependencies.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
     """
     merged_compilation_context = merge_compilation_contexts(
         transitive_compilation_contexts = compilation_contexts + [
@@ -92,4 +97,5 @@ def synthesize_interface(
             "Synthesizing Swift interface for {}".format(module_name)
         ),
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -35,6 +35,7 @@ load(
     "get_cc_feature_configuration",
     "is_feature_enabled",
 )
+load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(":utils.bzl", "get_swift_implicit_deps")
 
 def configure_features_for_binary(
@@ -138,7 +139,8 @@ def _create_embedded_debugging_linking_context(
         feature_configuration,
         label,
         module_context,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type):
     """Creates a linking context that embeds a .swiftmodule for debugging.
 
     Args:
@@ -152,6 +154,9 @@ def _create_embedded_debugging_linking_context(
             Typically, this is the first tuple element in the value returned by
             `compile`.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
 
     Returns:
         A valid `CcLinkingContext`, or `None` if no linking context was created.
@@ -171,6 +176,7 @@ def _create_embedded_debugging_linking_context(
                 label = label,
                 swiftmodule = module_context.swift.swiftmodule,
                 swift_toolchain = swift_toolchain,
+                toolchain_type = toolchain_type,
             ),
         ]
         return cc_common.create_linking_context(
@@ -193,6 +199,7 @@ def create_linking_context_from_compilation_outputs(
         module_context,
         name = None,
         swift_toolchain,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE,
         user_link_flags = []):
     """Creates a linking context from the outputs of a Swift compilation.
 
@@ -236,6 +243,9 @@ def create_linking_context_from_compilation_outputs(
             information about the Swift module that was compiled. Typically,
             this is the first tuple element in the value returned by `compile`.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
         user_link_flags: A `list` of strings containing additional flags that
             will be passed to the linker for any binary that links with the
             returned linking context.
@@ -260,6 +270,7 @@ def create_linking_context_from_compilation_outputs(
         label = label,
         module_context = module_context,
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )
     if debugging_linking_context:
         extra_linking_contexts.append(debugging_linking_context)
@@ -375,6 +386,7 @@ def register_link_binary_action(
         output_type,
         stamp,
         swift_toolchain,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE,
         user_link_flags = [],
         variables_extension = {}):
     """Registers an action that invokes the linker to produce a binary.
@@ -407,6 +419,9 @@ def register_link_binary_action(
             stamping is enabled. See `cc_common.link` for details about the
             behavior of this argument.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
         user_link_flags: Additional flags passed to the linker. Any
             `$(location ...)` placeholders are assumed to have already been
             expanded.
@@ -435,6 +450,7 @@ def register_link_binary_action(
             label = label,
             module_context = module_context,
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
         )
         if debugging_linking_context:
             linking_contexts.append(debugging_linking_context)

--- a/swift/internal/symbol_graph_extracting.bzl
+++ b/swift/internal/symbol_graph_extracting.bzl
@@ -17,6 +17,7 @@
 load("//swift:providers.bzl", "SwiftInfo")
 load(":action_names.bzl", "SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT")
 load(":actions.bzl", "run_toolchain_action")
+load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(":utils.bzl", "merge_compilation_contexts")
 
 def extract_symbol_graph(
@@ -30,7 +31,8 @@ def extract_symbol_graph(
         module_name,
         output_dir,
         swift_infos,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE):
     """Extracts the symbol graph from a Swift module.
 
     Args:
@@ -62,6 +64,9 @@ def extract_symbol_graph(
             target being compiled. This should include both propagated and
             non-propagated (implementation-only) dependencies.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
+        toolchain_type: The toolchain type of the `swift_toolchain` which is
+            used for the proper selection of the execution platform inside
+            `run_toolchain_action`.
     """
     merged_compilation_context = merge_compilation_contexts(
         transitive_compilation_contexts = compilation_contexts + [
@@ -116,4 +121,5 @@ def extract_symbol_graph(
             "Extracting symbol graph for {}".format(module_name)
         ),
         swift_toolchain = swift_toolchain,
+        toolchain_type = toolchain_type,
     )

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -573,6 +573,7 @@ def _compile_swift_overlay(
             ],
             module_context = compile_result.module_context,
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
             user_link_flags = overlay_info.linkopts,
         )
     )

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -42,6 +42,7 @@ load(
 )
 load(
     "//swift/internal:toolchain_utils.bzl",
+    "SWIFT_TOOLCHAIN_TYPE",
     "get_swift_toolchain",
     "use_swift_toolchain",
 )
@@ -298,6 +299,7 @@ def _handle_module(
         direct_swift_infos,
         swift_infos,
         swift_toolchain,
+        toolchain_type,
         target):
     """Processes a C/Objective-C target that is a dependency of a Swift target.
 
@@ -319,6 +321,7 @@ def _handle_module(
             created and returned for this target.
         swift_toolchain: The Swift toolchain being used to build this target.
         target: The C++ target to which the aspect is currently being applied.
+        toolchain_type: The toolchain type of the Swift toolchain.
 
     Returns:
         A list of providers that should be returned by the aspect.
@@ -413,6 +416,7 @@ def _handle_module(
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = target.label.name,
+        toolchain_type = toolchain_type,
     )
     precompiled_module = getattr(pcm_outputs, "pcm_file", None)
     pcm_indexstore = getattr(pcm_outputs, "indexstore_directory", None)
@@ -455,6 +459,7 @@ def _handle_module(
             overlay_info = overlay_info,
             swift_infos = swift_infos_for_overlay,
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
         )
         overlay_swift_info = overlay_compile_result.swift_info
         overlay_swift_module = overlay_swift_info.direct_modules[0].swift
@@ -495,7 +500,8 @@ def _compile_swift_overlay(
         module_name,
         overlay_info,
         swift_infos,
-        swift_toolchain):
+        swift_toolchain,
+        toolchain_type):
     """Compiles Swift code to be used as an overlay for a C/Objective-C module.
 
     Args:
@@ -510,6 +516,7 @@ def _compile_swift_overlay(
             dependencies of both the original C/Objective-C target and the
             Swift overlay.
         swift_toolchain: The Swift toolchain to use when compiling.
+        toolchain_type: The toolchain type of the Swift toolchain.
 
     Returns:
         The compilation result, as returned by `swift_common.compile`.
@@ -540,6 +547,7 @@ def _compile_swift_overlay(
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = overlay_info.label.name,
+        toolchain_type = toolchain_type,
         workspace_name = aspect_ctx.workspace_name,
     )
     linking_context, _ = (
@@ -706,7 +714,7 @@ def _find_swift_overlay_compile_info(aspect_ctx):
         return overlay_target[SwiftOverlayCompileInfo]
     return None
 
-def _swift_clang_module_aspect_impl(target, aspect_ctx):
+def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
     providers = [SwiftClangModuleAspectInfo()]
 
     # Do nothing if the target already propagates `SwiftInfo`.
@@ -738,6 +746,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
 
     swift_toolchain = get_swift_toolchain(
         aspect_ctx,
+        toolchain_type = toolchain_type,
     )
     feature_configuration = configure_features(
         ctx = aspect_ctx,
@@ -756,6 +765,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
             direct_swift_infos = direct_swift_infos,
             swift_infos = swift_infos,
             swift_toolchain = swift_toolchain,
+            toolchain_type = toolchain_type,
             target = target,
         )
 
@@ -769,9 +779,26 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx):
 
     return providers
 
-swift_clang_module_aspect = aspect(
-    attr_aspects = _MULTIPLE_TARGET_ASPECT_ATTRS,
-    doc = """\
+def make_swift_clang_module_aspect(*, toolchain_type):
+    """Creates a `swift_clang_module_aspect` with the given toolchain type.
+
+    Args:
+        toolchain_type: The toolchain type of the Swift toolchain.
+
+    Returns:
+        A `swift_clang_module_aspect` with the given toolchain type.
+    """
+
+    def _impl(target, aspect_ctx):
+        return _swift_clang_module_aspect_impl(
+            target = target,
+            aspect_ctx = aspect_ctx,
+            toolchain_type = toolchain_type,
+        )
+
+    return aspect(
+        attr_aspects = _MULTIPLE_TARGET_ASPECT_ATTRS,
+        doc = """\
 Propagates unified `SwiftInfo` providers for targets that represent
 C/Objective-C modules.
 
@@ -810,12 +837,18 @@ it propagates for its targets.
     suppressed (for example, using the `no_module` aspect hint). In this case,
     transitive dependency information is intentionally discarded.
 """,
-    fragments = ["cpp"],
-    implementation = _swift_clang_module_aspect_impl,
-    provides = [SwiftClangModuleAspectInfo],
-    required_aspect_providers = [
-        [apple_common.Objc],
-        [CcInfo],
-    ],
-    toolchains = use_swift_toolchain(),
+        fragments = ["cpp"],
+        implementation = _impl,
+        provides = [SwiftClangModuleAspectInfo],
+        required_aspect_providers = [
+            [apple_common.Objc],
+            [CcInfo],
+        ],
+        toolchains = use_swift_toolchain(
+            toolchain_type = toolchain_type,
+        ),
+    )
+
+swift_clang_module_aspect = make_swift_clang_module_aspect(
+    toolchain_type = SWIFT_TOOLCHAIN_TYPE,
 )


### PR DESCRIPTION
Cherry-picks:

- https://github.com/bazelbuild/rules_swift/commit/1532dfc73a98adfe22eaf592b9dee565762167e3
- https://github.com/bazelbuild/rules_swift/commit/7f28991db8d2b44dd41b2b0ad7436014bae9f715