### PR TITLE
Update CI to use Xcode 16.2

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   mac_common: &mac_common
     platform: macos_arm64
-    xcode_version: "15.4"
+    xcode_version: "16.2"
     build_targets:
       - "//examples/..."
     test_targets:


### PR DESCRIPTION
> Your selected Xcode version 15.4 was not available on the machine. Bazel CI automatically picked a fallback version: 16.2. Available versions are: 16.2.