### PR TITLE
Upstream: Ensure that `swift_synthesize_interface_aspect` generates unique outputs

### DIFF
--- a/swift/swift_synthesize_interface_aspect.bzl
+++ b/swift/swift_synthesize_interface_aspect.bzl
@@ -60,7 +60,10 @@ def _swift_synthesize_interface_aspect_impl(target, aspect_ctx):
 
         for module in swift_info.direct_modules:
             output_file = aspect_ctx.actions.declare_file(
-                "{}.synthesized.swift".format(target.label.name),
+                "{}.synthesized_interfaces/{}.synthesized.swift".format(
+                    target.label.name,
+                    module.name,
+                ),
             )
             direct_outputs.append(output_file)
             synthesize_interface(


### PR DESCRIPTION
Cherry-pick: https://github.com/bazelbuild/rules_swift/commit/634d0d16608e03d6dde9d23a517c2b9b40ce637c

The aspect generated a file named `<target>.synthesized.swift`, which was incorrect if a target had multiple modules in its `SwiftInfo.direct_modules` field. It would also be incorrect to just switch to `<module name>.synthesized.swift`, because two targets could potentially re-export the same module.

To fully disambiguate, we create an intermediate directory named for the target, and then use the module name as the filename in that directory.

PiperOrigin-RevId: 740414505