### PR TITLE
Upstream: Update the API of `swift_common.compile_module_interface`.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -279,12 +279,22 @@ Compiles a Swift module interface.
 
 **RETURNS**
 
-A Swift module context (as returned by `create_swift_module_context`)
-  that contains the Swift (and potentially C/Objective-C) compilation
-  prerequisites of the compiled module. This should typically be
-  propagated by a `SwiftInfo` provider of the calling rule, and the
-  `CcCompilationContext` inside the Clang module substructure should be
-  propagated by the `CcInfo` provider of the calling rule.
+A `struct` with the following fields:
+
+  *   `module_context`: A Swift module context (as returned by
+      `create_swift_module_context`) that contains the Swift (and
+      potentially C/Objective-C) compilation prerequisites of the compiled
+      module. This should typically be propagated by a `SwiftInfo`
+      provider of the calling rule, and the `CcCompilationContext` inside
+      the Clang module substructure should be propagated by the `CcInfo`
+      provider of the calling rule.
+
+  *   `supplemental_outputs`: A `struct` representing supplemental,
+      optional outputs. Its fields are:
+
+      *   `indexstore_directory`: A directory-type `File` that represents
+          the indexstore output files created when the feature
+          `swift.index_while_building` is enabled.
 
 
 <a id="swift_common.configure_features"></a>

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -180,12 +180,22 @@ def compile_module_interface(
             `run_toolchain_action`.
 
     Returns:
-        A Swift module context (as returned by `create_swift_module_context`)
-        that contains the Swift (and potentially C/Objective-C) compilation
-        prerequisites of the compiled module. This should typically be
-        propagated by a `SwiftInfo` provider of the calling rule, and the
-        `CcCompilationContext` inside the Clang module substructure should be
-        propagated by the `CcInfo` provider of the calling rule.
+        A `struct` with the following fields:
+
+        *   `module_context`: A Swift module context (as returned by
+            `create_swift_module_context`) that contains the Swift (and
+            potentially C/Objective-C) compilation prerequisites of the compiled
+            module. This should typically be propagated by a `SwiftInfo`
+            provider of the calling rule, and the `CcCompilationContext` inside
+            the Clang module substructure should be propagated by the `CcInfo`
+            provider of the calling rule.
+
+        *   `supplemental_outputs`: A `struct` representing supplemental,
+            optional outputs. Its fields are:
+
+            *   `indexstore_directory`: A directory-type `File` that represents
+                the indexstore output files created when the feature
+                `swift.index_while_building` is enabled.
     """
     swiftmodule_file = actions.declare_file("{}.swiftmodule".format(module_name))
 
@@ -308,7 +318,13 @@ def compile_module_interface(
         ),
     )
 
-    return module_context
+    return struct(
+        module_context = module_context,
+        supplemental_outputs = struct(
+            # TODO: b/401305010 - Generate indexstore when requested.
+            indexstore_directory = None,
+        ),
+    )
 
 def compile(
         *,

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -96,7 +96,7 @@ def _swift_import_impl(ctx):
     swift_infos = get_providers(deps, SwiftInfo)
 
     if swiftinterface:
-        module_context = compile_module_interface(
+        compile_result = compile_module_interface(
             actions = ctx.actions,
             compilation_contexts = get_compilation_contexts(ctx.attr.deps),
             feature_configuration = feature_configuration,
@@ -104,8 +104,9 @@ def _swift_import_impl(ctx):
             swiftinterface_file = swiftinterface,
             swift_infos = swift_infos,
             swift_toolchain = swift_toolchain,
-            target_name = ctx.attr.name,
+            target_name = ctx.label.name,
         )
+        module_context = compile_result.module_context
         swift_outputs = [
             module_context.swift.swiftmodule,
         ] + compact([module_context.swift.swiftdoc])


### PR DESCRIPTION
Cherry-pick: https://github.com/bazelbuild/rules_swift/commit/4c4184942dc091c1b43b0243848876d3c5b90c07

This adds the `target_name` argument that is present in other compile APIs so that supplemental outputs can get unique names based on the name of the Bazel target being compiled (will be used in a follow-up change).

Likewise, this changes the return type of the function from just the module context to a `struct` that contains two fields: `module_context` (the original value), and `supplemental_outputs`, which will eventually be used to provide an indexstore (supported starting from Swift 6.2/Xcode 16.3).

PiperOrigin-RevId: 741516048