### PR TITLE
Ensure undeclared outputs are deleted when not tracked

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -41,6 +41,7 @@ load(
     "SWIFT_FEATURE_COVERAGE_PREFIX_MAP",
     "SWIFT_FEATURE_DBG",
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
+    "SWIFT_FEATURE_DECLARE_SWIFTSOURCEINFO",
     "SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING",
     "SWIFT_FEATURE_DISABLE_CLANG_SPI",
     "SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX",
@@ -561,6 +562,15 @@ def compile_action_configs(
             features = [
                 [SWIFT_FEATURE_COVERAGE_PREFIX_MAP, SWIFT_FEATURE_COVERAGE],
             ],
+        ),
+
+        # Ensure that .swiftsourceinfo files are tracked and not deleted by the worker
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+            ],
+            configurators = [add_arg("-Xwrapped-swift=-emit-swiftsourceinfo")],
+            features = [SWIFT_FEATURE_DECLARE_SWIFTSOURCEINFO],
         ),
     ]
 

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -176,6 +176,12 @@ class SwiftRunner {
   // `-index-store-path`. After running `swiftc` `index-import` copies relevant
   // index outputs into the `index_store_path` to integrate outputs with Bazel.
   std::string global_index_store_import_path_;
+
+  // The path where the module files will be written
+  std::string swift_source_info_path_;
+
+  // Whether `.swiftsourceinfo` files are being generated.
+  bool emit_swift_source_info_;
 };
 
 #endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_SWIFT_RUNNER_H_


### PR DESCRIPTION
In rules_swift < 3.x the .swiftsourceinfo files are unconditionally written to the module path. In rules_swift >= 3.x these same files are no longer tracked by Bazel unless explicitly requested. When using non-sandboxed mode, previous builds will contain these files and cause build failures when Swift tries to use them, in order to work around this compatibility issue, we check the module path for the presence of .swiftsourceinfo files and if they are present but not requested, we remove them.

Testing:

- `bazel clean --expunge`
- `git checkout 2.8.2`
- `bazel build //examples/... --spawn_strategy=local` (pass)
- `git checkout master`
- `bazel build //examples/... --spawn_strategy=local` (failure)
- `git checkout <this-branch>`
- `bazel build //examples/... --spawn_strategy=local` (pass)