### PR TITLE
Add support for env var disabling toolchains

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -394,6 +394,10 @@ toolchain(
     )
 
 def _swift_autoconfiguration_impl(repository_ctx):
+    if repository_ctx.getenv("BAZEL_NO_SWIFT_TOOLCHAIN") == "1":
+        repository_ctx.file("BUILD", "")
+        return
+
     os_name = repository_ctx.os.name.lower()
     is_linux = False
     is_windows = False
@@ -436,7 +440,7 @@ package(default_visibility = ["//visibility:public"])
     )
 
 swift_autoconfiguration = repository_rule(
-    environ = ["CC", "PATH", "ProgramData", "Path"],
+    environ = ["BAZEL_NO_SWIFT_TOOLCHAIN", "CC", "PATH", "ProgramData", "Path"],
     implementation = _swift_autoconfiguration_impl,
     local = True,
 )


### PR DESCRIPTION
It's possible that swift is pulled in through transitive deps and you
want to never setup a toolchain, similar to C++

At the very least this stops it from logging when the swiftc executable
is missing but it's still in your dep tree
