### PR TITLE
Add `clang_deps` attr to `mixed_language_library`

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -1067,16 +1067,16 @@ swift_library(
 
 <pre>
 mixed_language_library(*, <a href="#mixed_language_library-name">name</a>, <a href="#mixed_language_library-always_include_developer_search_paths">always_include_developer_search_paths</a>, <a href="#mixed_language_library-alwayslink">alwayslink</a>, <a href="#mixed_language_library-clang_copts">clang_copts</a>,
-                       <a href="#mixed_language_library-clang_defines">clang_defines</a>, <a href="#mixed_language_library-clang_srcs">clang_srcs</a>, <a href="#mixed_language_library-data">data</a>, <a href="#mixed_language_library-enable_modules">enable_modules</a>, <a href="#mixed_language_library-hdrs">hdrs</a>, <a href="#mixed_language_library-includes">includes</a>, <a href="#mixed_language_library-linkopts">linkopts</a>,
-                       <a href="#mixed_language_library-module_map">module_map</a>, <a href="#mixed_language_library-module_name">module_name</a>, <a href="#mixed_language_library-non_arc_srcs">non_arc_srcs</a>, <a href="#mixed_language_library-package_name">package_name</a>, <a href="#mixed_language_library-private_deps">private_deps</a>, <a href="#mixed_language_library-sdk_dylibs">sdk_dylibs</a>,
-                       <a href="#mixed_language_library-sdk_frameworks">sdk_frameworks</a>, <a href="#mixed_language_library-swift_copts">swift_copts</a>, <a href="#mixed_language_library-swift_defines">swift_defines</a>, <a href="#mixed_language_library-swift_plugins">swift_plugins</a>, <a href="#mixed_language_library-swift_srcs">swift_srcs</a>,
-                       <a href="#mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#mixed_language_library-textual_hdrs">textual_hdrs</a>, <a href="#mixed_language_library-umbrella_header">umbrella_header</a>, <a href="#mixed_language_library-weak_sdk_frameworks">weak_sdk_frameworks</a>, <a href="#mixed_language_library-deps">deps</a>,
-                       <a href="#mixed_language_library-kwargs">**kwargs</a>)
+                       <a href="#mixed_language_library-clang_defines">clang_defines</a>, <a href="#mixed_language_library-clang_deps">clang_deps</a>, <a href="#mixed_language_library-clang_srcs">clang_srcs</a>, <a href="#mixed_language_library-data">data</a>, <a href="#mixed_language_library-enable_modules">enable_modules</a>, <a href="#mixed_language_library-hdrs">hdrs</a>, <a href="#mixed_language_library-includes">includes</a>,
+                       <a href="#mixed_language_library-linkopts">linkopts</a>, <a href="#mixed_language_library-module_map">module_map</a>, <a href="#mixed_language_library-module_name">module_name</a>, <a href="#mixed_language_library-non_arc_srcs">non_arc_srcs</a>, <a href="#mixed_language_library-package_name">package_name</a>, <a href="#mixed_language_library-private_deps">private_deps</a>,
+                       <a href="#mixed_language_library-sdk_dylibs">sdk_dylibs</a>, <a href="#mixed_language_library-sdk_frameworks">sdk_frameworks</a>, <a href="#mixed_language_library-swift_copts">swift_copts</a>, <a href="#mixed_language_library-swift_defines">swift_defines</a>, <a href="#mixed_language_library-swift_plugins">swift_plugins</a>,
+                       <a href="#mixed_language_library-swift_srcs">swift_srcs</a>, <a href="#mixed_language_library-swiftc_inputs">swiftc_inputs</a>, <a href="#mixed_language_library-textual_hdrs">textual_hdrs</a>, <a href="#mixed_language_library-umbrella_header">umbrella_header</a>, <a href="#mixed_language_library-weak_sdk_frameworks">weak_sdk_frameworks</a>,
+                       <a href="#mixed_language_library-deps">deps</a>, <a href="#mixed_language_library-kwargs">**kwargs</a>)
 </pre>
 
 Creates a mixed language library from a Clang and Swift library target     pair.
 
-Note: In the future `swift_library` will support mixed-langauge libraries.
+Note: In the future `swift_library` will support mixed-language libraries.
 Once that is the case, this macro will be deprecated.
 
 
@@ -1090,6 +1090,7 @@ Once that is the case, this macro will be deprecated.
 | <a id="mixed_language_library-alwayslink"></a>alwayslink |  If true, any binary that depends (directly or indirectly) on this library will link in all the object files for the files listed in `clang_srcs` and `swift_srcs`, even if some contain no symbols referenced by the binary. This is useful if your code isn't explicitly called by code in the binary; for example, if you rely on runtime checks for protocol conformances added in extensions in the library but do not directly reference any other symbols in the object file that adds that conformance.   |  `False` |
 | <a id="mixed_language_library-clang_copts"></a>clang_copts |  The compiler flags for the clang library. These will only be used for the clang library. If you want them to affect the swift library as well, you need to pass them with `-Xcc` in `swift_copts`.   |  `[]` |
 | <a id="mixed_language_library-clang_defines"></a>clang_defines |  Extra clang `-D` flags to pass to the compiler. They should be in the form `KEY=VALUE` or simply `KEY` and are passed not only to the compiler for this target (as `clang_copts` are) but also to all dependers of this target. Subject to "Make variable" substitution and Bourne shell tokenization.   |  `[]` |
+| <a id="mixed_language_library-clang_deps"></a>clang_deps |  A list of targets that are dependencies of only the clang library.   |  `[]` |
 | <a id="mixed_language_library-clang_srcs"></a>clang_srcs |  The list of C, C++, Objective-C, or Objective-C++ sources for the clang library.   |  none |
 | <a id="mixed_language_library-data"></a>data |  The list of files needed by this target at runtime.<br><br>Files and targets named in the `data` attribute will appear in the `*.runfiles` area of this target, if it has one. This may include data files needed by a binary or library, or other programs needed by it.   |  `[]` |
 | <a id="mixed_language_library-enable_modules"></a>enable_modules |  Enables clang module support (via `-fmodules`). Setting this to `True`  will allow you to `@import` system headers and other targets: `@import UIKit;` `@import path_to_package_target;`.   |  `False` |

--- a/mixed_language/mixed_language_library.bzl
+++ b/mixed_language/mixed_language_library.bzl
@@ -39,6 +39,7 @@ def mixed_language_library(
         alwayslink = False,
         clang_copts = [],
         clang_defines = [],
+        clang_deps = [],
         clang_srcs,
         data = [],
         enable_modules = False,
@@ -65,7 +66,7 @@ def mixed_language_library(
     """Creates a mixed language library from a Clang and Swift library target \
     pair.
 
-    Note: In the future `swift_library` will support mixed-langauge libraries.
+    Note: In the future `swift_library` will support mixed-language libraries.
     Once that is the case, this macro will be deprecated.
 
     Args:
@@ -90,6 +91,8 @@ def mixed_language_library(
             only to the compiler for this target (as `clang_copts` are) but also
             to all dependers of this target. Subject to "Make variable"
             substitution and Bourne shell tokenization.
+        clang_deps: A list of targets that are dependencies of only the
+            clang library.
         clang_srcs: The list of C, C++, Objective-C, or Objective-C++ sources
             for the clang library.
         data: The list of files needed by this target at runtime.
@@ -379,7 +382,7 @@ a mixed language Swift library, use a clang only library rule like \
         testonly = testonly,
         textual_hdrs = textual_hdrs,
         weak_sdk_frameworks = weak_sdk_frameworks,
-        deps = deps,
+        deps = deps + clang_deps,
         **kwargs
     )
 


### PR DESCRIPTION
At Square, we're using a headermap for the Swift generated header, so that the objective-C half of a module is able to import it using `#import <Module/Module-Swift.h>`.

This headermap target can't be placed in `deps`, as doing so creates a dependency cycle.

Here is an example of what the use case looks like: https://github.com/bazelbuild/rules_swift/compare/master...jschear:rules_swift:js/demo_swift_header_imports_in_clang_half

```
header_map(
    name = "swift_headermap",
    module_name = "MixedAnswer",
    propagate_include = False,
    # This relies on us knowing the naming scheme used for internal targets in mixed_language_library, which is not ideal.
    deps = ["MixedAnswer_swift"],
)

mixed_language_library(
    name = "MixedAnswer",
    hdrs = ["MixedAnswer.h"],
    clang_copts = [
        "-I$(execpath :swift_headermap)",
        "-I.",
    ],
    clang_deps = [":swift_headermap"],
    clang_srcs = [
        "MixedAnswer.m",
        "MixedAnswerPrivate.m",
        "MixedAnswerPrivate.h",
    ],
    enable_modules = True,
    module_name = "MixedAnswer",
    swift_srcs = [
        "MixedAnswer.swift",
    ],
    target_compatible_with = ["@platforms//os:macos"],
)
```