### PR TITLE
fix rules_cc for 7.x WORKSPACE/non-bzlmod users

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -48,13 +48,13 @@ x_defaults:
       - "//tools/..."
 
 tasks:
-  # macos_7:
-  #   name: "Previous LTS with no bzlmod"
-  #   bazel: 7.x
-  #   build_flags:
-  #     - "--noenable_bzlmod"
-  #     - "--enable_workspace"
-  #   <<: *mac_common
+  macos_7:
+    name: "Previous LTS with no bzlmod"
+    bazel: 7.x
+    build_flags:
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
+    <<: *mac_common
 
   macos_latest:
     name: "Current LTS"
@@ -75,17 +75,17 @@ tasks:
     - .bazelci/update_workspace_to_deps_heads.sh
     <<: *mac_common
 
-  # ubuntu2004_7:
-  #   name: "Previous LTS with no bzlmod"
-  #   bazel: 7.x
-  #   shell_commands:
-  #     - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
-  #     - "mkdir $SWIFT_HOME"
-  #     - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
-  #   build_flags:
-  #     - "--noenable_bzlmod"
-  #     - "--enable_workspace"
-  #   <<: *linux_common
+  ubuntu2004_7:
+    name: "Previous LTS with no bzlmod"
+    bazel: 7.x
+    shell_commands:
+      - "echo --- Downloading and extracting Swift $SWIFT_VERSION to $SWIFT_HOME"
+      - "mkdir $SWIFT_HOME"
+      - "curl https://download.swift.org/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz | tar xvz --strip-components=1 -C $SWIFT_HOME"
+    build_flags:
+      - "--noenable_bzlmod"
+      - "--enable_workspace"
+    <<: *linux_common
 
   ubuntu2004_latest:
     name: "Current LTS"

--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,7 @@ exports_files(["LICENSE"])
 # Consumed by Bazel integration tests (such as those defined in rules_apple).
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = [
         "WORKSPACE",
         "//swift:for_bazel_tests",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,8 +14,7 @@ bazel_dep(name = "apple_support", version = "1.21.0", repo_name = "build_bazel_a
 bazel_dep(name = "rules_cc", version = "0.1.2")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
+bazel_dep(name = "protobuf", version = "27.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "nlohmann_json", version = "3.6.1", repo_name = "com_github_nlohmann_json")
 bazel_dep(
     name = "swift_argument_parser",

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -776,7 +776,7 @@ swift_proto_library(<a href="#swift_proto_library-name">name</a>, <a href="#swif
 Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -794,7 +794,7 @@ If your protos depend on protos from other targets, add dependencies between the
 swift_proto_library targets which mirror the dependencies between the proto targets.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/examples/xplatform/custom_swift_proto_compiler/protos/BUILD
+++ b/examples/xplatform/custom_swift_proto_compiler/protos/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "example_proto",

--- a/examples/xplatform/grpc/service/BUILD
+++ b/examples/xplatform/grpc/service/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/examples/xplatform/proto/BUILD
+++ b/examples/xplatform/proto/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 

--- a/examples/xplatform/proto_files/BUILD
+++ b/examples/xplatform/proto_files/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 

--- a/examples/xplatform/proto_glob/BUILD
+++ b/examples/xplatform/proto_glob/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 

--- a/examples/xplatform/proto_library_group/request/BUILD
+++ b/examples/xplatform/proto_library_group/request/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "request_proto",

--- a/examples/xplatform/proto_library_group/response/BUILD
+++ b/examples/xplatform/proto_library_group/response/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@rules_proto//proto:defs.bzl",
-    "proto_library",
-)
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "response_proto",

--- a/examples/xplatform/proto_library_group/service/BUILD
+++ b/examples/xplatform/proto_library_group/service/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 load("//proto:swift_proto_library_group.bzl", "swift_proto_library_group")
 

--- a/examples/xplatform/proto_path/protos/package_1/BUILD
+++ b/examples/xplatform/proto_path/protos/package_1/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/examples/xplatform/proto_path/protos/package_2/BUILD
+++ b/examples/xplatform/proto_path/protos/package_2/BUILD
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/proto/BUILD
+++ b/proto/BUILD
@@ -40,7 +40,7 @@ bzl_library(
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
-        "@rules_proto//proto:defs",
+        "@com_google_protobuf//bazel/common:proto_info_bzl",
     ],
 )
 
@@ -60,7 +60,7 @@ bzl_library(
         "//swift/internal:toolchain_utils",
         "//swift/internal:utils",
         "@bazel_skylib//lib:dicts",
-        "@rules_proto//proto:defs",
+        "@com_google_protobuf//bazel/common:proto_info_bzl",
     ],
 )
 

--- a/proto/swift_proto_library.bzl
+++ b/proto/swift_proto_library.bzl
@@ -16,14 +16,8 @@
 Defines a rule that generates a Swift library from protocol buffer sources.
 """
 
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@rules_proto//proto:defs.bzl",
-    "ProtoInfo",
-)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load("//swift:module_name.bzl", "derive_swift_module_name")
 load("//swift:providers.bzl", "SwiftProtoCompilerInfo")
 load("//swift:swift_clang_module_aspect.bzl", "swift_clang_module_aspect")
@@ -154,7 +148,7 @@ on which fields are accepted and how they are used.
 Generates a Swift static library from one or more targets producing `ProtoInfo`.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(
@@ -172,7 +166,7 @@ If your protos depend on protos from other targets, add dependencies between the
 swift_proto_library targets which mirror the dependencies between the proto targets.
 
 ```python
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("//proto:swift_proto_library.bzl", "swift_proto_library")
 
 proto_library(

--- a/proto/swift_proto_library_group.bzl
+++ b/proto/swift_proto_library_group.bzl
@@ -16,14 +16,8 @@
 Defines a rule that generates Swift libraries from protocol buffer sources.
 """
 
-load(
-    "@bazel_skylib//lib:dicts.bzl",
-    "dicts",
-)
-load(
-    "@rules_proto//proto:defs.bzl",
-    "ProtoInfo",
-)
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@com_google_protobuf//bazel/common:proto_info.bzl", "ProtoInfo")
 load(
     "//proto:swift_proto_utils.bzl",
     "SwiftProtoCcInfo",

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -22,8 +22,8 @@ bzl_library(
     name = "extras",
     srcs = ["extras.bzl"],
     deps = [
+        "@bazel_features//:deps",
         "@build_bazel_apple_support//lib:repositories",
-        "@bazel_features//:deps"
     ],
 )
 

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -23,7 +23,7 @@ bzl_library(
     srcs = ["extras.bzl"],
     deps = [
         "@build_bazel_apple_support//lib:repositories",
-        "@rules_proto//proto:repositories",
+        # "@rules_proto//proto:repositories",
     ],
 )
 
@@ -358,7 +358,7 @@ bzl_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//swift/internal:for_bazel_tests",
         "//swift/toolchains:for_bazel_tests",

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -23,7 +23,7 @@ bzl_library(
     srcs = ["extras.bzl"],
     deps = [
         "@build_bazel_apple_support//lib:repositories",
-        # "@rules_proto//proto:repositories",
+        "@bazel_features//:deps"
     ],
 )
 

--- a/swift/extras.bzl
+++ b/swift/extras.bzl
@@ -18,11 +18,6 @@ dependencies of the Swift rules.
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-# load(
-#     "@rules_proto//proto:repositories.bzl",
-#     "rules_proto_dependencies",
-#     "rules_proto_toolchains",
-# )
 
 def swift_rules_extra_dependencies():
     """Fetches transitive repositories of the dependencies of `rules_swift`.
@@ -34,9 +29,5 @@ def swift_rules_extra_dependencies():
     """
 
     apple_support_dependencies()
-
-    # rules_proto_dependencies()
-
-    # rules_proto_toolchains()
 
     bazel_features_deps()

--- a/swift/extras.bzl
+++ b/swift/extras.bzl
@@ -18,11 +18,11 @@ dependencies of the Swift rules.
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
-load(
-    "@rules_proto//proto:repositories.bzl",
-    "rules_proto_dependencies",
-    "rules_proto_toolchains",
-)
+# load(
+#     "@rules_proto//proto:repositories.bzl",
+#     "rules_proto_dependencies",
+#     "rules_proto_toolchains",
+# )
 
 def swift_rules_extra_dependencies():
     """Fetches transitive repositories of the dependencies of `rules_swift`.
@@ -35,8 +35,8 @@ def swift_rules_extra_dependencies():
 
     apple_support_dependencies()
 
-    rules_proto_dependencies()
+    # rules_proto_dependencies()
 
-    rules_proto_toolchains()
+    # rules_proto_toolchains()
 
     bazel_features_deps()

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -331,7 +331,7 @@ bzl_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         # We should be depending on a filegroup here that represents this file
         # and its dependencies, but it doesn't exist yet.

--- a/swift/repositories.bzl
+++ b/swift/repositories.bzl
@@ -63,12 +63,18 @@ def swift_rules_dependencies(include_bzlmod_ready_dependencies = True):
 
         _maybe(
             http_archive,
-            name = "rules_proto",
-            urls = [
-                "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-            ],
-            sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-            strip_prefix = "rules_proto-5.3.0-21.7",
+            name = "rules_cc",
+            urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.1.2/rules_cc-0.1.2.tar.gz"],
+            sha256 = "d62624b45e0912713dcd3b8e30ba6ae55418ed6bf99e6d135cd61b8addae312b",
+            strip_prefix = "rules_cc-0.1.2",
+        )
+
+        _maybe(
+            http_archive,
+            name = "com_google_protobuf",
+            urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v27.0/protobuf-27.0.tar.gz"],
+            sha256 = "da288bf1daa6c04d03a9051781caa52aceb9163586bff9aa6cfb12f69b9395aa",
+            strip_prefix = "protobuf-27.0",
         )
 
         _maybe(

--- a/swift/toolchains/BUILD
+++ b/swift/toolchains/BUILD
@@ -64,7 +64,7 @@ bzl_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//swift/toolchains/config:for_bazel_tests",
     ],

--- a/swift/toolchains/config/BUILD
+++ b/swift/toolchains/config/BUILD
@@ -86,7 +86,7 @@ bzl_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//swift/toolchains:__pkg__",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,10 +1,9 @@
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//third_party/bazel_protos:for_bazel_tests",
-        "//third_party/rules_proto:for_bazel_tests",
     ],
     visibility = [
         "//:__pkg__",

--- a/third_party/bazel_protos/BUILD
+++ b/third_party/bazel_protos/BUILD
@@ -1,5 +1,5 @@
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 licenses(["notice"])
 
@@ -17,7 +17,7 @@ cc_proto_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//third_party:__pkg__",

--- a/third_party/rules_proto/BUILD
+++ b/third_party/rules_proto/BUILD
@@ -1,9 +1,0 @@
-# Consumed by Bazel integration tests.
-filegroup(
-    name = "for_bazel_tests",
-    testonly = 1,
-    srcs = glob(["**"]),
-    visibility = [
-        "//third_party:__pkg__",
-    ],
-)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -5,7 +5,7 @@ licenses(["notice"])
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]) + [
         "//tools/common:for_bazel_tests",
         "//tools/mkdir_and_run:for_bazel_tests",

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -57,7 +57,7 @@ cc_library(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//tools:__pkg__",

--- a/tools/mkdir_and_run/BUILD
+++ b/tools/mkdir_and_run/BUILD
@@ -18,7 +18,7 @@ native_binary(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//tools:__pkg__",

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -140,7 +140,7 @@ alias(
 # Consumed by Bazel integration tests.
 filegroup(
     name = "for_bazel_tests",
-    testonly = 1,
+    testonly = True,
     srcs = glob(["**"]),
     visibility = [
         "//tools:__pkg__",


### PR DESCRIPTION
only way i could figure to get this to work was to not assist in standing up neither `protobuf_deps()` nor `rules_cc_dependencies()` in `swift_extra_dependencies()` – this works around the ordering issue that breaks transitive dep loading of both rules_python/rules_java and our stardoc configuration