### PR TITLE
Fix .swiftsourceinfo readonly bugs in version 3+

### DIFF
--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -27,6 +27,14 @@ bool ArgumentEnablesWMO(const std::string &arg) {
          arg == "-force-single-frontend-invocation";
 }
 
+bool StripPrefix(const std::string &prefix, std::string &str) {
+  if (str.find(prefix) != 0) {
+    return false;
+  }
+  str.erase(0, prefix.size());
+  return true;
+}
+
 namespace {
 
 // Creates a temporary file and writes the given arguments to it, one per line.
@@ -90,17 +98,6 @@ static std::string Unescape(const std::string &arg) {
   }
 
   return result;
-}
-
-// If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
-// function returns true. Otherwise, `str` is left unmodified and the function
-// returns `false`.
-static bool StripPrefix(const std::string &prefix, std::string &str) {
-  if (str.find(prefix) != 0) {
-    return false;
-  }
-  str.erase(0, prefix.size());
-  return true;
 }
 
 }  // namespace

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -29,6 +29,11 @@
 // optimization in the compiler.
 extern bool ArgumentEnablesWMO(const std::string &arg);
 
+// If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
+// function returns true. Otherwise, `str` is left unmodified and the function
+// returns `false`.
+extern bool StripPrefix(const std::string &prefix, std::string &str);
+
 // Handles spawning the Swift compiler driver, making any required substitutions
 // of the command line arguments (for example, Bazel's magic Xcode placeholder
 // strings).

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -86,13 +86,19 @@ void WorkProcessor::ProcessWorkRequest(
   std::string emit_objc_header_path;
   bool is_wmo = false;
   bool is_dump_ast = false;
+  bool emit_swift_source_info = false;
 
   std::string prev_arg;
   for (std::string arg : request.arguments) {
     std::string original_arg = arg;
     // Peel off the `-output-file-map` argument, so we can rewrite it if
     // necessary later.
-    if (arg == "-output-file-map") {
+    if (StripPrefix("-Xwrapped-swift=", arg)) {
+      if (arg == "-emit-swiftsourceinfo") {
+        emit_swift_source_info = true;
+      }
+      arg.clear();
+    } else if (arg == "-output-file-map") {
       arg.clear();
     } else if (arg == "-dump-ast") {
       is_dump_ast = true;
@@ -153,11 +159,23 @@ void WorkProcessor::ProcessWorkRequest(
 
     for (const auto &expected_object_pair :
          output_file_map.incremental_inputs()) {
+
+      const auto expected_object_path = std::filesystem::path(expected_object_pair.second);
+
+      // In rules_swift < 3.x the .swiftsourceinfo files are unconditionally written to the module path.
+      // In rules_swift >= 3.x these same files are no longer tracked by Bazel unless explicitly requested.
+      // When using non-sandboxed mode, previous builds will contain these files and cause build failures
+      // when Swift tries to use them, in order to work around this compatibility issue, we remove them if they are
+      // present but not requested.
+      if (expected_object_path.extension() == ".swiftsourceinfo" && !emit_swift_source_info) {
+        std::filesystem::remove(expected_object_path);
+      }
+
       // Bazel creates the intermediate directories for the files declared at
       // analysis time, but not any any deeper directories, like one can have
       // with -emit-objc-header-path, so we need to create those.
       const std::string dir_path =
-          std::filesystem::path(expected_object_pair.second)
+          expected_object_path
               .parent_path()
               .string();
       dir_paths.insert(dir_path);


### PR DESCRIPTION
Similar to #1533 but when using `--strategy=worker`


In rules_swift < 3.x the .swiftsourceinfo files are unconditionally written to the module path. In rules_swift >= 3.x these same files are no longer tracked by Bazel unless explicitly requested. When using non-sandboxed mode, previous builds will contain these files and cause build failures when Swift tries to use them, in order to work around this compatibility issue, we check the module path for the presence of .swiftsourceinfo files and if they are present but not requested, we remove them.

Testing:

- `bazel clean --expunge`
- `git checkout 2.8.2`
- `bazel build @com_github_apple_swift_argument_parser//... --strategy=worker,local --worker_sandboxing=false` (pass)
- `git checkout master`
- `bazel build @com_github_apple_swift_argument_parser//... --strategy=worker,local --worker_sandboxing=false` (failure)
- `git checkout <this-branch>`
- `bazel build @com_github_apple_swift_argument_parser//... --strategy=worker,local --worker_sandboxing=false` (pass)
