### PR TITLE
Fix dropping args when checking for `-Xwrapped-swift` arg in worker

### DIFF
--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -27,14 +27,6 @@ bool ArgumentEnablesWMO(const std::string &arg) {
          arg == "-force-single-frontend-invocation";
 }
 
-bool StripPrefix(const std::string &prefix, std::string &str) {
-  if (str.find(prefix) != 0) {
-    return false;
-  }
-  str.erase(0, prefix.size());
-  return true;
-}
-
 namespace {
 
 // Creates a temporary file and writes the given arguments to it, one per line.
@@ -98,6 +90,17 @@ static std::string Unescape(const std::string &arg) {
   }
 
   return result;
+}
+
+// If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
+// function returns true. Otherwise, `str` is left unmodified and the function
+// returns `false`.
+static bool StripPrefix(const std::string &prefix, std::string &str) {
+  if (str.find(prefix) != 0) {
+    return false;
+  }
+  str.erase(0, prefix.size());
+  return true;
 }
 
 }  // namespace

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -29,11 +29,6 @@
 // optimization in the compiler.
 extern bool ArgumentEnablesWMO(const std::string &arg);
 
-// If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
-// function returns true. Otherwise, `str` is left unmodified and the function
-// returns `false`.
-extern bool StripPrefix(const std::string &prefix, std::string &str);
-
 // Handles spawning the Swift compiler driver, making any required substitutions
 // of the command line arguments (for example, Bazel's magic Xcode placeholder
 // strings).


### PR DESCRIPTION
Reverts some of #1550 to fix bugs with dropped args to instead use the existing logic with `prev_arg` with the full expected arg when checking if emitting `.swiftsourceinfo` files is enabled.

This continues to fix the readonly (file exists) bugs that #1550 originally was made for while fixing any regression to argument parsing in the worker code.