### PR TITLE
Pass -file-compilation-dir . explicitly to the Swift driver so that .swiftmodule files are hermetic.

### DIFF
--- a/swift/internal/action_names.bzl
+++ b/swift/internal/action_names.bzl
@@ -62,3 +62,10 @@ def all_action_names():
         SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
         SWIFT_ACTION_SYNTHESIZE_INTERFACE,
     )
+
+def all_compile_action_names():
+    """Returns all actions that compile source files."""
+    return [
+        SWIFT_ACTION_COMPILE,
+        SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+    ]

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -26,6 +26,7 @@ load(
     "SWIFT_ACTION_PRECOMPILE_C_MODULE",
     "SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT",
     "SWIFT_ACTION_SYNTHESIZE_INTERFACE",
+    "all_compile_action_names",
 )
 load(
     "//swift/internal:developer_dirs.bzl",

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -642,6 +642,21 @@ def compile_action_configs(
     #### Flags controlling how Swift/Clang modular inputs are processed
 
     action_configs += [
+
+        # When `-g` is passed to the compiler, the driver will pass
+        # `-file-compilation-dir <CWD>` to the frontend, which in turn passes
+        # `-ffile-compilation-dir <CWD>` to Clang. This CWD is fully resolved so
+        # it contains the absolute path to the workspace. If we pass
+        # `-file-compilation-dir .`, then the driver/frontend preserve that
+        # spelling, ensuring that the ClangImporter options section of the
+        # `.swiftmodule` file is hermetic.
+        ActionConfigInfo(
+            actions = all_compile_action_names(),
+            configurators = [
+                add_arg("-file-compilation-dir", "."),
+            ],
+        ),
+
         # Treat paths in .modulemap files as workspace-relative, not modulemap-
         # relative.
         ActionConfigInfo(


### PR DESCRIPTION
Cherry pick: [9c4fbaedfaca0932cdca51f7d8b6e882890a727a](https://github.com/bazelbuild/rules_swift/commit/9c4fbaedfaca0932cdca51f7d8b6e882890a727a)