### PR TITLE
Unconditionally add the testing macro plugin subdirectory to compile actions.

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -46,6 +46,7 @@ load(
     "SWIFT_ACTION_PRECOMPILE_C_MODULE",
     "SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT",
     "SWIFT_ACTION_SYNTHESIZE_INTERFACE",
+    "all_compile_action_names",
 )
 load("//swift/internal:attrs.bzl", "swift_toolchain_driver_attrs")
 load("//swift/internal:developer_dirs.bzl", "swift_developer_lib_dir")


### PR DESCRIPTION
Xcode 26.0 beta 5 has isolated this plugin to its own subdirectory and Xcode only passes it to the compiler when building test targets (previous versions had a symlink to make the default path work, but beta 5 removed that symlink). We don't want to make that distinction in our rules, so it's fine to just unconditionally pass it.

Cherry pick: [15da0d2eadfbfedf8b673b5eb0903080c35111e1](https://github.com/bazelbuild/rules_swift/commit/15da0d2eadfbfedf8b673b5eb0903080c35111e1)