### PR TITLE
Ensure that PCMs are hermetic on Xcode 16 and higher.

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -132,6 +132,11 @@ SWIFT_FEATURE_FULL_DEBUG_INFO = "swift.full_debug_info"
 # Use CodeView debug information, which enables generation of PDBs for debugging.
 SWIFT_FEATURE_CODEVIEW_DEBUG_INFO = "swift.codeview_debug_info"
 
+# If enabled, paths embedded into precompiled Clang modules will be relative to
+# the workspace, not to the modulemap file location. Paths in the module maps
+# themselves will still be treated as modulemap-relative.
+SWIFT_FEATURE_MODULE_HOME_IS_CWD = "swift.module_home_is_cwd"
+
 # If enabled, compilation actions and module map generation will assume that the
 # header paths in module maps are relative to the current working directory
 # (i.e., the workspace root); if disabled, header paths in module maps are

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -56,6 +56,7 @@ load(
     "SWIFT_FEATURE_DEBUG_PREFIX_MAP",
     "SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX",
     "SWIFT_FEATURE_FILE_PREFIX_MAP",
+    "SWIFT_FEATURE_MODULE_HOME_IS_CWD",
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
@@ -708,7 +709,16 @@ def _xcode_swift_toolchain_impl(ctx):
         requested_features.append(SWIFT_FEATURE_DISABLE_SWIFT_SANDBOX)
 
     if _is_xcode_at_least_version(xcode_config, "16.0"):
-        requested_features.append(SWIFT_FEATURE__SUPPORTS_V6)
+        requested_features.extend([
+            SWIFT_FEATURE__SUPPORTS_V6,
+            # Ensure hermetic PCM files (no absolute workspace paths). This flag
+            # is actually supported on Xcode 15.x as well, but it's bugged; a
+            # `MODULE_DIRECTORY` field remains in the PCM file that has the
+            # absolute workspace path, so it's not hermetic, and worse, it
+            # causes other compilation errors in the unfortunately common case
+            # where two modules contain the same header.
+            SWIFT_FEATURE_MODULE_HOME_IS_CWD,
+        ])
 
     unsupported_features = ctx.disabled_features + [
         SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD,

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -347,6 +347,8 @@ bool SwiftRunner::ProcessArgument(
       // Process default arguments
       if (arg == "-index-store-path") {
         consumer("-index-store-path");
+        ++itr;
+
         // If there was a global index store set, pass that to swiftc.
         // Otherwise, pass the users. We later copy index data onto the users.
         if (global_index_store_import_path_ != "") {

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -347,8 +347,6 @@ bool SwiftRunner::ProcessArgument(
       // Process default arguments
       if (arg == "-index-store-path") {
         consumer("-index-store-path");
-        ++itr;
-
         // If there was a global index store set, pass that to swiftc.
         // Otherwise, pass the users. We later copy index data onto the users.
         if (global_index_store_import_path_ != "") {


### PR DESCRIPTION
Also add a `DEVELOPER_DIR` remapping for debug info and index data to remove absolute paths to Xcode in those.

Cherry pick: [038b5bd71e3fad04e2cfa5a4d080533bde4f350d](https://github.com/bazelbuild/rules_swift/commit/038b5bd71e3fad04e2cfa5a4d080533bde4f350d)