### PR TITLE
Use apple constraints over config_setting_group in select

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])
 alias(
     name = "swizzle_absolute_xcttestsourcelocation",
     actual = select({
-        "@build_bazel_apple_support//configs:apple": (
+        "@build_bazel_apple_support//constraints:apple": (
             "@build_bazel_apple_support//lib:swizzle_absolute_xcttestsourcelocation"
         ),
         "//conditions:default": ":dummy_swizzle_absolute_xcttestsourcelocation",

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -75,7 +75,7 @@ cc_library(
         ],
     }),
     data = select({
-        "@build_bazel_apple_support//configs:apple": [
+        "@build_bazel_apple_support//constraints:apple": [
             "@build_bazel_rules_swift_index_import_5_8//:index_import",
             "@build_bazel_rules_swift_index_import_6_1//:index_import",
         ],


### PR DESCRIPTION
The intent of @apple_support//configs:apple is to provide a way for users to select on whether the current platform is an apple one or not.

It does that by iterating over APPLE_PLATFORMS_CONSTRAINTS, and checking whether the "cpus" is one of the apple known CPUs. This works in the general case, but in the exceptional case where the user wants to define custom apple platforms, it is a problem.

So in this patchset we're switching to using the constraint directly over the config_setting_group(). It should be a functional no-op for the general case, but it provides more flexibility if case the user needs a higher degree of customization.