### PR TITLE
feat(toolchain): add copts and objc_copts attributes to toolchains

### DIFF
--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -491,7 +491,7 @@ def _swift_toolchain_impl(ctx):
         target_triple = target_triple,
         sdkroot = ctx.attr.sdkroot,
         xctest_version = ctx.attr.xctest_version,
-        additional_swiftc_copts = swiftcopts,
+        additional_swiftc_copts = ctx.attr.copts + swiftcopts,
     )
 
     if ctx.attr.os == "windows":
@@ -626,6 +626,11 @@ configuration options that are applied to targets on a per-package basis.
             "version_file": attr.label(
                 mandatory = True,
                 allow_single_file = True,
+            ),
+            "copts": attr.string_list(
+                doc = """\
+A list of additional Swift compiler flags that should be passed to Swift compile actions.
+""",
             ),
             "_cc_toolchain": attr.label(
                 default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -736,12 +736,12 @@ def _xcode_swift_toolchain_impl(ctx):
         xcode_config = xcode_config,
     )
     all_action_configs = _all_action_configs(
-        additional_objc_copts = command_line_objc_copts(
+        additional_objc_copts = ctx.attr.objc_copts + command_line_objc_copts(
             ctx.var["COMPILATION_MODE"],
             ctx.fragments.cpp,
             ctx.fragments.objc,
         ),
-        additional_swiftc_copts = swiftcopts,
+        additional_swiftc_copts = ctx.attr.copts + swiftcopts,
         apple_toolchain = apple_toolchain,
         generated_header_rewriter = generated_header_rewriter,
         needs_resource_directory = swift_executable or toolchain_root,
@@ -929,6 +929,17 @@ configuration options that are applied to targets on a per-package basis.
                 doc = """\
 The label of the file specifying a list of protocols for extraction of conformances'
 const values.
+""",
+            ),
+            "copts": attr.string_list(
+                doc = """\
+A list of additional Swift compiler flags that should be passed to Swift compile actions.
+""",
+            ),
+            "objc_copts": attr.string_list(
+                doc = """\
+A list of additional Objective-C compiler flags that should be passed (preceded by `-Xcc`)
+to Swift compile actions *and* Swift explicit module precompile actions.
 """,
             ),
             "_cc_toolchain": attr.label(


### PR DESCRIPTION
When using rules_swift with a custom (rules based) cc_toolchain, it is sometimes useful to propagate certain flags to every swift invocation. And while a cc_library() could potentially be used in implicit_deps to pass the usual options (-isystem, -iquote, -D, etc...), the CcInfo provider does not allow propagating every option.

Some options in particular (such as -Xclang -internal-externc-system) cannot currently be propagated that way, and they can nonetheless be necessary in certain environment.

So we're making the current toolchain rules a tad more flexible in this commit, by allowing the user to specify "objc_copts" (for xcode only) and "copts" at toolchain parameters. The content of these attributes is then added to the corresponding compilation actions.