### PR TITLE
Make sure that symbol graph extraction and interface synthesis honor `-Xcc` flags that are derived from Bazel's `--objccopt` flags and from `--compilation_mode`.

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1269,6 +1269,8 @@ def compile_action_configs(
                     SWIFT_ACTION_DERIVE_FILES,
                     SWIFT_ACTION_DUMP_AST,
                     SWIFT_ACTION_PRECOMPILE_C_MODULE,
+                    SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
+                    SWIFT_ACTION_SYNTHESIZE_INTERFACE,
                 ],
                 configurators = [
                     lambda _, args: args.add_all(


### PR DESCRIPTION
Without these, the symbol graph/synthesis invocation will not be able to load explicit modules produced by the compiler when building dependencies.

PiperOrigin-RevId: 803055033

Cherry-picks: https://github.com/bazelbuild/rules_swift/commit/f79116bd94adaee2cd43201f6fad5e7ce6f0327e