### PR TITLE
Rename private num threads feature to match upstream

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -58,7 +58,7 @@ load(
     "SWIFT_FEATURE_THIN_LTO",
     "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
     "SWIFT_FEATURE_VFSOVERLAY",
-    "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
+    "SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
 load(
@@ -1697,7 +1697,7 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
     # checking the flags if the feature is disabled.
     is_single_threaded = is_feature_enabled(
         feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS,
+        feature_name = SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS,
     ) or find_num_threads_flag_value(user_compile_flags) == 0
 
     return struct(

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -328,10 +328,10 @@ SWIFT_FEATURE_REMAP_XCODE_PATH = "swift.remap_xcode_path"
 # enable, disable, or query this feature.
 SWIFT_FEATURE__WMO_IN_SWIFTCOPTS = "swift._wmo_in_swiftcopts"
 
-# A private feature that is set by the toolchain if the flags `-num-threads 0`
+# A private feature that is set by the toolchain if the flags `-num-threads 1`
 # were passed on the command line using `--swiftcopt`. Users should never
 # manually enable, disable, or query this feature.
-SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS = "swift._num_threads_0_in_swiftcopts"
+SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS = "swift._num_threads_1_in_swiftcopts"
 
 # A feature to enable setting pch-output-dir
 # This is a directory to persist automatically created precompiled bridging headers

--- a/swift/internal/wmo.bzl
+++ b/swift/internal/wmo.bzl
@@ -16,7 +16,7 @@
 
 load(
     ":feature_names.bzl",
-    "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
+    "SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
 )
 
@@ -49,7 +49,7 @@ def features_from_swiftcopts(swiftcopts):
     if is_wmo_manually_requested(user_compile_flags = swiftcopts):
         features.append(SWIFT_FEATURE__WMO_IN_SWIFTCOPTS)
     if find_num_threads_flag_value(user_compile_flags = swiftcopts) == 0:
-        features.append(SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS)
+        features.append(SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS)
     return features
 
 def find_num_threads_flag_value(user_compile_flags):
@@ -110,7 +110,7 @@ def wmo_features_from_swiftcopts(swiftcopts):
     if is_wmo_manually_requested(user_compile_flags = swiftcopts):
         features.append(SWIFT_FEATURE__WMO_IN_SWIFTCOPTS)
     if find_num_threads_flag_value(user_compile_flags = swiftcopts) == 1:
-        features.append(SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS)
+        features.append(SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS)
     return features
 
 def _safe_int(s):

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -84,7 +84,7 @@ load(
     "SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE",
     "SWIFT_FEATURE_USE_PCH_OUTPUT_DIR",
     "SWIFT_FEATURE_VFSOVERLAY",
-    "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
+    "SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
     "SWIFT_FEATURE__SUPPORTS_V6",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
@@ -1057,7 +1057,7 @@ def compile_action_configs(
                 [SWIFT_FEATURE_OPT, SWIFT_FEATURE_OPT_USES_WMO],
                 [SWIFT_FEATURE__WMO_IN_SWIFTCOPTS],
             ],
-            not_features = [SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS],
+            not_features = [SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS],
         ),
         ActionConfigInfo(
             actions = [
@@ -1073,7 +1073,7 @@ def compile_action_configs(
             ],
             not_features = [
                 [SWIFT_FEATURE_OPT, SWIFT_FEATURE_OPT_USES_WMO],
-                [SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS],
+                [SWIFT_FEATURE__NUM_THREADS_1_IN_SWIFTCOPTS],
             ],
         ),
 


### PR DESCRIPTION
This was re-applied in: https://github.com/bazelbuild/rules_swift/commit/2f4a41cb23f17645ab6a4fca2fe9749948e95a2a but was not cherry-picked. The intent seems the same so we can match the name to upstream to avoid confusion.