### PR TITLE
Make sure that .swiftinterface compile actions also use `-file-prefix-map`, so that indexstores emitted by those actions are also deterministic.

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -535,6 +535,7 @@ def compile_action_configs(
         ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
             ],
             configurators = [
                 add_arg("-Xwrapped-swift=-file-prefix-pwd-is-dot"),


### PR DESCRIPTION
Cherry-pick: fbe3074ba98b42e5c3d277dfe33f654734000018