### PR TITLE
swift explicit modules examples

### DIFF
--- a/examples/apple/objc_interop_modulemap/BUILD
+++ b/examples/apple/objc_interop_modulemap/BUILD
@@ -5,13 +5,26 @@
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 load("//swift:swift_library.bzl", "swift_library")
+load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
 
 licenses(["notice"])
+
+swift_interop_hint(
+    name = "PrintStream_swift_interop",
+    module_name = "examples_apple_objc_interop_modulemap_PrintStream",
+    system_pcms = select({
+        # this lets objc library to depend on the same system_sdks as the swift library
+        "//conditions:default": [
+            "@build_bazel_rules_swift//system_sdks:system_sdks",
+        ],
+    }),
+)
 
 objc_library(
     name = "PrintStream",
     srcs = ["OIPrintStream.m"],
     hdrs = ["OIPrintStream.h"],
+    aspect_hints = [":PrintStream_swift_interop"],
     target_compatible_with = ["@platforms//os:macos"],
 )
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -730,6 +730,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         feature_configuration = feature_configuration,
         feature_name = SWIFT_FEATURE_NO_GENERATED_MODULE_MAP,
     ):
+
         compilation_context_to_compile = (
             compilation_context_for_explicit_module_compilation(
                 compilation_contexts = [

--- a/swift/internal/swift_interop_info.bzl
+++ b/swift/internal/swift_interop_info.bzl
@@ -72,5 +72,9 @@ processes frameworks with headers that do not follow strict layering can request
 that `swift.strict_module` always be disabled for its targets even if it is
 enabled by default in the toolchain.
 """,
+        "system_pcms": """\
+A list of precompiled clang modules with `SwiftInfo` providers for system modules.
+This is used to pass `system_pcm` dependencies originating from `swift_interop_hint`.
+""",
     },
 )

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -408,7 +408,7 @@ def _handle_module(
     )
 
     output_groups = {}
-
+    
     pcm_outputs = precompile_clang_module(
         actions = aspect_ctx.actions,
         cc_compilation_context = compilation_context_to_compile,
@@ -420,6 +420,7 @@ def _handle_module(
         target_name = target.label.name,
         toolchain_type = toolchain_type,
     )
+
     precompiled_module = getattr(pcm_outputs, "pcm_file", None)
     pcm_indexstore = getattr(pcm_outputs, "indexstore_directory", None)
 
@@ -733,6 +734,10 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
         # nothing (not even transitive dependencies).
         if interop_info.suppressed:
             return providers
+
+        # Add system_pcms passed via `swift_interop_hint` to swift_infos 
+        for system_pcm in interop_info.system_pcms:
+            swift_infos.append(system_pcm[SwiftInfo])
 
         exclude_headers = interop_info.exclude_headers
         module_map_file = interop_info.module_map

--- a/swift/swift_interop_hint.bzl
+++ b/swift/swift_interop_hint.bzl
@@ -24,6 +24,7 @@ def _swift_interop_hint_impl(ctx):
         module_map = ctx.file.module_map,
         module_name = ctx.attr.module_name,
         suppressed = ctx.attr.suppressed,
+        system_pcms = ctx.attr.system_pcms,
     )
 
 swift_interop_hint = rule(
@@ -73,6 +74,14 @@ other non-identifier characters with underscores.
             doc = """\
 If `True`, the hinted target should suppress any module that it would otherwise
 generate.
+""",
+            mandatory = False,
+        ),
+        "system_pcms": attr.label_list(
+            doc = """\
+A list of precompiled clang modules with `SwiftInfo` providers for system modules.
+This is used to define system pcm dependencies and eventually propagated to swift_interop_info.
+swift_interop_info will pass those to compile actions. 
 """,
             mandatory = False,
         ),

--- a/swift/swift_interop_info.bzl
+++ b/swift/swift_interop_info.bzl
@@ -38,7 +38,8 @@ def create_swift_interop_info(
         requested_features = [],
         suppressed = False,
         swift_infos = [],
-        unsupported_features = []):
+        unsupported_features = [],
+        system_pcms = []):
     """Returns a provider that lets a target expose C/Objective-C APIs to Swift.
 
     The provider returned by this function allows custom build rules written in
@@ -107,6 +108,9 @@ def create_swift_interop_info(
             strict layering can request that `swift.strict_module` always be
             disabled for its targets even if it is enabled by default in the
             toolchain.
+        system_pcms: A list of precompiled clang modules with `SwiftInfo`
+            providers for system modules. This is used to define system pcm 
+            dependencies passed from `swift_interop_hint`.
 
     Returns:
         A provider whose type/layout is an implementation detail and should not
@@ -128,4 +132,5 @@ def create_swift_interop_info(
         suppressed = suppressed,
         swift_infos = swift_infos,
         unsupported_features = unsupported_features,
+        system_pcms = system_pcms,
     )

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1348,6 +1348,7 @@ def compile_action_configs(
                     SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                     SWIFT_ACTION_DERIVE_FILES,
                     SWIFT_ACTION_DUMP_AST,
+                    SWIFT_ACTION_PRECOMPILE_C_MODULE,
                 ],
                 configurators = [
                     lambda _, args: args.add_all(

--- a/system_sdks/16.3.0.16E140/BUILD
+++ b/system_sdks/16.3.0.16E140/BUILD
@@ -1,0 +1,104 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "macos_x86_64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "ios_device_arm64",
+    constraint_values = [
+        "@platforms//os:ios",
+        "@platforms//cpu:arm64",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+config_setting(
+    name = "ios_sim_x86_64",
+    constraint_values = [
+        "@platforms//os:ios",
+        "@platforms//cpu:x86_64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+config_setting(
+    name = "ios_sim_arm64",
+    constraint_values = [
+        "@platforms//os:ios",
+        "@platforms//cpu:arm64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+config_setting(
+    name = "watchos_sim_arm64",
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:arm64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+config_setting(
+    name = "watchos_sim_x86_64",
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:x86_64",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+config_setting(
+    name = "watchos_device_arm64_32",
+    constraint_values = [
+        "@platforms//os:watchos",
+        "@platforms//cpu:arm64_32",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+swift_library_group(
+    name = "system_sdks",
+    deps = select({
+        "ios_device_arm64": ["//system_sdks/16.3.0.16E140/iPhoneOS/arm64:all_generated_targets"],
+        "watchos_device_arm64_32": ["//system_sdks/16.3.0.16E140/WatchOS/arm64_32:all_generated_targets"],
+        "watchos_sim_arm64": ["//system_sdks/16.3.0.16E140/WatchSimulator/arm64:all_generated_targets"],
+        "watchos_sim_x86_64": ["//system_sdks/16.3.0.16E140/WatchSimulator/x86_64:all_generated_targets"],
+        "ios_sim_arm64": ["//system_sdks/16.3.0.16E140/iPhoneSimulator/arm64:all_generated_targets"],
+        "ios_sim_x86_64": ["//system_sdks/16.3.0.16E140/iPhoneSimulator/x86_64:all_generated_targets"],
+        "macos_arm64": ["//system_sdks/16.3.0.16E140/MacOSX/arm64:all_generated_targets"],
+        "macos_x86_64": ["//system_sdks/16.3.0.16E140/MacOSX/x86_64:all_generated_targets"],
+        "//conditions:default": [],
+    }),
+)
+
+
+swift_library_group(
+    name = "testonly_system_sdks",
+    testonly = True,
+    deps = select({
+        "ios_device_arm64": ["//system_sdks/16.3.0.16E140/iPhoneOS/arm64:all_generated_testonly_targets"],
+        "watchos_device_arm64_32": ["//system_sdks/16.3.0.16E140/WatchOS/arm64_32:all_generated_testonly_targets"],
+        "watchos_sim_arm64": ["//system_sdks/16.3.0.16E140/WatchSimulator/arm64:all_generated_testonly_targets"],
+        "watchos_sim_x86_64": ["//system_sdks/16.3.0.16E140/WatchSimulator/x86_64:all_generated_testonly_targets"],
+        "ios_sim_arm64": ["//system_sdks/16.3.0.16E140/iPhoneSimulator/arm64:all_generated_testonly_targets"],
+        "ios_sim_x86_64": ["//system_sdks/16.3.0.16E140/iPhoneSimulator/x86_64:all_generated_testonly_targets"],
+        "macos_arm64": ["//system_sdks/16.3.0.16E140/MacOSX/arm64:all_generated_testonly_targets"],
+        "macos_x86_64": ["//system_sdks/16.3.0.16E140/MacOSX/x86_64:all_generated_testonly_targets"],
+        "//conditions:default": [],
+    }),
+)

--- a/system_sdks/16.3.0.16E140/MacOSX/arm64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/MacOSX/arm64/BUILD.bazel
@@ -1,0 +1,9190 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":JavaRuntimeSupport",
+        ":IOBluetoothUI",
+        ":SecurityInterface",
+        ":DiscRecording",
+        ":Automator",
+        ":ExceptionHandling",
+        ":IOBluetooth",
+        ":GSS",
+        ":OpenGL",
+        ":FinderSync",
+        ":Quartz",
+        ":UserNotificationsUI",
+        ":TWAIN",
+        ":MetalPerformanceShaders",
+        ":AutomaticAssessmentConfiguration",
+        ":ExternalAccessory",
+        ":ScreenSaver",
+        ":PreferencePanes",
+        ":NetFS",
+        ":MediaToolbox",
+        ":ForceFeedback",
+        ":MetalFX",
+        ":OSAKit",
+        ":ServiceManagement",
+        ":ScreenTime",
+        ":CoreVideo",
+        ":ScriptingBridge",
+        ":ApplicationServices",
+        ":AGL",
+        ":vmnet",
+        ":Cocoa",
+        ":DiscRecordingUI",
+        ":ParavirtualizedGraphics",
+        ":DeviceCheck",
+        ":MailKit",
+        ":ImageIO",
+        ":BackgroundTasks",
+        ":Carbon",
+        ":CoreBluetooth",
+        ":ThreadNetwork",
+        ":Security",
+        ":StickerFoundation",
+        ":ReplayKit",
+        ":IOSurface",
+        ":MediaLibrary",
+        ":IntentsUI",
+        ":BusinessChat",
+        ":OpenDirectory",
+        ":DirectoryService",
+        ":ColorSync",
+        ":AppleScriptObjC",
+        ":CoreWLAN",
+        ":CoreServices",
+        ":MultipeerConnectivity",
+        ":NotificationCenter",
+        ":SystemConfiguration",
+        ":CoreTelephony",
+        ":AVFAudio",
+        ":AudioUnit",
+        ":Social",
+        ":Matter",
+        ":ExecutionPolicy",
+        ":Hypervisor",
+        ":ICADevices",
+        ":ClassKit",
+        ":DVDPlayback",
+        ":PHASE",
+        ":SecurityFoundation",
+        ":GLUT",
+        ":MetalPerformanceShadersGraph",
+        ":Collaboration",
+        ":AudioVideoBridging",
+        ":Accounts",
+        ":FileProviderUI",
+        ":ProximityReaderStub",
+        ":QuickLook",
+        ":KernelManagement",
+        ":AudioToolbox",
+        ":SystemExtensions",
+        ":ContactsUI",
+        ":Tcl",
+        ":AdSupport",
+        ":LocalAuthenticationEmbeddedUI",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":OpenAL",
+        ":AppTrackingTransparency",
+        ":CoreHaptics",
+        ":AVRouting",
+        ":AVKit",
+        ":AddressBook",
+        ":IOUSBHost",
+        ":LatentSemanticMapping",
+        ":CFNetwork",
+        ":JavaScriptCore",
+        ":DiskArbitration",
+        ":PushToTalk",
+        ":InputMethodKit",
+        ":ImageCaptureCore",
+        ":AdServices",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":iTunesLibrary",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":MetricKit_swift",
+        ":Network_swift",
+        ":GameKit_swift",
+        ":CreateML_swift",
+        ":Speech_swift",
+        ":FSKit_swift",
+        ":SafariServices_swift",
+        ":Metal_swift",
+        ":QuartzCore_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":FinanceKitUI_swift",
+        ":CoreMediaIO_swift",
+        ":Symbols_swift",
+        ":LightweightCodeRequirements_swift",
+        ":MediaPlayer_swift",
+        ":LinkPresentation_swift",
+        ":MediaExtension_swift",
+        ":System_swift",
+        ":CryptoKit_swift",
+        ":MLCompute_swift",
+        ":NaturalLanguage_swift",
+        ":CoreHID_swift",
+        ":SensitiveContentAnalysis_swift",
+        ":MetalKit_swift",
+        ":DockKit_swift",
+        ":OSLog_swift",
+        ":PDFKit_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":IOKit_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":SensorKit_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":RealityKit_swift",
+        ":PhotosUI_swift",
+        ":ImagePlayground_swift",
+        ":Virtualization_swift",
+        ":QuickLookUI_swift",
+        ":SpriteKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":VideoSubscriberAccount_swift",
+        ":PencilKit_swift",
+        ":FinanceKit_swift",
+        ":HealthKit_swift",
+        ":BackgroundAssets_swift",
+        ":WebKit_swift",
+        ":GameController_swift",
+        ":OpenCL_swift",
+        ":SwiftUICore_swift",
+        ":FileProvider_swift",
+        ":DeviceActivity_swift",
+        ":AppKit_swift",
+        ":IdentityLookup_swift",
+        ":CoreImage_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":Cinematic_swift",
+        ":MusicKit_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":CoreAudioKit_swift",
+        ":VisionKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":ModelIO_swift",
+        ":SharedWithYou_swift",
+        ":CreateMLComponents_swift",
+        ":ScreenCaptureKit_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":RealityFoundation_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":WeatherKit_swift",
+        ":DataDetection_swift",
+        ":NearbyInteraction_swift",
+        ":CoreSpotlight_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":Accessibility_swift",
+        ":Vision_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":MediaAccessibility_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":StickerKit_swift",
+        ":WidgetKit_swift",
+        ":SoundAnalysis_swift",
+        ":GroupActivities_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":SharedWithYouCore_swift",
+        ":BrowserEngineCore_swift",
+        ":Photos_swift",
+        ":GameplayKit_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":CoreMIDI_swift",
+        ":PassKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":GLKit_swift",
+        ":CryptoTokenKit_swift",
+        ":VideoToolbox_swift",
+        ":Translation_swift",
+        ":ManagedAppDistribution_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":SceneKit_swift",
+        ":StoreKitTest_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_AppIntents_AppKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_LocalAuthentication_SwiftUI_swift",
+        ":_GroupActivities_AppKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "iTunesLibrary",
+    module_name = "iTunesLibrary",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/iTunesLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AdServices",
+    module_name = "AdServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AdServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "InputMethodKit",
+    module_name = "InputMethodKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/InputMethodKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Cocoa",
+        ":Carbon",
+    ],
+)
+
+swift_c_module(
+    name = "PushToTalk",
+    module_name = "PushToTalk",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PushToTalk.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "LatentSemanticMapping",
+    module_name = "LatentSemanticMapping",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LatentSemanticMapping.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":Carbon",
+        ":_stdio",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "IOUSBHost",
+    module_name = "IOUSBHost",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOUSBHost.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":IOKit",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBook",
+    module_name = "AddressBook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AddressBook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Carbon",
+        ":Foundation",
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "AVRouting",
+    module_name = "AVRouting",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVRouting.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+    ],
+)
+
+swift_c_module(
+    name = "CoreHaptics",
+    module_name = "CoreHaptics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreHaptics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppTrackingTransparency",
+    module_name = "AppTrackingTransparency",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppTrackingTransparency.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "OpenAL",
+    module_name = "OpenAL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenAL.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AdSupport",
+    module_name = "AdSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AdSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Tcl",
+    module_name = "Tcl",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/Modules/module.modulemap",
+    deps = [
+        ":_stdio",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":_stdlib",
+        ":_ctype",
+        ":_Builtin_limits",
+    ],
+)
+
+swift_c_module(
+    name = "ContactsUI",
+    module_name = "ContactsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ContactsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "SystemExtensions",
+    module_name = "SystemExtensions",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SystemExtensions.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "KernelManagement",
+    module_name = "KernelManagement",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/KernelManagement.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ProximityReaderStub",
+    module_name = "ProximityReaderStub",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ProximityReaderStub.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "FileProviderUI",
+    module_name = "FileProviderUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FileProviderUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":FileProvider",
+        ":AppKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "Accounts",
+    module_name = "Accounts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accounts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AudioVideoBridging",
+    module_name = "AudioVideoBridging",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioVideoBridging.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IOKit",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "Collaboration",
+    module_name = "Collaboration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Collaboration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreServices",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShadersGraph",
+    module_name = "MetalPerformanceShadersGraph",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":MetalPerformanceShaders",
+    ],
+)
+
+swift_c_module(
+    name = "GLUT",
+    module_name = "GLUT",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework/Modules/module.modulemap",
+    deps = [
+        ":OpenGL",
+        ":_math",
+    ],
+)
+
+swift_c_module(
+    name = "PHASE",
+    module_name = "PHASE",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PHASE.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":AVFAudio",
+        ":simd",
+        ":AVFoundation",
+        ":ModelIO",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DVDPlayback",
+    module_name = "DVDPlayback",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DVDPlayback.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":ApplicationServices",
+        ":Security",
+    ],
+)
+
+swift_c_module(
+    name = "ClassKit",
+    module_name = "ClassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ClassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ICADevices",
+    module_name = "ICADevices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ICADevices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreServices",
+        ":CoreFoundation",
+        ":IOBluetooth",
+    ],
+)
+
+swift_c_module(
+    name = "Hypervisor",
+    module_name = "Hypervisor",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Hypervisor.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Darwin",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":DarwinFoundation",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "ExecutionPolicy",
+    module_name = "ExecutionPolicy",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExecutionPolicy.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Social",
+    module_name = "Social",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Social.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTelephony",
+    module_name = "CoreTelephony",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreTelephony.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemConfiguration",
+    module_name = "SystemConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":Dispatch",
+        ":sys_types",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_c_module(
+    name = "NotificationCenter",
+    module_name = "NotificationCenter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NotificationCenter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "CoreWLAN",
+    module_name = "CoreWLAN",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreWLAN.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IOKit",
+    ],
+)
+
+swift_c_module(
+    name = "AppleScriptObjC",
+    module_name = "AppleScriptObjC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppleScriptObjC.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DirectoryService",
+    module_name = "DirectoryService",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DirectoryService.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "OpenDirectory",
+    module_name = "OpenDirectory",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenDirectory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":ObjectiveC",
+    ],
+)
+
+swift_c_module(
+    name = "BusinessChat",
+    module_name = "BusinessChat",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BusinessChat.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "IntentsUI",
+    module_name = "IntentsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IntentsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Intents",
+    ],
+)
+
+swift_c_module(
+    name = "MediaLibrary",
+    module_name = "MediaLibrary",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ReplayKit",
+    module_name = "ReplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ReplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AppKit",
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "StickerFoundation",
+    module_name = "StickerFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StickerFoundation.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "ThreadNetwork",
+    module_name = "ThreadNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ThreadNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundTasks",
+    module_name = "BackgroundTasks",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BackgroundTasks.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MailKit",
+    module_name = "MailKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MailKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ParavirtualizedGraphics",
+    module_name = "ParavirtualizedGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ParavirtualizedGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Metal",
+        ":IOSurface",
+        ":Dispatch",
+        ":AppKit",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "DiscRecordingUI",
+    module_name = "DiscRecordingUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiscRecordingUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":DiscRecording",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":Carbon",
+    ],
+)
+
+swift_c_module(
+    name = "vmnet",
+    module_name = "vmnet",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/vmnet.framework/Modules/module.modulemap",
+    deps = [
+        ":Dispatch",
+        ":XPC",
+        ":ObjectiveC",
+        ":os_availability",
+        ":DarwinFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "AGL",
+    module_name = "AGL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AGL.framework/Modules/module.modulemap",
+    deps = [
+        ":OpenGL",
+        ":Carbon",
+    ],
+)
+
+swift_c_module(
+    name = "ScriptingBridge",
+    module_name = "ScriptingBridge",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScriptingBridge.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreServices",
+        ":ApplicationServices",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenTime",
+    module_name = "ScreenTime",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenTime.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "ServiceManagement",
+    module_name = "ServiceManagement",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ServiceManagement.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":DarwinFoundation",
+        ":XPC",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalFX",
+    module_name = "MetalFX",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalFX.framework/Modules/module.modulemap",
+    deps = [
+        ":Metal",
+    ],
+)
+
+swift_c_module(
+    name = "ForceFeedback",
+    module_name = "ForceFeedback",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ForceFeedback.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":IOKit",
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "NetFS",
+    module_name = "NetFS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NetFS.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "PreferencePanes",
+    module_name = "PreferencePanes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PreferencePanes.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenSaver",
+    module_name = "ScreenSaver",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenSaver.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+        ":_stdlib",
+        ":_Builtin_limits",
+    ],
+)
+
+swift_c_module(
+    name = "ExternalAccessory",
+    module_name = "ExternalAccessory",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExternalAccessory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AutomaticAssessmentConfiguration",
+    module_name = "AutomaticAssessmentConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AutomaticAssessmentConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "TWAIN",
+    module_name = "TWAIN",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/TWAIN.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "FinderSync",
+    module_name = "FinderSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinderSync.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "GSS",
+    module_name = "GSS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GSS.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_inttypes",
+        ":unistd",
+        ":_Builtin_stdarg",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "ExceptionHandling",
+    module_name = "ExceptionHandling",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExceptionHandling.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Automator",
+    module_name = "Automator",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Automator.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OSAKit",
+        ":AppKit",
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "OSAKit",
+    module_name = "OSAKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OSAKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Carbon",
+    ],
+)
+
+swift_c_module(
+    name = "DiscRecording",
+    module_name = "DiscRecording",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiscRecording.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":_math",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "IOBluetoothUI",
+    module_name = "IOBluetoothUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOBluetoothUI.framework/Modules/module.modulemap",
+    deps = [
+        ":IOBluetooth",
+        ":os_availability",
+        ":Cocoa",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "IOBluetooth",
+    module_name = "IOBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":IOKit",
+        ":Darwin",
+        ":Foundation",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_errno",
+        ":unistd",
+        ":_Builtin_stdint",
+        ":CoreServices",
+        ":CoreAudio",
+    ],
+)
+
+swift_c_module(
+    name = "JavaRuntimeSupport",
+    module_name = "JavaRuntimeSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaRuntimeSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":os_availability",
+        ":DarwinFoundation",
+        ":ApplicationServices",
+        ":Foundation",
+        ":QuartzCore",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":AppKit",
+        ":AVFoundation",
+        ":Foundation",
+        ":Cocoa",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_QuickLook_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":Quartz",
+        ":QuickLook",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":QuartzCore_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":CoreText_swift",
+        ":AppKit_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":PDFKit_swift",
+        ":QuickLookUI_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Quartz",
+    module_name = "Quartz",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Quartz.framework/Modules/module.modulemap",
+    deps = [
+        ":QuartzCore",
+        ":Cocoa",
+        ":ImageCaptureCore",
+        ":AppKit",
+        ":Foundation",
+        ":CoreImage",
+        ":ApplicationServices",
+        ":os_availability",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":PDFKit",
+        ":OpenGL",
+        ":QuickLookUI",
+    ],
+)
+
+swift_c_module(
+    name = "ImageCaptureCore",
+    module_name = "ImageCaptureCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageCaptureCore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+        ":Cocoa",
+    ],
+)
+
+swift_library_group(
+    name = "_ManagedAppDistribution_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedAppDistribution_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Translation_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":Translation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GroupActivities_AppKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_LocalAuthentication_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthenticationEmbeddedUI",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthenticationEmbeddedUI",
+    module_name = "LocalAuthenticationEmbeddedUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AppKit",
+        ":Foundation",
+        ":LocalAuthentication",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_AppKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_DeviceActivity_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":DeviceActivity_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_RealityKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":SwiftUICore_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKitTest_swift",
+    testonly = False,
+    deps = [
+        ":StoreKitTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKitTest",
+    module_name = "StoreKitTest",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/StoreKitTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":StoreKit",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedAppDistribution_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Contacts_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":CoreGraphics",
+        ":Contacts",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":XPC",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "StickerKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":MetalPerformanceShaders",
+        ":StickerKit",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreMotion_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":MetalKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":PhotosUI_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StickerKit",
+    module_name = "StickerKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StickerKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OSLog",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MediaAccessibility_swift",
+    testonly = False,
+    deps = [
+        ":MediaAccessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaAccessibility",
+    module_name = "MediaAccessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaAccessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":AvailabilityMacros",
+        ":CoreText",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":IOSurface",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":Security",
+        ":os_availability",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+        ":CoreMIDI_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":CoreMedia_swift",
+        ":Metal_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "ScreenCaptureKit_swift",
+    testonly = False,
+    deps = [
+        ":ScreenCaptureKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":AppKit_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenCaptureKit",
+    module_name = "ScreenCaptureKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenCaptureKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":CoreMedia",
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYou_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYou",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreTransferable_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":SharedWithYouCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYou",
+    module_name = "SharedWithYou",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SharedWithYou.framework/Modules/module.modulemap",
+    deps = [
+        ":SharedWithYouCore",
+        ":TargetConditionals",
+        ":Foundation",
+        ":AppKit",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYouCore_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYouCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYouCore",
+    module_name = "SharedWithYouCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SharedWithYouCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "VisionKit_swift",
+    testonly = False,
+    deps = [
+        ":VisionKit",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VisionKit",
+    module_name = "VisionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VisionKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CoreAudioKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":AppKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":CoreAudio_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioKit",
+    module_name = "CoreAudioKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudioKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Cocoa",
+        ":AudioUnit",
+        ":AVFoundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "AudioUnit",
+    module_name = "AudioUnit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceDiscoveryExtension_swift",
+    testonly = False,
+    deps = [
+        ":DeviceDiscoveryExtension",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceDiscoveryExtension",
+    module_name = "DeviceDiscoveryExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeviceDiscoveryExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Cinematic_swift",
+    testonly = False,
+    deps = [
+        ":Cinematic",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Cinematic",
+    module_name = "Cinematic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Cinematic.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreMedia",
+        ":Metal",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityInterface",
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityInterface",
+    module_name = "SecurityInterface",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityInterface.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Security",
+        ":os_availability",
+        ":SecurityFoundation",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityFoundation",
+    module_name = "SecurityFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "IdentityLookup_swift",
+    testonly = False,
+    deps = [
+        ":IdentityLookup",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookup",
+    module_name = "IdentityLookup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IdentityLookup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "FileProvider_swift",
+    testonly = False,
+    deps = [
+        ":FileProvider",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FileProvider",
+    module_name = "FileProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FileProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "OpenCL_swift",
+    testonly = False,
+    deps = [
+        ":OpenCL",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Dispatch_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OpenCL",
+    module_name = "OpenCL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenCL.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdarg",
+        ":AvailabilityMacros",
+        ":OpenGL",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "WebKit_swift",
+    testonly = False,
+    deps = [
+        ":WebKit",
+        ":_SwiftConcurrencyShims",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":ObjectiveC_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":Dispatch_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WebKit",
+    module_name = "WebKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ObjectiveC",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AppKit",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Network",
+        ":JavaScriptCore",
+    ],
+)
+
+swift_c_module(
+    name = "JavaScriptCore",
+    module_name = "JavaScriptCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdbool",
+        ":Foundation",
+        ":_Builtin_stddef",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_library_group(
+    name = "BackgroundAssets_swift",
+    testonly = False,
+    deps = [
+        ":BackgroundAssets",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundAssets",
+    module_name = "BackgroundAssets",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BackgroundAssets.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "VideoSubscriberAccount_swift",
+    testonly = False,
+    deps = [
+        ":VideoSubscriberAccount",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoSubscriberAccount",
+    module_name = "VideoSubscriberAccount",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VideoSubscriberAccount.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookThumbnailing_swift",
+    testonly = False,
+    deps = [
+        ":QuickLookThumbnailing",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookThumbnailing",
+    module_name = "QuickLookThumbnailing",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLookThumbnailing.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookUI_swift",
+    testonly = False,
+    deps = [
+        ":QuickLookUI",
+        ":_SwiftConcurrencyShims",
+        ":PDFKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":AppKit_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookUI",
+    module_name = "QuickLookUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLookUI.framework/Modules/module.modulemap",
+    deps = [
+        ":QuickLook",
+        ":Foundation",
+        ":AppKit",
+        ":UniformTypeIdentifiers",
+        ":CoreGraphics",
+        ":PDFKit",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLook",
+    module_name = "QuickLook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":ApplicationServices",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Virtualization_swift",
+    testonly = False,
+    deps = [
+        ":Virtualization",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Virtualization",
+    module_name = "Virtualization",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Virtualization.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+        ":TargetConditionals",
+        ":Darwin",
+        ":AppKit",
+        ":Cocoa",
+    ],
+)
+
+swift_library_group(
+    name = "ImagePlayground_swift",
+    testonly = False,
+    deps = [
+        ":ImagePlayground",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":PencilKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ImagePlayground",
+    module_name = "ImagePlayground",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImagePlayground.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PencilKit_swift",
+    testonly = False,
+    deps = [
+        ":PencilKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PencilKit",
+    module_name = "PencilKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PencilKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Cocoa",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Photos_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":MapKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":AppKit",
+        ":Photos",
+        ":MapKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":CoreLocation_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":AppKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Photos_swift",
+    testonly = False,
+    deps = [
+        ":Photos",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Photos",
+    module_name = "Photos",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Photos.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ImageIO",
+        ":CoreLocation",
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "RealityKit_swift",
+    testonly = False,
+    deps = [
+        ":MultipeerConnectivity",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Metal_swift",
+        ":RealityFoundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MultipeerConnectivity",
+    module_name = "MultipeerConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MultipeerConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RealityFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "GroupActivities_swift",
+    testonly = False,
+    deps = [
+        ":GroupActivities",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CloudKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreTransferable_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GroupActivities",
+    module_name = "GroupActivities",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GroupActivities.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "SensorKit_swift",
+    testonly = False,
+    deps = [
+        ":SensorKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":Speech_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":SoundAnalysis_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensorKit",
+    module_name = "SensorKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SensorKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreLocation",
+        ":Speech",
+        ":SoundAnalysis",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "PDFKit_swift",
+    testonly = False,
+    deps = [
+        ":PDFKit",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PDFKit",
+    module_name = "PDFKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PDFKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Cocoa",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "DockKit_swift",
+    testonly = False,
+    deps = [
+        ":DockKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DockKit",
+    module_name = "DockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensitiveContentAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":SensitiveContentAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensitiveContentAnalysis",
+    module_name = "SensitiveContentAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SensitiveContentAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "CoreHID_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MLCompute_swift",
+    testonly = False,
+    deps = [
+        ":MLCompute",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MLCompute",
+    module_name = "MLCompute",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MLCompute.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+    ],
+)
+
+swift_library_group(
+    name = "MediaExtension_swift",
+    testonly = False,
+    deps = [
+        ":MediaExtension",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreMedia_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":VideoToolbox_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaExtension",
+    module_name = "MediaExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreMedia",
+        ":Foundation",
+        ":AVFoundation",
+        ":CoreFoundation",
+        ":VideoToolbox",
+        ":CoreVideo",
+    ],
+)
+
+swift_library_group(
+    name = "LinkPresentation_swift",
+    testonly = False,
+    deps = [
+        ":LinkPresentation",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LinkPresentation",
+    module_name = "LinkPresentation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LinkPresentation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+        ":TargetConditionals",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LightweightCodeRequirements_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":CoreFoundation_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMediaIO_swift",
+    testonly = False,
+    deps = [
+        ":CoreMediaIO",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMediaIO",
+    module_name = "CoreMediaIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMediaIO.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreMedia",
+        ":CoreFoundation",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKitUI_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKitUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionKit_swift",
+        ":FinanceKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WidgetKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKitUI",
+    module_name = "FinanceKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinanceKitUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreSpotlight_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreSpotlight_swift",
+    testonly = False,
+    deps = [
+        ":CoreSpotlight",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreSpotlight",
+    module_name = "CoreSpotlight",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreSpotlight.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":AppKit_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":IOKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":CoreFoundation_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "SafariServices_swift",
+    testonly = False,
+    deps = [
+        ":SafariServices",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafariServices",
+    module_name = "SafariServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "FSKit_swift",
+    testonly = False,
+    deps = [
+        ":FSKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FSKit",
+    module_name = "FSKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FSKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Speech_swift",
+    testonly = False,
+    deps = [
+        ":Speech",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Speech",
+    module_name = "Speech",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Speech.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateML_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":MetalPerformanceShaders",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CreateMLComponents_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":VideoToolbox_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShaders",
+    module_name = "MetalPerformanceShaders",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalPerformanceShaders.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+        ":simd",
+        ":_Builtin_stdint",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "VideoToolbox_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":VideoToolbox",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoToolbox",
+    module_name = "VideoToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VideoToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":CoreMedia",
+        ":CoreFoundation",
+        ":CoreVideo",
+        ":Metal",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":RegexBuilder_swift",
+        ":SoundAnalysis_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Vision_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":MachO",
+        ":Vision",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Vision",
+    module_name = "Vision",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Vision.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreML",
+        ":CoreGraphics",
+        ":simd",
+        ":CoreVideo",
+        ":CoreMedia",
+        ":Metal",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":MediaToolbox",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "MediaToolbox",
+    module_name = "MediaToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "AudioToolbox",
+    module_name = "AudioToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":_stdio",
+        ":Foundation",
+        ":CoreMIDI",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":Carbon",
+        ":os_workgroup",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "Carbon",
+    module_name = "Carbon",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":Foundation",
+        ":os_availability",
+        ":Security",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMIDI_swift",
+    testonly = False,
+    deps = [
+        ":CoreMIDI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":Foundation",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":CoreAudio",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudioTypes",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":os_availability",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_math_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":MetalKit_swift",
+        ":ModelIO_swift",
+        ":SpriteKit_swift",
+        ":GLKit_swift",
+        ":SceneKit_swift",
+        ":GameplayKit_swift",
+        ":GameController_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":Cocoa",
+        ":Metal",
+        ":MetalKit",
+        ":SpriteKit",
+        ":SceneKit",
+        ":GameplayKit",
+        ":GameController",
+        ":ModelIO",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AppKit",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "GameController_swift",
+    testonly = False,
+    deps = [
+        ":GameController",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameController",
+    module_name = "GameController",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameController.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":IOKit",
+        ":AppKit",
+    ],
+)
+
+swift_library_group(
+    name = "GameplayKit_swift",
+    testonly = False,
+    deps = [
+        ":GameplayKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":SpriteKit_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+        ":SceneKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameplayKit",
+    module_name = "GameplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":SpriteKit",
+        ":Foundation",
+        ":simd",
+        ":os_availability",
+        ":TargetConditionals",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":ModelIO_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreText_swift",
+        ":AppKit_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":GLKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ModelIO",
+        ":QuartzCore",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":AppKit",
+        ":CoreGraphics",
+        ":simd",
+        ":Metal",
+        ":GLKit",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":Metal",
+        ":GLKit",
+        ":Cocoa",
+        ":os_availability",
+        ":TargetConditionals",
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "Cocoa",
+    module_name = "Cocoa",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Cocoa.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AppKit",
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "GLKit_swift",
+    testonly = False,
+    deps = [
+        ":GLKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":ModelIO_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GLKit",
+    module_name = "GLKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OpenGL",
+        ":_math",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_string",
+        ":CoreFoundation",
+        ":os_availability",
+        ":ModelIO",
+        ":CoreGraphics",
+        ":AppKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "MetalKit_swift",
+    testonly = False,
+    deps = [
+        ":MetalKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":ModelIO_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":AppKit_swift",
+        ":CoreText_swift",
+        ":CoreImage_swift",
+        ":Symbols_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalKit",
+    module_name = "MetalKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":ModelIO",
+        ":Metal",
+        ":simd",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AppKit",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "ModelIO_swift",
+    testonly = False,
+    deps = [
+        ":ModelIO",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ModelIO",
+    module_name = "ModelIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ModelIO.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "AppKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit",
+        ":OpenGL",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreImage_swift",
+        ":Metal_swift",
+        ":CoreData_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppKit",
+    module_name = "AppKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":TargetConditionals",
+        ":CoreText",
+        ":ApplicationServices",
+        ":CoreImage",
+        ":os_availability",
+        ":CoreFoundation",
+        ":_Builtin_limits",
+        ":IOKit",
+        ":CoreGraphics",
+        ":Symbols",
+        ":CoreData",
+        ":OpenGL",
+        ":QuartzCore",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "QuartzCore_swift",
+    testonly = False,
+    deps = [
+        ":QuartzCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":ObjectiveC",
+        ":Metal",
+        ":CoreVideo",
+        ":OpenGL",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreImage_swift",
+    testonly = False,
+    deps = [
+        ":CoreImage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreImage",
+    module_name = "CoreImage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreImage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":OpenGL",
+        ":TargetConditionals",
+        ":ImageIO",
+        ":IOSurface",
+        ":ObjectiveC",
+        ":Metal",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+        ":OpenGL",
+        ":ApplicationServices",
+        ":Metal",
+        ":IOSurface",
+    ],
+)
+
+swift_c_module(
+    name = "ApplicationServices",
+    module_name = "ApplicationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ApplicationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreServices",
+        ":ColorSync",
+        ":CoreGraphics",
+        ":CoreText",
+        ":ImageIO",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":sys_types",
+        ":Foundation",
+        ":CUPS",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "CUPS",
+    module_name = "CUPS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/cups.modulemap",
+    deps = [
+        ":sys_types",
+        ":_stdio",
+        ":_stdlib",
+        ":Darwin",
+        ":_Builtin_stddef",
+        ":_string",
+        ":_time",
+        ":unistd",
+        ":_Builtin_stdarg",
+        ":_locale",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "OpenGL",
+    module_name = "OpenGL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Metal_swift",
+    testonly = False,
+    deps = [
+        ":Metal",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Metal",
+    module_name = "Metal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Metal.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_math",
+        ":os_availability",
+        ":TargetConditionals",
+        ":IOSurface",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "IOSurface",
+    module_name = "IOSurface",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOSurface.framework/Modules/module.modulemap",
+    deps = [
+        ":XPC",
+        ":IOKit",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "DataDetection_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":IOKit",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+        ":XPC_swift",
+        ":IOKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetricKit_swift",
+    testonly = False,
+    deps = [
+        ":MetricKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetricKit",
+    module_name = "MetricKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetricKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":IOKit_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreServices",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":AvailabilityMacros",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":Darwin",
+        ":XPC",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CFNetwork",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_fenv",
+        ":_Builtin_stdint",
+        ":DarwinFoundation",
+        ":TargetConditionals",
+        ":Darwin",
+        ":Dispatch",
+        ":sys_types",
+        ":DiskArbitration",
+        ":_math",
+        ":Security",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Darwin",
+        ":os_availability",
+        ":CoreFoundation",
+        ":_stdio",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":unistd",
+        ":DarwinFoundation",
+        ":XPC",
+        ":Dispatch",
+        ":os_object",
+        ":_Builtin_stdbool",
+        ":libDER",
+        ":_string",
+    ],
+)
+
+swift_c_module(
+    name = "libDER",
+    module_name = "libDER",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libDER/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_string",
+        ":_Builtin_stdbool",
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DiskArbitration",
+    module_name = "DiskArbitration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiskArbitration.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":IOKit",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "CFNetwork",
+    module_name = "CFNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CFNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "IOKit_swift",
+    testonly = False,
+    deps = [
+        ":IOKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":CoreFoundation_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IOKit",
+    module_name = "IOKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":_Builtin_stdbool",
+        ":libkern",
+        ":sys_types",
+        ":CoreFoundation",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "libkern",
+    module_name = "libkern",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libkern.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":XPC",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_library_group(
+    name = "XPC_swift",
+    testonly = False,
+    deps = [
+        ":XPC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XPC",
+    module_name = "XPC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/xpc.modulemap",
+    deps = [
+        ":os_object",
+        ":Dispatch",
+        ":Darwin",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_stdio",
+        ":_string",
+        ":unistd",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":launch",
+    ],
+)
+
+swift_c_module(
+    name = "launch",
+    module_name = "launch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/launch.modulemap",
+    deps = [
+        ":Darwin",
+        ":os_availability",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_string",
+        ":Darwin",
+        ":MachO",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":iTunesLibrary",
+        ":SafetyKit",
+        ":AdServices",
+        ":InputMethodKit",
+        ":PushToTalk",
+        ":LatentSemanticMapping",
+        ":IOUSBHost",
+        ":AddressBook",
+        ":AVRouting",
+        ":CoreHaptics",
+        ":AppTrackingTransparency",
+        ":OpenAL",
+        ":PushKit",
+        ":AdSupport",
+        ":Tcl",
+        ":ContactsUI",
+        ":SystemExtensions",
+        ":KernelManagement",
+        ":ProximityReaderStub",
+        ":FileProviderUI",
+        ":Accounts",
+        ":AudioVideoBridging",
+        ":Collaboration",
+        ":MetalPerformanceShadersGraph",
+        ":GLUT",
+        ":PHASE",
+        ":DVDPlayback",
+        ":ClassKit",
+        ":ICADevices",
+        ":Hypervisor",
+        ":ExecutionPolicy",
+        ":Social",
+        ":CoreTelephony",
+        ":SystemConfiguration",
+        ":NotificationCenter",
+        ":CoreWLAN",
+        ":AppleScriptObjC",
+        ":DirectoryService",
+        ":OpenDirectory",
+        ":BusinessChat",
+        ":IntentsUI",
+        ":MediaLibrary",
+        ":ReplayKit",
+        ":StickerFoundation",
+        ":ThreadNetwork",
+        ":CoreBluetooth",
+        ":BackgroundTasks",
+        ":MailKit",
+        ":DeviceCheck",
+        ":ParavirtualizedGraphics",
+        ":DiscRecordingUI",
+        ":vmnet",
+        ":AGL",
+        ":ScriptingBridge",
+        ":ScreenTime",
+        ":ServiceManagement",
+        ":MetalFX",
+        ":ForceFeedback",
+        ":NetFS",
+        ":PreferencePanes",
+        ":ScreenSaver",
+        ":ExternalAccessory",
+        ":AutomaticAssessmentConfiguration",
+        ":TWAIN",
+        ":UserNotificationsUI",
+        ":FinderSync",
+        ":GSS",
+        ":ExceptionHandling",
+        ":Automator",
+        ":OSAKit",
+        ":DiscRecording",
+        ":IOBluetoothUI",
+        ":IOBluetooth",
+        ":JavaRuntimeSupport",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_MapKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":AVKit",
+        ":_Intents_TipKit_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":Quartz",
+        ":ImageCaptureCore",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_GroupActivities_AppKit_swift",
+        ":_LocalAuthentication_SwiftUI_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_AppKit_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":StoreKitTest_swift",
+        ":StoreKitTest",
+        ":ManagedAppDistribution_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":TipKit_swift",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":StickerKit_swift",
+        ":StickerKit",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":MediaAccessibility_swift",
+        ":MediaAccessibility",
+        ":EventKit_swift",
+        ":EventKit",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":ScreenCaptureKit_swift",
+        ":ScreenCaptureKit",
+        ":SharedWithYou_swift",
+        ":SharedWithYou",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYouCore",
+        ":VisionKit_swift",
+        ":VisionKit",
+        ":CoreAudioKit_swift",
+        ":CoreAudioKit",
+        ":AudioUnit",
+        ":DeviceDiscoveryExtension_swift",
+        ":DeviceDiscoveryExtension",
+        ":MusicKit_swift",
+        ":Cinematic_swift",
+        ":Cinematic",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":SecurityInterface",
+        ":SecurityFoundation",
+        ":IdentityLookup_swift",
+        ":IdentityLookup",
+        ":DeviceActivity_swift",
+        ":FileProvider_swift",
+        ":FileProvider",
+        ":OpenCL_swift",
+        ":OpenCL",
+        ":WebKit_swift",
+        ":WebKit",
+        ":JavaScriptCore",
+        ":BackgroundAssets_swift",
+        ":BackgroundAssets",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":VideoSubscriberAccount_swift",
+        ":VideoSubscriberAccount",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookThumbnailing",
+        ":QuickLookUI_swift",
+        ":QuickLookUI",
+        ":QuickLook",
+        ":Virtualization_swift",
+        ":Virtualization",
+        ":ImagePlayground_swift",
+        ":ImagePlayground",
+        ":PencilKit_swift",
+        ":PencilKit",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":MapKit_swift",
+        ":MapKit",
+        ":Photos_swift",
+        ":Photos",
+        ":RealityKit_swift",
+        ":MultipeerConnectivity",
+        ":RealityFoundation_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":GroupActivities_swift",
+        ":GroupActivities",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":SensorKit_swift",
+        ":SensorKit",
+        ":FamilyControls_swift",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":PDFKit_swift",
+        ":PDFKit",
+        ":DockKit_swift",
+        ":DockKit",
+        ":SensitiveContentAnalysis_swift",
+        ":SensitiveContentAnalysis",
+        ":CoreHID_swift",
+        ":MLCompute_swift",
+        ":MLCompute",
+        ":MediaExtension_swift",
+        ":MediaExtension",
+        ":LinkPresentation_swift",
+        ":LinkPresentation",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":LightweightCodeRequirements_swift",
+        ":CoreMediaIO_swift",
+        ":CoreMediaIO",
+        ":FinanceKitUI_swift",
+        ":FinanceKitUI",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":Intents_swift",
+        ":Intents",
+        ":UserNotifications",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreSpotlight_swift",
+        ":CoreSpotlight",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":Spatial_swift",
+        ":Spatial",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":SafariServices_swift",
+        ":SafariServices",
+        ":FSKit_swift",
+        ":FSKit",
+        ":Speech_swift",
+        ":Speech",
+        ":CreateML_swift",
+        ":MetalPerformanceShaders",
+        ":VideoToolbox_swift",
+        ":VideoToolbox",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":CreateMLComponents_swift",
+        ":Vision_swift",
+        ":Vision",
+        ":TabularData_swift",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":RegexBuilder_swift",
+        ":CoreML_swift",
+        ":CoreML",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":MediaToolbox",
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":Carbon",
+        ":CoreMIDI_swift",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":GameKit_swift",
+        ":GameKit",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":GameController_swift",
+        ":GameController",
+        ":GameplayKit_swift",
+        ":GameplayKit",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":Cocoa",
+        ":GLKit_swift",
+        ":GLKit",
+        ":MetalKit_swift",
+        ":MetalKit",
+        ":ModelIO_swift",
+        ":ModelIO",
+        ":AppKit_swift",
+        ":AppKit",
+        ":QuartzCore_swift",
+        ":QuartzCore",
+        ":CoreData_swift",
+        ":CoreData",
+        ":CoreImage_swift",
+        ":CoreImage",
+        ":CoreVideo",
+        ":ApplicationServices",
+        ":CUPS",
+        ":ImageIO",
+        ":ColorSync",
+        ":OpenGL",
+        ":Metal_swift",
+        ":Metal",
+        ":IOSurface",
+        ":Symbols_swift",
+        ":Symbols",
+        ":OSLog_swift",
+        ":OSLog",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":DataDetection_swift",
+        ":DataDetection",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Distributed_swift",
+        ":MetricKit_swift",
+        ":MetricKit",
+        ":Foundation_swift",
+        ":Foundation",
+        ":CoreServices",
+        ":Security",
+        ":libDER",
+        ":DiskArbitration",
+        ":CFNetwork",
+        ":IOKit_swift",
+        ":IOKit",
+        ":libkern",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":os_swift",
+        ":os",
+        ":XPC_swift",
+        ":XPC",
+        ":launch",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":Combine_swift",
+        ":ObjectiveC_swift",
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC",
+        ":MachO",
+        ":Darwin_swift",
+        ":Darwin",
+        ":AvailabilityMacros",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/MacOSX/x86_64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/MacOSX/x86_64/BUILD.bazel
@@ -1,0 +1,9161 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":AGL",
+        ":AVFAudio",
+        ":AVFoundation_swift",
+        ":AVKit",
+        ":AVRouting",
+        ":Accelerate_swift",
+        ":Accessibility_swift",
+        ":Accounts",
+        ":AdServices",
+        ":AdSupport",
+        ":AddressBook",
+        ":AppIntents_swift",
+        ":AppKit_swift",
+        ":AppTrackingTransparency",
+        ":AppleArchive_swift",
+        ":AppleScriptObjC",
+        ":ApplicationServices",
+        ":AudioToolbox",
+        ":AudioUnit",
+        ":AudioVideoBridging",
+        ":AuthenticationServices_swift",
+        ":AutomaticAssessmentConfiguration",
+        ":Automator",
+        ":BackgroundAssets_swift",
+        ":BackgroundTasks",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineKit_swift",
+        ":BusinessChat",
+        ":CFNetwork",
+        ":CallKit_swift",
+        ":CarKey_swift",
+        ":Carbon",
+        ":Charts_swift",
+        ":Cinematic_swift",
+        ":ClassKit",
+        ":CloudKit_swift",
+        ":Cocoa",
+        ":Collaboration",
+        ":ColorSync",
+        ":Combine_swift",
+        ":Compression_swift",
+        ":ContactsUI",
+        ":Contacts_swift",
+        ":CoreAudioKit_swift",
+        ":CoreAudioTypes",
+        ":CoreAudio_swift",
+        ":CoreBluetooth",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreHID_swift",
+        ":CoreHaptics",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":CoreMIDI_swift",
+        ":CoreML_swift",
+        ":CoreMediaIO_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreServices",
+        ":CoreSpotlight_swift",
+        ":CoreTelephony",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":CoreVideo",
+        ":CoreWLAN",
+        ":CreateMLComponents_swift",
+        ":CreateML_swift",
+        ":CryptoKit_swift",
+        ":CryptoTokenKit_swift",
+        ":DVDPlayback",
+        ":Darwin_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":DeviceActivity_swift",
+        ":DeviceCheck",
+        ":DeviceDiscoveryExtension_swift",
+        ":DirectoryService",
+        ":DiscRecording",
+        ":DiscRecordingUI",
+        ":DiskArbitration",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":DockKit_swift",
+        ":EventKit_swift",
+        ":ExceptionHandling",
+        ":ExecutionPolicy",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":ExternalAccessory",
+        ":FSKit_swift",
+        ":FamilyControls_swift",
+        ":FileProviderUI",
+        ":FileProvider_swift",
+        ":FinanceKitUI_swift",
+        ":FinanceKit_swift",
+        ":FinderSync",
+        ":ForceFeedback",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":GLUT",
+        ":GSS",
+        ":GameController_swift",
+        ":GameKit_swift",
+        ":GameplayKit_swift",
+        ":GroupActivities_swift",
+        ":HealthKit_swift",
+        ":Hypervisor",
+        ":ICADevices",
+        ":IOBluetooth",
+        ":IOBluetoothUI",
+        ":IOKit_swift",
+        ":IOSurface",
+        ":IOUSBHost",
+        ":IdentityLookup_swift",
+        ":ImageCaptureCore",
+        ":ImageIO",
+        ":ImagePlayground_swift",
+        ":InputMethodKit",
+        ":IntentsUI",
+        ":Intents_swift",
+        ":JavaRuntimeSupport",
+        ":JavaScriptCore",
+        ":KernelManagement",
+        ":LatentSemanticMapping",
+        ":LightweightCodeRequirements_swift",
+        ":LinkPresentation_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":LocalAuthentication_swift",
+        ":MLCompute_swift",
+        ":MailKit",
+        ":ManagedAppDistribution_swift",
+        ":ManagedSettings_swift",
+        ":MapKit_swift",
+        ":Matter",
+        ":MatterSupport_swift",
+        ":MediaAccessibility_swift",
+        ":MediaExtension_swift",
+        ":MediaLibrary",
+        ":MediaPlayer_swift",
+        ":MediaToolbox",
+        ":MetalFX",
+        ":MetalKit_swift",
+        ":MetalPerformanceShaders",
+        ":MetalPerformanceShadersGraph",
+        ":Metal_swift",
+        ":MetricKit_swift",
+        ":ModelIO_swift",
+        ":MultipeerConnectivity",
+        ":MusicKit_swift",
+        ":NaturalLanguage_swift",
+        ":NearbyInteraction_swift",
+        ":NetFS",
+        ":NetworkExtension_swift",
+        ":Network_swift",
+        ":NotificationCenter",
+        ":OSAKit",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":OpenAL",
+        ":OpenCL_swift",
+        ":OpenDirectory",
+        ":OpenGL",
+        ":PDFKit_swift",
+        ":PHASE",
+        ":ParavirtualizedGraphics",
+        ":PassKit_swift",
+        ":PencilKit_swift",
+        ":PhotosUI_swift",
+        ":Photos_swift",
+        ":PreferencePanes",
+        ":ProximityReaderStub",
+        ":PushKit",
+        ":PushToTalk",
+        ":Quartz",
+        ":QuartzCore_swift",
+        ":QuickLook",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookUI_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":RegexBuilder_swift",
+        ":ReplayKit",
+        ":SafariServices_swift",
+        ":SafetyKit",
+        ":SceneKit_swift",
+        ":ScreenCaptureKit_swift",
+        ":ScreenSaver",
+        ":ScreenTime",
+        ":ScriptingBridge",
+        ":Security",
+        ":SecurityFoundation",
+        ":SecurityInterface",
+        ":SecurityUI_swift",
+        ":SensitiveContentAnalysis_swift",
+        ":SensorKit_swift",
+        ":ServiceManagement",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYou_swift",
+        ":ShazamKit_swift",
+        ":Social",
+        ":SoundAnalysis_swift",
+        ":Spatial_swift",
+        ":Speech_swift",
+        ":SpriteKit_swift",
+        ":StickerFoundation",
+        ":StickerKit_swift",
+        ":StoreKitTest",
+        ":StoreKit_swift",
+        ":SwiftData_swift",
+        ":SwiftOnoneSupport_swift",
+        ":SwiftUICore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":Synchronization_swift",
+        ":SystemConfiguration",
+        ":SystemExtensions",
+        ":System_swift",
+        ":TWAIN",
+        ":TabularData_swift",
+        ":Tcl",
+        ":Testing_swift",
+        ":ThreadNetwork",
+        ":TipKit_swift",
+        ":Translation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UserNotifications",
+        ":UserNotificationsUI",
+        ":VideoSubscriberAccount_swift",
+        ":VideoToolbox_swift",
+        ":Virtualization_swift",
+        ":VisionKit_swift",
+        ":Vision_swift",
+        ":WeatherKit_swift",
+        ":WebKit_swift",
+        ":WidgetKit_swift",
+        ":WorkoutKit_swift",
+        ":XCTest_swift",
+        ":XCUIAutomation_swift",
+        ":XPC_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_AppIntents_AppKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_Darwin_xlocale",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_GroupActivities_AppKit_swift",
+        ":_Intents_TipKit_swift",
+        ":_LocalAuthentication_SwiftUI_swift",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":hvf_swift",
+        ":iTunesLibrary",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+        ":vmnet",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKitTest",
+    testonly = False,
+    module_name = "StoreKitTest",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/StoreKitTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":StoreKit",
+    ],
+)
+
+swift_c_module(
+    name = "iTunesLibrary",
+    testonly = False,
+    module_name = "iTunesLibrary",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/iTunesLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    testonly = False,
+    module_name = "SafetyKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "AdServices",
+    testonly = False,
+    module_name = "AdServices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AdServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "InputMethodKit",
+    testonly = False,
+    module_name = "InputMethodKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/InputMethodKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":Cocoa",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "PushToTalk",
+    testonly = False,
+    module_name = "PushToTalk",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PushToTalk.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "LatentSemanticMapping",
+    testonly = False,
+    module_name = "LatentSemanticMapping",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LatentSemanticMapping.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":_stdio",
+    ],
+)
+
+swift_c_module(
+    name = "IOUSBHost",
+    testonly = False,
+    module_name = "IOUSBHost",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOUSBHost.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IOKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBook",
+    testonly = False,
+    module_name = "AddressBook",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AddressBook.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":Cocoa",
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AVRouting",
+    testonly = False,
+    module_name = "AVRouting",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVRouting.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+    ],
+)
+
+swift_c_module(
+    name = "CoreHaptics",
+    testonly = False,
+    module_name = "CoreHaptics",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreHaptics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppTrackingTransparency",
+    testonly = False,
+    module_name = "AppTrackingTransparency",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppTrackingTransparency.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "OpenAL",
+    testonly = False,
+    module_name = "OpenAL",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenAL.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    testonly = False,
+    module_name = "PushKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AdSupport",
+    testonly = False,
+    module_name = "AdSupport",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AdSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Tcl",
+    testonly = False,
+    module_name = "Tcl",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Tcl.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_ctype",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+    ],
+)
+
+swift_c_module(
+    name = "ContactsUI",
+    testonly = False,
+    module_name = "ContactsUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ContactsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+    ],
+)
+
+swift_c_module(
+    name = "SystemExtensions",
+    testonly = False,
+    module_name = "SystemExtensions",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SystemExtensions.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "KernelManagement",
+    testonly = False,
+    module_name = "KernelManagement",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/KernelManagement.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ProximityReaderStub",
+    testonly = False,
+    module_name = "ProximityReaderStub",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ProximityReaderStub.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "FileProviderUI",
+    testonly = False,
+    module_name = "FileProviderUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FileProviderUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":FileProvider",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "Accounts",
+    testonly = False,
+    module_name = "Accounts",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accounts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AudioVideoBridging",
+    testonly = False,
+    module_name = "AudioVideoBridging",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioVideoBridging.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":Foundation",
+        ":IOKit",
+    ],
+)
+
+swift_c_module(
+    name = "Collaboration",
+    testonly = False,
+    module_name = "Collaboration",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Collaboration.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreServices",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShadersGraph",
+    testonly = False,
+    module_name = "MetalPerformanceShadersGraph",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":MetalPerformanceShaders",
+    ],
+)
+
+swift_c_module(
+    name = "GLUT",
+    testonly = False,
+    module_name = "GLUT",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLUT.framework/Modules/module.modulemap",
+    deps = [
+        ":OpenGL",
+        ":_math",
+    ],
+)
+
+swift_c_module(
+    name = "PHASE",
+    testonly = False,
+    module_name = "PHASE",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PHASE.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFAudio",
+        ":AVFoundation",
+        ":CoreAudioTypes",
+        ":Foundation",
+        ":ModelIO",
+        ":simd",
+    ],
+)
+
+swift_c_module(
+    name = "DVDPlayback",
+    testonly = False,
+    module_name = "DVDPlayback",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DVDPlayback.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":Security",
+    ],
+)
+
+swift_c_module(
+    name = "ClassKit",
+    testonly = False,
+    module_name = "ClassKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ClassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ICADevices",
+    testonly = False,
+    module_name = "ICADevices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ICADevices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreServices",
+        ":IOBluetooth",
+    ],
+)
+
+swift_c_module(
+    name = "Hypervisor",
+    testonly = False,
+    module_name = "Hypervisor",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Hypervisor.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "ExecutionPolicy",
+    testonly = False,
+    module_name = "ExecutionPolicy",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExecutionPolicy.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Social",
+    testonly = False,
+    module_name = "Social",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Social.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTelephony",
+    testonly = False,
+    module_name = "CoreTelephony",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreTelephony.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemConfiguration",
+    testonly = False,
+    module_name = "SystemConfiguration",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":Security",
+        ":TargetConditionals",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "NotificationCenter",
+    testonly = False,
+    module_name = "NotificationCenter",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NotificationCenter.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreWLAN",
+    testonly = False,
+    module_name = "CoreWLAN",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreWLAN.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IOKit",
+    ],
+)
+
+swift_c_module(
+    name = "AppleScriptObjC",
+    testonly = False,
+    module_name = "AppleScriptObjC",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppleScriptObjC.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DirectoryService",
+    testonly = False,
+    module_name = "DirectoryService",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DirectoryService.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":_Builtin_stdarg",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "OpenDirectory",
+    testonly = False,
+    module_name = "OpenDirectory",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenDirectory.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":ObjectiveC",
+    ],
+)
+
+swift_c_module(
+    name = "BusinessChat",
+    testonly = False,
+    module_name = "BusinessChat",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BusinessChat.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "IntentsUI",
+    testonly = False,
+    module_name = "IntentsUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IntentsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Intents",
+    ],
+)
+
+swift_c_module(
+    name = "MediaLibrary",
+    testonly = False,
+    module_name = "MediaLibrary",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ReplayKit",
+    testonly = False,
+    module_name = "ReplayKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ReplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AppKit",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "StickerFoundation",
+    testonly = False,
+    module_name = "StickerFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StickerFoundation.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "ThreadNetwork",
+    testonly = False,
+    module_name = "ThreadNetwork",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ThreadNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    testonly = False,
+    module_name = "CoreBluetooth",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundTasks",
+    testonly = False,
+    module_name = "BackgroundTasks",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BackgroundTasks.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MailKit",
+    testonly = False,
+    module_name = "MailKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MailKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    testonly = False,
+    module_name = "DeviceCheck",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ParavirtualizedGraphics",
+    testonly = False,
+    module_name = "ParavirtualizedGraphics",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ParavirtualizedGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreVideo",
+        ":Dispatch",
+        ":Foundation",
+        ":IOSurface",
+        ":Metal",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "DiscRecordingUI",
+    testonly = False,
+    module_name = "DiscRecordingUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiscRecordingUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Carbon",
+        ":Cocoa",
+        ":DiscRecording",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "vmnet",
+    testonly = False,
+    module_name = "vmnet",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/vmnet.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":ObjectiveC",
+        ":XPC",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "AGL",
+    testonly = False,
+    module_name = "AGL",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AGL.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":OpenGL",
+    ],
+)
+
+swift_c_module(
+    name = "ScriptingBridge",
+    testonly = False,
+    module_name = "ScriptingBridge",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScriptingBridge.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":CoreServices",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenTime",
+    testonly = False,
+    module_name = "ScreenTime",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenTime.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ServiceManagement",
+    testonly = False,
+    module_name = "ServiceManagement",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ServiceManagement.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":Foundation",
+        ":Security",
+        ":TargetConditionals",
+        ":XPC",
+    ],
+)
+
+swift_c_module(
+    name = "MetalFX",
+    testonly = False,
+    module_name = "MetalFX",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalFX.framework/Modules/module.modulemap",
+    deps = [
+        ":Metal",
+    ],
+)
+
+swift_c_module(
+    name = "ForceFeedback",
+    testonly = False,
+    module_name = "ForceFeedback",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ForceFeedback.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":IOKit",
+    ],
+)
+
+swift_c_module(
+    name = "NetFS",
+    testonly = False,
+    module_name = "NetFS",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NetFS.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "PreferencePanes",
+    testonly = False,
+    module_name = "PreferencePanes",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PreferencePanes.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenSaver",
+    testonly = False,
+    module_name = "ScreenSaver",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenSaver.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":_Builtin_limits",
+        ":_stdlib",
+    ],
+)
+
+swift_c_module(
+    name = "ExternalAccessory",
+    testonly = False,
+    module_name = "ExternalAccessory",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExternalAccessory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AutomaticAssessmentConfiguration",
+    testonly = False,
+    module_name = "AutomaticAssessmentConfiguration",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AutomaticAssessmentConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "TWAIN",
+    testonly = False,
+    module_name = "TWAIN",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/TWAIN.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    testonly = False,
+    module_name = "UserNotificationsUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "FinderSync",
+    testonly = False,
+    module_name = "FinderSync",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinderSync.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "GSS",
+    testonly = False,
+    module_name = "GSS",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GSS.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "ExceptionHandling",
+    testonly = False,
+    module_name = "ExceptionHandling",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExceptionHandling.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Automator",
+    testonly = False,
+    module_name = "Automator",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Automator.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":Foundation",
+        ":OSAKit",
+    ],
+)
+
+swift_c_module(
+    name = "OSAKit",
+    testonly = False,
+    module_name = "OSAKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OSAKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":Cocoa",
+    ],
+)
+
+swift_c_module(
+    name = "DiscRecording",
+    testonly = False,
+    module_name = "DiscRecording",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiscRecording.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreServices",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":_math",
+    ],
+)
+
+swift_c_module(
+    name = "IOBluetoothUI",
+    testonly = False,
+    module_name = "IOBluetoothUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOBluetoothUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Cocoa",
+        ":IOBluetooth",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "IOBluetooth",
+    testonly = False,
+    module_name = "IOBluetooth",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudio",
+        ":CoreFoundation",
+        ":CoreServices",
+        ":Darwin",
+        ":Foundation",
+        ":IOKit",
+        ":_Builtin_stdint",
+        ":_errno",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "JavaRuntimeSupport",
+    testonly = False,
+    module_name = "JavaRuntimeSupport",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/JavaRuntimeSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":Cocoa",
+        ":DarwinFoundation",
+        ":Foundation",
+        ":QuartzCore",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    testonly = False,
+    module_name = "_Darwin_xlocale",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":PassKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_PassKit_SwiftUI",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    testonly = False,
+    module_name = "_PassKit_SwiftUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":AVKit",
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    testonly = False,
+    module_name = "AVKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AppKit",
+        ":Cocoa",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_QuickLook_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PDFKit_swift",
+        ":Quartz",
+        ":QuartzCore_swift",
+        ":QuickLook",
+        ":QuickLookUI_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Quartz",
+    testonly = False,
+    module_name = "Quartz",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Quartz.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":Cocoa",
+        ":CoreImage",
+        ":Foundation",
+        ":ImageCaptureCore",
+        ":OpenGL",
+        ":PDFKit",
+        ":QuartzCore",
+        ":QuickLookUI",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ImageCaptureCore",
+    testonly = False,
+    module_name = "ImageCaptureCore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageCaptureCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "_ManagedAppDistribution_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedAppDistribution_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_Translation_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Translation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_CoreData_CloudKit",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    testonly = False,
+    module_name = "_CoreData_CloudKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_GroupActivities_AppKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_LocalAuthentication_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":LocalAuthentication_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthenticationEmbeddedUI",
+    testonly = False,
+    module_name = "LocalAuthenticationEmbeddedUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":LocalAuthentication",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_AppKit_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents_swift",
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_DeviceActivity_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":DeviceActivity_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_RealityKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":SwiftUICore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData_swift",
+        ":SwiftData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StoreKit_SwiftUI",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    testonly = False,
+    module_name = "_StoreKit_SwiftUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    testonly = False,
+    module_name = "AppleArchive",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_assert",
+        ":_string",
+        ":_time",
+        ":os_availability",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    testonly = False,
+    module_name = "Compression",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/compression.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    testonly = True,
+    module_name = "XCTest",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XCUIAutomation",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    testonly = True,
+    module_name = "XCUIAutomation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedAppDistribution_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":Translation",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    testonly = False,
+    module_name = "Translation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CryptoTokenKit",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    testonly = False,
+    module_name = "CryptoTokenKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Contacts_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":LocalAuthentication_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PassKit",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    testonly = False,
+    module_name = "PassKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Contacts",
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineKit",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    testonly = False,
+    module_name = "BrowserEngineKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":BrowserEngineCore",
+        ":Foundation",
+        ":XPC",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    testonly = False,
+    module_name = "BrowserEngineCore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "StickerKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMotion_swift",
+        ":CoreSpotlight_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MetalKit_swift",
+        ":MetalPerformanceShaders",
+        ":Metal_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":PhotosUI_swift",
+        ":QuartzCore_swift",
+        ":StickerKit",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StickerKit",
+    testonly = False,
+    module_name = "StickerKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StickerKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OSLog",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    testonly = False,
+    module_name = "CallKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "MediaAccessibility_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MediaAccessibility",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaAccessibility",
+    testonly = False,
+    module_name = "MediaAccessibility",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaAccessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":Foundation",
+        ":IOSurface",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":EventKit",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    testonly = False,
+    module_name = "EventKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":NetworkExtension",
+        ":Network_swift",
+        ":ObjectiveC_swift",
+        ":Security",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    testonly = False,
+    module_name = "NetworkExtension",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":Foundation",
+        ":Network",
+        ":Security",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Matter",
+        ":MatterSupport",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    testonly = False,
+    module_name = "MatterSupport",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    testonly = False,
+    module_name = "Matter",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":NearbyInteraction",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    testonly = False,
+    module_name = "NearbyInteraction",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":AuthenticationServices",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":LocalAuthentication_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    testonly = False,
+    module_name = "AuthenticationServices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":MusicKit_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":QuartzCore_swift",
+        ":ShazamKit",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    testonly = False,
+    module_name = "ShazamKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFAudio",
+        ":AVFoundation",
+        ":Foundation",
+        ":TargetConditionals",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "ScreenCaptureKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":AppKit_swift",
+        ":CoreAudio_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":ScreenCaptureKit",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenCaptureKit",
+    testonly = False,
+    module_name = "ScreenCaptureKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ScreenCaptureKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AppKit",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYou_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SharedWithYou",
+        ":SharedWithYouCore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYou",
+    testonly = False,
+    module_name = "SharedWithYou",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SharedWithYou.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":SharedWithYouCore",
+        ":TargetConditionals",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYouCore_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":SharedWithYouCore",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYouCore",
+    testonly = False,
+    module_name = "SharedWithYouCore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SharedWithYouCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "VisionKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":VisionKit",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "VisionKit",
+    testonly = False,
+    module_name = "VisionKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VisionKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CoreAudioKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":AppKit_swift",
+        ":CoreAudioKit",
+        ":CoreAudio_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioKit",
+    testonly = False,
+    module_name = "CoreAudioKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudioKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AppKit",
+        ":AudioUnit",
+        ":Cocoa",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AudioUnit",
+    testonly = False,
+    module_name = "AudioUnit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioUnit.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceDiscoveryExtension_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":DeviceDiscoveryExtension",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Network_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceDiscoveryExtension",
+    testonly = False,
+    module_name = "DeviceDiscoveryExtension",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeviceDiscoveryExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Cinematic_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":Cinematic",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Cinematic",
+    testonly = False,
+    module_name = "Cinematic",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Cinematic.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":CoreMedia",
+        ":Foundation",
+        ":Metal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SecurityInterface",
+        ":SecurityUI",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    testonly = False,
+    module_name = "SecurityUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityInterface",
+    testonly = False,
+    module_name = "SecurityInterface",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityInterface.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":Security",
+        ":SecurityFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityFoundation",
+    testonly = False,
+    module_name = "SecurityFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SecurityFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "IdentityLookup_swift",
+    testonly = False,
+    deps = [
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":IdentityLookup",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookup",
+    testonly = False,
+    module_name = "IdentityLookup",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IdentityLookup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "FileProvider_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":FileProvider",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FileProvider",
+    testonly = False,
+    module_name = "FileProvider",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FileProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OpenCL_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":OpenCL",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OpenCL",
+    testonly = False,
+    module_name = "OpenCL",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenCL.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":OpenGL",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "WebKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":Network_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":WebKit",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WebKit",
+    testonly = False,
+    module_name = "WebKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreGraphics",
+        ":Foundation",
+        ":JavaScriptCore",
+        ":Network",
+        ":ObjectiveC",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "JavaScriptCore",
+    testonly = False,
+    module_name = "JavaScriptCore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "BackgroundAssets_swift",
+    testonly = False,
+    deps = [
+        ":BackgroundAssets",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundAssets",
+    testonly = False,
+    module_name = "BackgroundAssets",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/BackgroundAssets.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreLocation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":HealthKit",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":notify",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    testonly = False,
+    module_name = "HealthKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "VideoSubscriberAccount_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":VideoSubscriberAccount",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoSubscriberAccount",
+    testonly = False,
+    module_name = "VideoSubscriberAccount",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VideoSubscriberAccount.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookThumbnailing_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":QuickLookThumbnailing",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookThumbnailing",
+    testonly = False,
+    module_name = "QuickLookThumbnailing",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLookThumbnailing.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PDFKit_swift",
+        ":QuartzCore_swift",
+        ":QuickLookUI",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookUI",
+    testonly = False,
+    module_name = "QuickLookUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLookUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreGraphics",
+        ":Foundation",
+        ":PDFKit",
+        ":QuickLook",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLook",
+    testonly = False,
+    module_name = "QuickLook",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuickLook.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":CoreFoundation",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Virtualization_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":Virtualization",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Virtualization",
+    testonly = False,
+    module_name = "Virtualization",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Virtualization.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":Darwin",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ImagePlayground_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":ImagePlayground",
+        ":PencilKit_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "ImagePlayground",
+    testonly = False,
+    module_name = "ImagePlayground",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImagePlayground.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PencilKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PencilKit",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PencilKit",
+    testonly = False,
+    module_name = "PencilKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PencilKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":AppKit_swift",
+        ":CoreAudio_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MapKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PhotosUI",
+        ":Photos_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    testonly = False,
+    module_name = "PhotosUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":MapKit",
+        ":Photos",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MapKit",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    testonly = False,
+    module_name = "MapKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Photos_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreAudio_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Photos",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Photos",
+    testonly = False,
+    module_name = "Photos",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Photos.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreLocation",
+        ":CoreMedia",
+        ":Foundation",
+        ":ImageIO",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "RealityKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":MultipeerConnectivity",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":RealityFoundation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MultipeerConnectivity",
+    testonly = False,
+    module_name = "MultipeerConnectivity",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MultipeerConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Cocoa",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RealityFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AVFoundation_swift",
+        ":Accessibility_swift",
+        ":AudioToolbox",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreLocation_swift",
+        ":CoreMotion",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    testonly = False,
+    module_name = "CoreMotion",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "GroupActivities_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CloudKit_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreTransferable_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GroupActivities",
+        ":IOKit_swift",
+        ":ImageIO",
+        ":ObjectiveC_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GroupActivities",
+    testonly = False,
+    module_name = "GroupActivities",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GroupActivities.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":CoreFoundation_swift",
+        ":CoreLocation_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    testonly = False,
+    module_name = "CloudKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreLocation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensorKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreMIDI_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SensorKit",
+        ":SoundAnalysis_swift",
+        ":Speech_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensorKit",
+    testonly = False,
+    module_name = "SensorKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SensorKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreLocation",
+        ":CoreMedia",
+        ":Foundation",
+        ":SoundAnalysis",
+        ":Speech",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreServices",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "PDFKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":PDFKit",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PDFKit",
+    testonly = False,
+    module_name = "PDFKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/PDFKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "DockKit_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":DockKit",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DockKit",
+    testonly = False,
+    module_name = "DockKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensitiveContentAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":SensitiveContentAnalysis",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensitiveContentAnalysis",
+    testonly = False,
+    module_name = "SensitiveContentAnalysis",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SensitiveContentAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "CoreHID_swift",
+    testonly = False,
+    deps = [
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "MLCompute_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MLCompute",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MLCompute",
+    testonly = False,
+    module_name = "MLCompute",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MLCompute.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+    ],
+)
+
+swift_library_group(
+    name = "MediaExtension_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MediaExtension",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":VideoToolbox_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaExtension",
+    testonly = False,
+    module_name = "MediaExtension",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":Foundation",
+        ":VideoToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "LinkPresentation_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":LinkPresentation",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":Vision_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LinkPresentation",
+    testonly = False,
+    module_name = "LinkPresentation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LinkPresentation.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MediaPlayer",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    testonly = False,
+    module_name = "MediaPlayer",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LightweightCodeRequirements_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":ObjectiveC_swift",
+        ":Security",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMediaIO_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMediaIO",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMediaIO",
+    testonly = False,
+    module_name = "CoreMediaIO",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMediaIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":Dispatch",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKitUI_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionKit_swift",
+        ":FinanceKitUI",
+        ":FinanceKit_swift",
+        ":Foundation_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":WidgetKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKitUI",
+    testonly = False,
+    module_name = "FinanceKitUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinanceKitUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Intents_swift",
+        ":ObjectiveC_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":WidgetKit",
+        ":XPC_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    testonly = False,
+    module_name = "WidgetKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Intents",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    testonly = False,
+    module_name = "Intents",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    testonly = False,
+    module_name = "UserNotifications",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreSpotlight_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":notify",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    testonly = False,
+    module_name = "notify",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/notify.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    testonly = False,
+    module_name = "AppIntents",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreSpotlight_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreSpotlight",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreSpotlight",
+    testonly = False,
+    module_name = "CoreSpotlight",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreSpotlight.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreLocation",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    testonly = False,
+    module_name = "CoreLocation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":FinanceKit",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    testonly = False,
+    module_name = "FinanceKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    testonly = False,
+    module_name = "ExtensionKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":ExtensionFoundation",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":SwiftUI",
+        ":SwiftUICore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    testonly = False,
+    module_name = "SwiftUI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":QuartzCore_swift",
+        ":SwiftUICore",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    testonly = False,
+    module_name = "SwiftUICore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreText",
+        ":Foundation",
+        ":QuartzCore",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    testonly = False,
+    module_name = "Spatial",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_Builtin_stdbool",
+        ":_math",
+        ":_stdio",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Security",
+        ":StoreKit",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    testonly = False,
+    module_name = "StoreKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":ObjectiveC_swift",
+        ":Security",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":LocalAuthentication",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    testonly = False,
+    module_name = "LocalAuthentication",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "SafariServices_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SafariServices",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafariServices",
+    testonly = False,
+    module_name = "SafariServices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "FSKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":FSKit",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FSKit",
+    testonly = False,
+    module_name = "FSKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/FSKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Speech_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Speech",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Speech",
+    testonly = False,
+    module_name = "Speech",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Speech.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateML_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":CreateMLComponents_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ImageIO",
+        ":MetalPerformanceShaders",
+        ":Metal_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":VideoToolbox_swift",
+        ":Vision_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShaders",
+    testonly = False,
+    module_name = "MetalPerformanceShaders",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalPerformanceShaders.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":Metal",
+        ":_Builtin_stdint",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "VideoToolbox_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":VideoToolbox",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoToolbox",
+    testonly = False,
+    module_name = "VideoToolbox",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/VideoToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":Metal",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":NaturalLanguage",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    testonly = False,
+    module_name = "NaturalLanguage",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreMIDI_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":RegexBuilder_swift",
+        ":SoundAnalysis_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Vision_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ImageIO",
+        ":MachO",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":Vision",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Vision",
+    testonly = False,
+    module_name = "Vision",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Vision.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreML",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":Foundation",
+        ":ImageIO",
+        ":Metal",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":SoundAnalysis",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    testonly = False,
+    module_name = "SoundAnalysis",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFAudio",
+        ":CoreML",
+        ":CoreMedia",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreML",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    testonly = False,
+    module_name = "CoreML",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Foundation",
+        ":ImageIO",
+        ":os_availability",
+        ":os_availability_internal",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_availability",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    testonly = False,
+    module_name = "Accelerate",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":TargetConditionals",
+        ":_Builtin_intrinsics",
+        ":_Builtin_limits",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_math",
+        ":_stdio",
+        ":_stdlib",
+        ":os",
+        ":os_availability",
+        ":os_object",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    testonly = False,
+    module_name = "AVFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFAudio",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":Foundation",
+        ":ImageIO",
+        ":MediaToolbox",
+        ":QuartzCore",
+        ":TargetConditionals",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+        ":simd",
+    ],
+)
+
+swift_c_module(
+    name = "MediaToolbox",
+    testonly = False,
+    module_name = "MediaToolbox",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MediaToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreFoundation",
+        ":CoreMedia",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    testonly = False,
+    module_name = "AVFAudio",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreAudioTypes",
+        ":CoreMIDI",
+        ":CoreMedia",
+        ":Darwin",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "AudioToolbox",
+    testonly = False,
+    module_name = "AudioToolbox",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AudioToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":Carbon",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":CoreMIDI",
+        ":Darwin",
+        ":Dispatch",
+        ":Foundation",
+        ":TargetConditionals",
+        ":_stdio",
+        ":os_availability",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "Carbon",
+    testonly = False,
+    module_name = "Carbon",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":CoreServices",
+        ":Foundation",
+        ":Security",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMIDI_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreMIDI",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    testonly = False,
+    module_name = "CoreMIDI",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia",
+        ":CoreText_swift",
+        ":CoreVideo",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    testonly = False,
+    module_name = "CoreMedia",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    testonly = False,
+    module_name = "CoreAudio",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    testonly = False,
+    module_name = "CoreAudioTypes",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":Combine_swift",
+        ":Contacts_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":GameController_swift",
+        ":GameKit",
+        ":GameplayKit_swift",
+        ":IOKit_swift",
+        ":MetalKit_swift",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SceneKit_swift",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    testonly = False,
+    module_name = "GameKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":Contacts",
+        ":CoreGraphics",
+        ":Foundation",
+        ":GameController",
+        ":GameplayKit",
+        ":Metal",
+        ":MetalKit",
+        ":ModelIO",
+        ":ObjectiveC",
+        ":SceneKit",
+        ":SpriteKit",
+        ":TargetConditionals",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    testonly = False,
+    module_name = "Contacts",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    testonly = False,
+    module_name = "ExtensionFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "GameController_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GameController",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameController",
+    testonly = False,
+    module_name = "GameController",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameController.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Foundation",
+        ":IOKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GameplayKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":GameplayKit",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SceneKit_swift",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameplayKit",
+    testonly = False,
+    module_name = "GameplayKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GameplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":SceneKit",
+        ":SpriteKit",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SceneKit",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    testonly = False,
+    module_name = "SceneKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":AvailabilityMacros",
+        ":CoreGraphics",
+        ":Foundation",
+        ":GLKit",
+        ":Metal",
+        ":ModelIO",
+        ":QuartzCore",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":SpriteKit",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    testonly = False,
+    module_name = "SpriteKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":Cocoa",
+        ":CoreGraphics",
+        ":Foundation",
+        ":GLKit",
+        ":Metal",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+    ],
+)
+
+swift_c_module(
+    name = "Cocoa",
+    testonly = False,
+    module_name = "Cocoa",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Cocoa.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreData",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "GLKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":GLKit",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GLKit",
+    testonly = False,
+    module_name = "GLKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/GLKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":Foundation",
+        ":ModelIO",
+        ":OpenGL",
+        ":TargetConditionals",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_math",
+        ":_string",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "MetalKit_swift",
+    testonly = False,
+    deps = [
+        ":AppKit_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MetalKit",
+        ":Metal_swift",
+        ":ModelIO_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalKit",
+    testonly = False,
+    module_name = "MetalKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetalKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AppKit",
+        ":CoreGraphics",
+        ":Foundation",
+        ":Metal",
+        ":ModelIO",
+        ":QuartzCore",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "ModelIO_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ModelIO",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":simd_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ModelIO",
+    testonly = False,
+    module_name = "ModelIO",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ModelIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":_math",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "AppKit_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility_swift",
+        ":AppKit",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreText_swift",
+        ":CoreTransferable_swift",
+        ":Darwin_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":OpenGL",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppKit",
+    testonly = False,
+    module_name = "AppKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/AppKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":CoreData",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreText",
+        ":Darwin",
+        ":Foundation",
+        ":IOKit",
+        ":OpenGL",
+        ":QuartzCore",
+        ":Symbols",
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "QuartzCore_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    testonly = False,
+    module_name = "QuartzCore",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Darwin",
+        ":Foundation",
+        ":Metal",
+        ":ObjectiveC",
+        ":OpenGL",
+        ":TargetConditionals",
+        ":_Builtin_float",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreData",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    testonly = False,
+    module_name = "CoreData",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Foundation",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreImage_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage",
+        ":CoreText_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreImage",
+    testonly = False,
+    module_name = "CoreImage",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreImage.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Foundation",
+        ":IOSurface",
+        ":ImageIO",
+        ":Metal",
+        ":ObjectiveC",
+        ":OpenGL",
+        ":TargetConditionals",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    testonly = False,
+    module_name = "CoreVideo",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":ApplicationServices",
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":IOSurface",
+        ":Metal",
+        ":OpenGL",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ApplicationServices",
+    testonly = False,
+    module_name = "ApplicationServices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ApplicationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CUPS",
+        ":ColorSync",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreServices",
+        ":CoreText",
+        ":Foundation",
+        ":ImageIO",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "CUPS",
+    testonly = False,
+    module_name = "CUPS",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/cups.modulemap",
+    deps = [
+        ":Darwin",
+        ":TargetConditionals",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":_locale",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":os_availability",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    testonly = False,
+    module_name = "ImageIO",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":_Builtin_float",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    testonly = False,
+    module_name = "ColorSync",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "OpenGL",
+    testonly = False,
+    module_name = "OpenGL",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OpenGL.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Metal_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Metal",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Metal",
+    testonly = False,
+    module_name = "Metal",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Metal.framework/Modules/module.modulemap",
+    deps = [
+        ":Darwin",
+        ":Foundation",
+        ":IOSurface",
+        ":TargetConditionals",
+        ":_math",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "IOSurface",
+    testonly = False,
+    module_name = "IOSurface",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOSurface.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Foundation",
+        ":IOKit",
+        ":TargetConditionals",
+        ":XPC",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":Symbols",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    testonly = False,
+    module_name = "Symbols",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":OSLog",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    testonly = False,
+    module_name = "OSLog",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    testonly = False,
+    module_name = "DeveloperToolsSupport",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "DataDetection_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":DataDetection",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    testonly = False,
+    module_name = "DataDetection",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    testonly = False,
+    module_name = "CoreTransferable",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreText",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    testonly = False,
+    module_name = "CoreText",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":Darwin",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    testonly = False,
+    module_name = "UniformTypeIdentifiers",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    testonly = False,
+    module_name = "Accessibility",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":CoreGraphics",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    testonly = False,
+    module_name = "CoreGraphics",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":Dispatch",
+        ":IOKit",
+        ":TargetConditionals",
+        ":_Builtin_float",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":simd",
+        ":sys_time_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    testonly = False,
+    module_name = "simd",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":Network",
+        ":ObjectiveC_swift",
+        ":Security",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    testonly = False,
+    module_name = "Network",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":Foundation",
+        ":Security",
+        ":TargetConditionals",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":dnssd",
+        ":os_object",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    testonly = False,
+    module_name = "dnssd",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dnssd.modulemap",
+    deps = [
+        ":Dispatch",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetricKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":IOKit_swift",
+        ":MetricKit",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetricKit",
+    testonly = False,
+    module_name = "MetricKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/MetricKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation",
+        ":IOKit_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    testonly = False,
+    module_name = "Foundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":CoreServices",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":ObjectiveC",
+        ":Security",
+        ":TargetConditionals",
+        ":XPC",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_setjmp",
+        ":os_availability",
+        ":ptrauth",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    testonly = False,
+    module_name = "CoreServices",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CFNetwork",
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":DiskArbitration",
+        ":Dispatch",
+        ":Security",
+        ":TargetConditionals",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdint",
+        ":_fenv",
+        ":_math",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    testonly = False,
+    module_name = "Security",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":TargetConditionals",
+        ":XPC",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdio",
+        ":_string",
+        ":libDER",
+        ":os_availability",
+        ":os_object",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "libDER",
+    testonly = False,
+    module_name = "libDER",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libDER/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_string",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    testonly = False,
+    module_name = "_Builtin_intrinsics",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdlib",
+    ],
+)
+
+swift_c_module(
+    name = "DiskArbitration",
+    testonly = False,
+    module_name = "DiskArbitration",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/DiskArbitration.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":IOKit",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "CFNetwork",
+    testonly = False,
+    module_name = "CFNetwork",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CFNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Darwin",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "IOKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":IOKit",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IOKit",
+    testonly = False,
+    module_name = "IOKit",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/IOKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":CoreFoundation",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":TargetConditionals",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":libkern",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "libkern",
+    testonly = False,
+    module_name = "libkern",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/libkern.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    testonly = False,
+    module_name = "CoreFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":TargetConditionals",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":os_availability",
+        ":ptrauth",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    testonly = False,
+    module_name = "ptrauth",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":os",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    testonly = False,
+    module_name = "os",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":MachO",
+        ":XPC",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":os_object",
+        ":os_workgroup",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_library_group(
+    name = "XPC_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":XPC",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XPC",
+    testonly = False,
+    module_name = "XPC",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/xpc.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Dispatch",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":launch",
+        ":os_availability",
+        ":os_object",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "launch",
+    testonly = False,
+    module_name = "launch",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/launch.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Combine_swift",
+        ":Darwin_swift",
+        ":Dispatch",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    testonly = False,
+    module_name = "Dispatch",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/dispatch.modulemap",
+    deps = [
+        ":Darwin",
+        ":DarwinFoundation",
+        ":TargetConditionals",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_signal",
+        ":_string",
+        ":os_availability",
+        ":os_object",
+        ":os_workgroup",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    testonly = False,
+    module_name = "os_workgroup",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_string",
+        ":os_availability",
+        ":os_object",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    testonly = False,
+    module_name = "os_object",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":ObjectiveC",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":ObjectiveC",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    testonly = False,
+    module_name = "_SwiftConcurrencyShims",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    testonly = False,
+    module_name = "ObjectiveC",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":MachO",
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_string",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    testonly = False,
+    module_name = "MachO",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":TargetConditionals",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_types",
+        ":unistd",
+    ],
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    testonly = False,
+    module_name = "Darwin",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/Darwin.modulemap",
+    deps = [
+        ":AvailabilityMacros",
+        ":DarwinFoundation",
+        ":TargetConditionals",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":__wctype",
+        ":_assert",
+        ":_complex",
+        ":_ctype",
+        ":_errno",
+        ":_fenv",
+        ":_inttypes",
+        ":_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_strings",
+        ":_sys_select",
+        ":_time",
+        ":_wchar",
+        ":_wctype",
+        ":mach",
+        ":netinet_in",
+        ":nl_types",
+        ":os_availability",
+        ":pthread",
+        ":sys_resource",
+        ":sys_select",
+        ":sys_time",
+        ":sys_types",
+        ":sys_wait",
+        ":unistd",
+        ":uuid",
+        ":xlocale",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    testonly = False,
+    module_name = "AvailabilityMacros",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    testonly = False,
+    module_name = "pthread",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_signal",
+        ":_time",
+        ":mach",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    testonly = False,
+    module_name = "nl_types",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    testonly = False,
+    module_name = "xlocale",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    testonly = False,
+    module_name = "_wctype",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    testonly = False,
+    module_name = "_wchar",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":__wctype",
+        ":_stdio",
+        ":_time",
+        ":os_availability",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    testonly = False,
+    module_name = "__wctype",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    testonly = False,
+    module_name = "_Builtin_tgmath",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    testonly = False,
+    module_name = "_tgmath",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_complex",
+        ":_math",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    testonly = False,
+    module_name = "_string",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_errno",
+        ":_strings",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    testonly = False,
+    module_name = "_strings",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    testonly = False,
+    module_name = "_stdlib",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":alloca",
+        ":os_availability",
+        ":ptrcheck",
+        ":runetype",
+        ":sys_types",
+        ":sys_wait",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    testonly = False,
+    module_name = "alloca",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    testonly = False,
+    module_name = "sys_wait",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_signal",
+        ":sys_resource",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    testonly = False,
+    module_name = "sys_resource",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    testonly = False,
+    module_name = "_Builtin_stdbool",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    testonly = False,
+    module_name = "_Builtin_stdatomic",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    testonly = False,
+    module_name = "_setjmp",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    testonly = False,
+    module_name = "_locale",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    testonly = False,
+    module_name = "_Builtin_limits",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    testonly = False,
+    module_name = "_Builtin_iso646",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    testonly = False,
+    module_name = "_Builtin_inttypes",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    testonly = False,
+    module_name = "_inttypes",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    testonly = False,
+    module_name = "_fenv",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    testonly = False,
+    module_name = "_ctype",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    testonly = False,
+    module_name = "runetype",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    testonly = False,
+    module_name = "_Builtin_stdint",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    testonly = False,
+    module_name = "_stdint",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    testonly = False,
+    module_name = "_complex",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    testonly = False,
+    module_name = "_assert",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    testonly = False,
+    module_name = "TargetConditionals",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    testonly = False,
+    module_name = "unistd",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_limits",
+        ":_stdio",
+        ":_useconds_t",
+        ":gethostuuid",
+        ":os_availability",
+        ":sys_select",
+        ":sys_types",
+        ":uuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    testonly = False,
+    module_name = "gethostuuid",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":os_availability",
+        ":uuid",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    testonly = False,
+    module_name = "uuid",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    testonly = False,
+    module_name = "sys_select",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_signal",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    testonly = False,
+    module_name = "_limits",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":sys_time",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    testonly = False,
+    module_name = "sys_time",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_time",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    testonly = False,
+    module_name = "_time",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    testonly = False,
+    module_name = "_stdio",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    testonly = False,
+    module_name = "_signal",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    testonly = False,
+    module_name = "sys_types",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_errno",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    testonly = False,
+    module_name = "_sys_select",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    testonly = False,
+    module_name = "_useconds_t",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    testonly = False,
+    module_name = "netinet_in",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    testonly = False,
+    module_name = "mach",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_math",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    testonly = False,
+    module_name = "_math",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_errno",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    testonly = False,
+    module_name = "_errno",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    testonly = False,
+    module_name = "DarwinFoundation",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+        ":os_availability",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    testonly = False,
+    module_name = "_Builtin_stddef",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    testonly = False,
+    module_name = "_Builtin_stdarg",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    testonly = False,
+    module_name = "os_availability",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    testonly = False,
+    module_name = "os_availability_internal",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    testonly = False,
+    module_name = "ptrcheck",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_Builtin_float",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    testonly = False,
+    module_name = "_Builtin_float",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    testonly = False,
+    module_name = "_float",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    testonly = False,
+    module_name = "SwiftShims",
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":AGL",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":AVFoundation_swift",
+        ":AVKit",
+        ":AVRouting",
+        ":Accelerate",
+        ":Accelerate_swift",
+        ":Accessibility",
+        ":Accessibility_swift",
+        ":Accounts",
+        ":AdServices",
+        ":AdSupport",
+        ":AddressBook",
+        ":AppIntents",
+        ":AppIntents_swift",
+        ":AppKit",
+        ":AppKit_swift",
+        ":AppTrackingTransparency",
+        ":AppleArchive",
+        ":AppleArchive_swift",
+        ":AppleScriptObjC",
+        ":ApplicationServices",
+        ":AudioToolbox",
+        ":AudioUnit",
+        ":AudioVideoBridging",
+        ":AuthenticationServices",
+        ":AuthenticationServices_swift",
+        ":AutomaticAssessmentConfiguration",
+        ":Automator",
+        ":AvailabilityMacros",
+        ":BackgroundAssets",
+        ":BackgroundAssets_swift",
+        ":BackgroundTasks",
+        ":BrowserEngineCore",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineKit",
+        ":BrowserEngineKit_swift",
+        ":BusinessChat",
+        ":CFNetwork",
+        ":CUPS",
+        ":CallKit",
+        ":CallKit_swift",
+        ":CarKey_swift",
+        ":Carbon",
+        ":Charts_swift",
+        ":Cinematic",
+        ":Cinematic_swift",
+        ":ClassKit",
+        ":CloudKit",
+        ":CloudKit_swift",
+        ":Cocoa",
+        ":Collaboration",
+        ":ColorSync",
+        ":Combine_swift",
+        ":Compression",
+        ":Compression_swift",
+        ":Contacts",
+        ":ContactsUI",
+        ":Contacts_swift",
+        ":CoreAudio",
+        ":CoreAudioKit",
+        ":CoreAudioKit_swift",
+        ":CoreAudioTypes",
+        ":CoreAudio_swift",
+        ":CoreBluetooth",
+        ":CoreData",
+        ":CoreData_swift",
+        ":CoreFoundation",
+        ":CoreFoundation_swift",
+        ":CoreGraphics",
+        ":CoreGraphics_swift",
+        ":CoreHID_swift",
+        ":CoreHaptics",
+        ":CoreImage",
+        ":CoreImage_swift",
+        ":CoreLocation",
+        ":CoreLocation_swift",
+        ":CoreMIDI",
+        ":CoreMIDI_swift",
+        ":CoreML",
+        ":CoreML_swift",
+        ":CoreMedia",
+        ":CoreMediaIO",
+        ":CoreMediaIO_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion",
+        ":CoreMotion_swift",
+        ":CoreServices",
+        ":CoreSpotlight",
+        ":CoreSpotlight_swift",
+        ":CoreTelephony",
+        ":CoreText",
+        ":CoreText_swift",
+        ":CoreTransferable",
+        ":CoreTransferable_swift",
+        ":CoreVideo",
+        ":CoreWLAN",
+        ":CreateMLComponents_swift",
+        ":CreateML_swift",
+        ":CryptoKit_swift",
+        ":CryptoTokenKit",
+        ":CryptoTokenKit_swift",
+        ":DVDPlayback",
+        ":Darwin",
+        ":DarwinFoundation",
+        ":Darwin_swift",
+        ":DataDetection",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport",
+        ":DeveloperToolsSupport_swift",
+        ":DeviceActivity_swift",
+        ":DeviceCheck",
+        ":DeviceDiscoveryExtension",
+        ":DeviceDiscoveryExtension_swift",
+        ":DirectoryService",
+        ":DiscRecording",
+        ":DiscRecordingUI",
+        ":DiskArbitration",
+        ":Dispatch",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":DockKit",
+        ":DockKit_swift",
+        ":EventKit",
+        ":EventKit_swift",
+        ":ExceptionHandling",
+        ":ExecutionPolicy",
+        ":ExtensionFoundation",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit",
+        ":ExtensionKit_swift",
+        ":ExternalAccessory",
+        ":FSKit",
+        ":FSKit_swift",
+        ":FamilyControls_swift",
+        ":FileProvider",
+        ":FileProviderUI",
+        ":FileProvider_swift",
+        ":FinanceKit",
+        ":FinanceKitUI",
+        ":FinanceKitUI_swift",
+        ":FinanceKit_swift",
+        ":FinderSync",
+        ":ForceFeedback",
+        ":Foundation",
+        ":Foundation_swift",
+        ":GLKit",
+        ":GLKit_swift",
+        ":GLUT",
+        ":GSS",
+        ":GameController",
+        ":GameController_swift",
+        ":GameKit",
+        ":GameKit_swift",
+        ":GameplayKit",
+        ":GameplayKit_swift",
+        ":GroupActivities",
+        ":GroupActivities_swift",
+        ":HealthKit",
+        ":HealthKit_swift",
+        ":Hypervisor",
+        ":ICADevices",
+        ":IOBluetooth",
+        ":IOBluetoothUI",
+        ":IOKit",
+        ":IOKit_swift",
+        ":IOSurface",
+        ":IOUSBHost",
+        ":IdentityLookup",
+        ":IdentityLookup_swift",
+        ":ImageCaptureCore",
+        ":ImageIO",
+        ":ImagePlayground",
+        ":ImagePlayground_swift",
+        ":InputMethodKit",
+        ":Intents",
+        ":IntentsUI",
+        ":Intents_swift",
+        ":JavaRuntimeSupport",
+        ":JavaScriptCore",
+        ":KernelManagement",
+        ":LatentSemanticMapping",
+        ":LightweightCodeRequirements_swift",
+        ":LinkPresentation",
+        ":LinkPresentation_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":LocalAuthentication",
+        ":LocalAuthenticationEmbeddedUI",
+        ":LocalAuthentication_swift",
+        ":MLCompute",
+        ":MLCompute_swift",
+        ":MachO",
+        ":MailKit",
+        ":ManagedAppDistribution_swift",
+        ":ManagedSettings_swift",
+        ":MapKit",
+        ":MapKit_swift",
+        ":Matter",
+        ":MatterSupport",
+        ":MatterSupport_swift",
+        ":MediaAccessibility",
+        ":MediaAccessibility_swift",
+        ":MediaExtension",
+        ":MediaExtension_swift",
+        ":MediaLibrary",
+        ":MediaPlayer",
+        ":MediaPlayer_swift",
+        ":MediaToolbox",
+        ":Metal",
+        ":MetalFX",
+        ":MetalKit",
+        ":MetalKit_swift",
+        ":MetalPerformanceShaders",
+        ":MetalPerformanceShadersGraph",
+        ":Metal_swift",
+        ":MetricKit",
+        ":MetricKit_swift",
+        ":ModelIO",
+        ":ModelIO_swift",
+        ":MultipeerConnectivity",
+        ":MusicKit_swift",
+        ":NaturalLanguage",
+        ":NaturalLanguage_swift",
+        ":NearbyInteraction",
+        ":NearbyInteraction_swift",
+        ":NetFS",
+        ":Network",
+        ":NetworkExtension",
+        ":NetworkExtension_swift",
+        ":Network_swift",
+        ":NotificationCenter",
+        ":OSAKit",
+        ":OSLog",
+        ":OSLog_swift",
+        ":ObjectiveC",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":OpenAL",
+        ":OpenCL",
+        ":OpenCL_swift",
+        ":OpenDirectory",
+        ":OpenGL",
+        ":PDFKit",
+        ":PDFKit_swift",
+        ":PHASE",
+        ":ParavirtualizedGraphics",
+        ":PassKit",
+        ":PassKit_swift",
+        ":PencilKit",
+        ":PencilKit_swift",
+        ":Photos",
+        ":PhotosUI",
+        ":PhotosUI_swift",
+        ":Photos_swift",
+        ":PreferencePanes",
+        ":ProximityReaderStub",
+        ":PushKit",
+        ":PushToTalk",
+        ":Quartz",
+        ":QuartzCore",
+        ":QuartzCore_swift",
+        ":QuickLook",
+        ":QuickLookThumbnailing",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookUI",
+        ":QuickLookUI_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":RegexBuilder_swift",
+        ":ReplayKit",
+        ":SafariServices",
+        ":SafariServices_swift",
+        ":SafetyKit",
+        ":SceneKit",
+        ":SceneKit_swift",
+        ":ScreenCaptureKit",
+        ":ScreenCaptureKit_swift",
+        ":ScreenSaver",
+        ":ScreenTime",
+        ":ScriptingBridge",
+        ":Security",
+        ":SecurityFoundation",
+        ":SecurityInterface",
+        ":SecurityUI",
+        ":SecurityUI_swift",
+        ":SensitiveContentAnalysis",
+        ":SensitiveContentAnalysis_swift",
+        ":SensorKit",
+        ":SensorKit_swift",
+        ":ServiceManagement",
+        ":SharedWithYou",
+        ":SharedWithYouCore",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYou_swift",
+        ":ShazamKit",
+        ":ShazamKit_swift",
+        ":Social",
+        ":SoundAnalysis",
+        ":SoundAnalysis_swift",
+        ":Spatial",
+        ":Spatial_swift",
+        ":Speech",
+        ":Speech_swift",
+        ":SpriteKit",
+        ":SpriteKit_swift",
+        ":StickerFoundation",
+        ":StickerKit",
+        ":StickerKit_swift",
+        ":StoreKit",
+        ":StoreKitTest",
+        ":StoreKit_swift",
+        ":SwiftData_swift",
+        ":SwiftOnoneSupport_swift",
+        ":SwiftShims",
+        ":SwiftUI",
+        ":SwiftUICore",
+        ":SwiftUICore_swift",
+        ":SwiftUI_swift",
+        ":Swift_swift",
+        ":Symbols",
+        ":Symbols_swift",
+        ":Synchronization_swift",
+        ":SystemConfiguration",
+        ":SystemExtensions",
+        ":System_swift",
+        ":TWAIN",
+        ":TabularData_swift",
+        ":TargetConditionals",
+        ":Tcl",
+        ":Testing_swift",
+        ":ThreadNetwork",
+        ":TipKit_swift",
+        ":Translation",
+        ":Translation_swift",
+        ":UniformTypeIdentifiers",
+        ":UniformTypeIdentifiers_swift",
+        ":UserNotifications",
+        ":UserNotificationsUI",
+        ":VideoSubscriberAccount",
+        ":VideoSubscriberAccount_swift",
+        ":VideoToolbox",
+        ":VideoToolbox_swift",
+        ":Virtualization",
+        ":Virtualization_swift",
+        ":Vision",
+        ":VisionKit",
+        ":VisionKit_swift",
+        ":Vision_swift",
+        ":WeatherKit_swift",
+        ":WebKit",
+        ":WebKit_swift",
+        ":WidgetKit",
+        ":WidgetKit_swift",
+        ":WorkoutKit_swift",
+        ":XPC",
+        ":XPC_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_AppIntents_AppKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_Builtin_float",
+        ":_Builtin_float_swift",
+        ":_Builtin_intrinsics",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Concurrency_swift",
+        ":_CoreData_CloudKit",
+        ":_CoreData_CloudKit_swift",
+        ":_Darwin_xlocale",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_GroupActivities_AppKit_swift",
+        ":_Intents_TipKit_swift",
+        ":_LocalAuthentication_SwiftUI_swift",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_PassKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StringProcessing_swift",
+        ":_SwiftConcurrencyShims",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":__wctype",
+        ":_assert",
+        ":_complex",
+        ":_ctype",
+        ":_errno",
+        ":_errno_swift",
+        ":_fenv",
+        ":_float",
+        ":_inttypes",
+        ":_limits",
+        ":_locale",
+        ":_math",
+        ":_math_swift",
+        ":_setjmp",
+        ":_signal",
+        ":_signal_swift",
+        ":_stdint",
+        ":_stdio",
+        ":_stdio_swift",
+        ":_stdlib",
+        ":_string",
+        ":_strings",
+        ":_sys_select",
+        ":_tgmath",
+        ":_time",
+        ":_time_swift",
+        ":_useconds_t",
+        ":_wchar",
+        ":_wctype",
+        ":alloca",
+        ":dnssd",
+        ":gethostuuid",
+        ":hvf_swift",
+        ":iTunesLibrary",
+        ":launch",
+        ":libDER",
+        ":libkern",
+        ":mach",
+        ":netinet_in",
+        ":nl_types",
+        ":notify",
+        ":os",
+        ":os_availability",
+        ":os_availability_internal",
+        ":os_object",
+        ":os_swift",
+        ":os_workgroup",
+        ":pthread",
+        ":ptrauth",
+        ":ptrcheck",
+        ":runetype",
+        ":simd",
+        ":simd_swift",
+        ":sys_resource",
+        ":sys_select",
+        ":sys_time",
+        ":sys_time_swift",
+        ":sys_types",
+        ":sys_wait",
+        ":unistd",
+        ":unistd_swift",
+        ":uuid",
+        ":vmnet",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":XCTest_swift",
+        ":XCUIAutomation",
+        ":XCUIAutomation_swift",
+        ":imports_swift",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/WatchOS/arm64_32/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/WatchOS/arm64_32/BUILD.bazel
@@ -1,0 +1,5118 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":QuartzCore",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreLocationUI",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":CoreBluetooth",
+        ":Security",
+        ":MobileCoreServices",
+        ":ColorSync",
+        ":CoreServices",
+        ":AVFAudio",
+        ":Matter",
+        ":DataDetection",
+        ":BrowserKit",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":AVKit",
+        ":CoreMIDI",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Network_swift",
+        ":GameKit_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":Symbols_swift",
+        ":LightweightCodeRequirements_swift",
+        ":MediaPlayer_swift",
+        ":UIKit_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":PhotosUI_swift",
+        ":SpriteKit_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":FinanceKit_swift",
+        ":HealthKit_swift",
+        ":SwiftUICore_swift",
+        ":DeviceActivity_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":MusicKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":WatchKit_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":NearbyInteraction_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":WidgetKit_swift",
+        ":SoundAnalysis_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":BrowserEngineCore_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":PassKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":CryptoTokenKit_swift",
+        ":Translation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":SceneKit_swift",
+        ":StoreKitTest_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_WatchKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_WatchKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_ClockKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchOS.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchOS.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKitTest_swift",
+    testonly = True,
+    deps = [
+        ":StoreKitTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKitTest",
+    module_name = "StoreKitTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchOS.platform/Developer/Library/Frameworks/StoreKitTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":StoreKit",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":UserNotifications",
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":WatchKit",
+    ],
+)
+
+swift_library_group(
+    name = "WatchKit_swift",
+    testonly = False,
+    deps = [
+        ":WatchKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WatchKit",
+    module_name = "WatchKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreGraphics",
+        ":UIKit",
+        ":HomeKit",
+        ":MapKit",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":ObjectiveC",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "LightweightCodeRequirements_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_math_swift",
+        ":SpriteKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":SceneKit_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":SpriteKit",
+        ":SceneKit",
+        ":Foundation",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":Darwin",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":PushKit",
+        ":BrowserKit",
+        ":ColorSync",
+        ":MobileCoreServices",
+        ":CoreBluetooth",
+        ":DeviceCheck",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_WatchKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":AVKit",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":RegexBuilder_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":TipKit_swift",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":EventKit_swift",
+        ":EventKit",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":CreateMLComponents_swift",
+        ":TabularData_swift",
+        ":MusicKit_swift",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":WatchKit_swift",
+        ":WatchKit",
+        ":MapKit_swift",
+        ":MapKit",
+        ":Spatial_swift",
+        ":Spatial",
+        ":DeviceActivity_swift",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":Intents_swift",
+        ":Intents",
+        ":UserNotifications",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":QuartzCore",
+        ":AVFAudio",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":LightweightCodeRequirements_swift",
+        ":CoreML_swift",
+        ":CoreML",
+        ":ImageIO",
+        ":CoreVideo",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":OSLog_swift",
+        ":OSLog",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":GameKit_swift",
+        ":GameKit",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":UIKit_swift",
+        ":UIKit",
+        ":DataDetection",
+        ":Symbols_swift",
+        ":Symbols",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Foundation_swift",
+        ":Foundation",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":Distributed_swift",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":ObjectiveC_swift",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Combine_swift",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+        ":StoreKitTest_swift",
+        ":StoreKitTest",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/WatchSimulator/arm64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/WatchSimulator/arm64/BUILD.bazel
@@ -1,0 +1,5052 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":QuartzCore",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreLocationUI",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":CoreBluetooth",
+        ":Security",
+        ":MobileCoreServices",
+        ":ColorSync",
+        ":CoreServices",
+        ":AVFAudio",
+        ":Matter",
+        ":DataDetection",
+        ":BrowserKit",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":AVKit",
+        ":CoreMIDI",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Network_swift",
+        ":GameKit_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":Symbols_swift",
+        ":MediaPlayer_swift",
+        ":UIKit_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":PhotosUI_swift",
+        ":SpriteKit_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":FinanceKit_swift",
+        ":HealthKit_swift",
+        ":SwiftUICore_swift",
+        ":DeviceActivity_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":MusicKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":WatchKit_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":NearbyInteraction_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":WidgetKit_swift",
+        ":SoundAnalysis_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":BrowserEngineCore_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":PassKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":CryptoTokenKit_swift",
+        ":Translation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":SceneKit_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_WatchKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_WatchKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_ClockKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":UserNotifications",
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":WatchKit",
+    ],
+)
+
+swift_library_group(
+    name = "WatchKit_swift",
+    testonly = False,
+    deps = [
+        ":WatchKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WatchKit",
+    module_name = "WatchKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreGraphics",
+        ":UIKit",
+        ":HomeKit",
+        ":MapKit",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":ObjectiveC",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_math_swift",
+        ":SpriteKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":SceneKit_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":SpriteKit",
+        ":SceneKit",
+        ":Foundation",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":Darwin",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":PushKit",
+        ":BrowserKit",
+        ":ColorSync",
+        ":MobileCoreServices",
+        ":CoreBluetooth",
+        ":DeviceCheck",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_WatchKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":AVKit",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":RegexBuilder_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":TipKit_swift",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":EventKit_swift",
+        ":EventKit",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":CreateMLComponents_swift",
+        ":TabularData_swift",
+        ":MusicKit_swift",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":WatchKit_swift",
+        ":WatchKit",
+        ":MapKit_swift",
+        ":MapKit",
+        ":Spatial_swift",
+        ":Spatial",
+        ":DeviceActivity_swift",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":Intents_swift",
+        ":Intents",
+        ":UserNotifications",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":QuartzCore",
+        ":AVFAudio",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":CoreML_swift",
+        ":CoreML",
+        ":ImageIO",
+        ":CoreVideo",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":OSLog_swift",
+        ":OSLog",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":GameKit_swift",
+        ":GameKit",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":UIKit_swift",
+        ":UIKit",
+        ":DataDetection",
+        ":Symbols_swift",
+        ":Symbols",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Foundation_swift",
+        ":Foundation",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":Distributed_swift",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":ObjectiveC_swift",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Combine_swift",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/WatchSimulator/x86_64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/WatchSimulator/x86_64/BUILD.bazel
@@ -1,0 +1,5057 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":QuartzCore",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreLocationUI",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":CoreBluetooth",
+        ":Security",
+        ":MobileCoreServices",
+        ":ColorSync",
+        ":CoreServices",
+        ":AVFAudio",
+        ":Matter",
+        ":DataDetection",
+        ":BrowserKit",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":AVKit",
+        ":CoreMIDI",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Network_swift",
+        ":GameKit_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":Symbols_swift",
+        ":MediaPlayer_swift",
+        ":UIKit_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":PhotosUI_swift",
+        ":SpriteKit_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":FinanceKit_swift",
+        ":HealthKit_swift",
+        ":SwiftUICore_swift",
+        ":DeviceActivity_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":MusicKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":WatchKit_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":NearbyInteraction_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":WidgetKit_swift",
+        ":SoundAnalysis_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":BrowserEngineCore_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":PassKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":CryptoTokenKit_swift",
+        ":Translation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":SceneKit_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_WatchKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_WatchKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_ClockKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":UserNotifications",
+        ":_SwiftConcurrencyShims",
+        ":ClockKit_swift",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":WatchKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":WatchKit",
+    ],
+)
+
+swift_library_group(
+    name = "WatchKit_swift",
+    testonly = False,
+    deps = [
+        ":WatchKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":HomeKit_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+        ":SceneKit_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WatchKit",
+    module_name = "WatchKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreGraphics",
+        ":UIKit",
+        ":HomeKit",
+        ":MapKit",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":Foundation",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":ObjectiveC",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_math_swift",
+        ":SpriteKit_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":SceneKit_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":SpriteKit",
+        ":SceneKit",
+        ":Foundation",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdlib",
+    ],
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":Darwin",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":PushKit",
+        ":BrowserKit",
+        ":ColorSync",
+        ":MobileCoreServices",
+        ":CoreBluetooth",
+        ":DeviceCheck",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_WatchKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":AVKit",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_ClockKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":RegexBuilder_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":TipKit_swift",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":EventKit_swift",
+        ":EventKit",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":CreateMLComponents_swift",
+        ":TabularData_swift",
+        ":MusicKit_swift",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":WatchKit_swift",
+        ":WatchKit",
+        ":MapKit_swift",
+        ":MapKit",
+        ":Spatial_swift",
+        ":Spatial",
+        ":DeviceActivity_swift",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":Intents_swift",
+        ":Intents",
+        ":UserNotifications",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":QuartzCore",
+        ":AVFAudio",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":CoreML_swift",
+        ":CoreML",
+        ":ImageIO",
+        ":CoreVideo",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":OSLog_swift",
+        ":OSLog",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":GameKit_swift",
+        ":GameKit",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":UIKit_swift",
+        ":UIKit",
+        ":DataDetection",
+        ":Symbols_swift",
+        ":Symbols",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Foundation_swift",
+        ":Foundation",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":Distributed_swift",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":ObjectiveC_swift",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Combine_swift",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/iPhoneOS/arm64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/iPhoneOS/arm64/BUILD.bazel
@@ -1,0 +1,9487 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":AddressBookUI",
+        ":AppClip",
+        ":GSS",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreMediaIO",
+        ":CoreLocationUI",
+        ":MetalPerformanceShaders",
+        ":AutomaticAssessmentConfiguration",
+        ":ExternalAccessory",
+        ":IdentityLookupUI",
+        ":MediaToolbox",
+        ":MetalFX",
+        ":ScreenTime",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":BackgroundTasks",
+        ":CoreBluetooth",
+        ":ThreadNetwork",
+        ":Security",
+        ":StickerFoundation",
+        ":ReplayKit",
+        ":IOSurface",
+        ":MobileCoreServices",
+        ":IntentsUI",
+        ":BusinessChat",
+        ":ColorSync",
+        ":CoreServices",
+        ":MultipeerConnectivity",
+        ":NotificationCenter",
+        ":SystemConfiguration",
+        ":CoreTelephony",
+        ":AVFAudio",
+        ":AudioUnit",
+        ":Social",
+        ":Matter",
+        ":MediaSetup",
+        ":ExposureNotification",
+        ":ClassKit",
+        ":PHASE",
+        ":OpenGLES",
+        ":MetalPerformanceShadersGraph",
+        ":Accounts",
+        ":FileProviderUI",
+        ":AudioToolbox",
+        ":SystemExtensions",
+        ":BrowserKit",
+        ":AdSupport",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":OpenAL",
+        ":iAd",
+        ":AppTrackingTransparency",
+        ":CoreHaptics",
+        ":AVRouting",
+        ":AddressBook",
+        ":CFNetwork",
+        ":JavaScriptCore",
+        ":PushToTalk",
+        ":ImageCaptureCore",
+        ":AdServices",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":MetricKit_swift",
+        ":Network_swift",
+        ":ContactProvider_swift",
+        ":GameKit_swift",
+        ":CreateML_swift",
+        ":Speech_swift",
+        ":SafariServices_swift",
+        ":ProximityReader_swift",
+        ":Metal_swift",
+        ":QuartzCore_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":FinanceKitUI_swift",
+        ":ARKit_swift",
+        ":Symbols_swift",
+        ":LightweightCodeRequirements_swift",
+        ":Assignables_swift",
+        ":MediaPlayer_swift",
+        ":LinkPresentation_swift",
+        ":UIKit_swift",
+        ":MessageUI_swift",
+        ":CoreNFC_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":MLCompute_swift",
+        ":NaturalLanguage_swift",
+        ":SensitiveContentAnalysis_swift",
+        ":MetalKit_swift",
+        ":DockKit_swift",
+        ":OSLog_swift",
+        ":PDFKit_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":SensorKit_swift",
+        ":Contacts_swift",
+        ":LockedCameraCapture_swift",
+        ":CarPlay_swift",
+        ":ExtensionFoundation_swift",
+        ":RealityKit_swift",
+        ":PhotosUI_swift",
+        ":RoomPlan_swift",
+        ":AdAttributionKit_swift",
+        ":ImagePlayground_swift",
+        ":TranslationUIProvider_swift",
+        ":SpriteKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":VideoSubscriberAccount_swift",
+        ":AccessorySetupKit_swift",
+        ":PencilKit_swift",
+        ":FinanceKit_swift",
+        ":ManagedSettingsUI_swift",
+        ":HealthKit_swift",
+        ":BackgroundAssets_swift",
+        ":WebKit_swift",
+        ":GameController_swift",
+        ":SecureElementCredential_swift",
+        ":ActivityKit_swift",
+        ":AssetsLibrary_swift",
+        ":SwiftUICore_swift",
+        ":FileProvider_swift",
+        ":DeviceActivity_swift",
+        ":IdentityLookup_swift",
+        ":CoreImage_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":Cinematic_swift",
+        ":MusicKit_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":AutomatedDeviceEnrollment_swift",
+        ":CoreAudioKit_swift",
+        ":VisionKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":ModelIO_swift",
+        ":ManagedApp_swift",
+        ":SharedWithYou_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":RealityFoundation_swift",
+        ":QuickLook_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":DataDetection_swift",
+        ":NearbyInteraction_swift",
+        ":ContactsUI_swift",
+        ":CoreSpotlight_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":Vision_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":MediaAccessibility_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":JournalingSuggestions_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":StickerKit_swift",
+        ":WidgetKit_swift",
+        ":AVKit_swift",
+        ":SoundAnalysis_swift",
+        ":GroupActivities_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":SharedWithYouCore_swift",
+        ":BrowserEngineCore_swift",
+        ":Photos_swift",
+        ":GameplayKit_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":CoreMIDI_swift",
+        ":PassKit_swift",
+        ":MarketplaceKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":GLKit_swift",
+        ":Messages_swift",
+        ":CryptoTokenKit_swift",
+        ":VideoToolbox_swift",
+        ":Translation_swift",
+        ":ManagedAppDistribution_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":EventKitUI_swift",
+        ":SceneKit_swift",
+        ":StoreKitTest_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AdServices",
+    module_name = "AdServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ImageCaptureCore",
+    module_name = "ImageCaptureCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageCaptureCore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "PushToTalk",
+    module_name = "PushToTalk",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushToTalk.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "JavaScriptCore",
+    module_name = "JavaScriptCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdbool",
+        ":Foundation",
+        ":_Builtin_stddef",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "AVRouting",
+    module_name = "AVRouting",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVRouting.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+    ],
+)
+
+swift_c_module(
+    name = "AppTrackingTransparency",
+    module_name = "AppTrackingTransparency",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppTrackingTransparency.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "iAd",
+    module_name = "iAd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/iAd.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "OpenAL",
+    module_name = "OpenAL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenAL.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AdSupport",
+    module_name = "AdSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemExtensions",
+    module_name = "SystemExtensions",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemExtensions.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "FileProviderUI",
+    module_name = "FileProviderUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProviderUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":FileProvider",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "Accounts",
+    module_name = "Accounts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accounts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShadersGraph",
+    module_name = "MetalPerformanceShadersGraph",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":MetalPerformanceShaders",
+    ],
+)
+
+swift_c_module(
+    name = "PHASE",
+    module_name = "PHASE",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PHASE.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":AVFAudio",
+        ":simd",
+        ":AVFoundation",
+        ":ModelIO",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ClassKit",
+    module_name = "ClassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ExposureNotification",
+    module_name = "ExposureNotification",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExposureNotification.framework/Modules/module.modulemap",
+    deps = [
+        ":Dispatch",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MediaSetup",
+    module_name = "MediaSetup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaSetup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "Social",
+    module_name = "Social",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Social.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTelephony",
+    module_name = "CoreTelephony",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTelephony.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemConfiguration",
+    module_name = "SystemConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":Dispatch",
+        ":sys_types",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "NotificationCenter",
+    module_name = "NotificationCenter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NotificationCenter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "BusinessChat",
+    module_name = "BusinessChat",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BusinessChat.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "IntentsUI",
+    module_name = "IntentsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IntentsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Intents",
+        ":CoreGraphics",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "StickerFoundation",
+    module_name = "StickerFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StickerFoundation.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "ThreadNetwork",
+    module_name = "ThreadNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ThreadNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundTasks",
+    module_name = "BackgroundTasks",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundTasks.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenTime",
+    module_name = "ScreenTime",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ScreenTime.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "MetalFX",
+    module_name = "MetalFX",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalFX.framework/Modules/module.modulemap",
+    deps = [
+        ":Metal",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookupUI",
+    module_name = "IdentityLookupUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookupUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IdentityLookup",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "ExternalAccessory",
+    module_name = "ExternalAccessory",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExternalAccessory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AutomaticAssessmentConfiguration",
+    module_name = "AutomaticAssessmentConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AutomaticAssessmentConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMediaIO",
+    module_name = "CoreMediaIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMediaIO.framework/Modules/module.modulemap",
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "GSS",
+    module_name = "GSS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GSS.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_inttypes",
+        ":unistd",
+        ":_Builtin_stdarg",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppClip",
+    module_name = "AppClip",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppClip.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBookUI",
+    module_name = "AddressBookUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBookUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AddressBook",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_ManagedAppDistribution_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedAppDistribution_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Translation_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":Translation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_MarketplaceKit_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":MarketplaceKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GroupActivities_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":AVKit_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_QuickLook_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":QuickLook_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_DeviceActivity_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeviceActivity_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GameController_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":GameController_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AdAttributionKit_StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AdAttributionKit_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_RealityKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreHaptics",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":MetalKit_swift",
+        ":Observation_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":SwiftUICore_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreHaptics",
+    module_name = "CoreHaptics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreHaptics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreNFC_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreNFC_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKitTest_swift",
+    testonly = True,
+    deps = [
+        ":StoreKitTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKitTest",
+    module_name = "StoreKitTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/StoreKitTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":StoreKit",
+    ],
+)
+
+swift_library_group(
+    name = "EventKitUI_swift",
+    testonly = False,
+    deps = [
+        ":EventKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":EventKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKitUI",
+    module_name = "EventKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":EventKit",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedAppDistribution_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "MarketplaceKit_swift",
+    testonly = False,
+    deps = [
+        ":MarketplaceKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MarketplaceKit",
+    module_name = "MarketplaceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MarketplaceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+        ":CoreGraphics",
+        ":Contacts",
+        ":AddressBook",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+        ":XPC",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "AVKit_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":CoreMedia",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "StickerKit_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":MetalPerformanceShaders",
+        ":StickerKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreImage_swift",
+        ":Combine_swift",
+        ":CoreMotion_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Messages_swift",
+        ":Metal_swift",
+        ":MetalKit_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":PhotosUI_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StickerKit",
+    module_name = "StickerKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StickerKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OSLog",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Messages_swift",
+    testonly = False,
+    deps = [
+        ":Messages",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Messages",
+    module_name = "Messages",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Messages.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "JournalingSuggestions_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Photos_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MediaAccessibility_swift",
+    testonly = False,
+    deps = [
+        ":MediaAccessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaAccessibility",
+    module_name = "MediaAccessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaAccessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":AvailabilityMacros",
+        ":CoreText",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":IOSurface",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AddressBook",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBook",
+    module_name = "AddressBook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthenticationEmbeddedUI_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthenticationEmbeddedUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":LocalAuthentication_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthenticationEmbeddedUI",
+    module_name = "LocalAuthenticationEmbeddedUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":LocalAuthentication",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ContactsUI_swift",
+    testonly = False,
+    deps = [
+        ":ContactsUI",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactsUI",
+    module_name = "ContactsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYou_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYou",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreTransferable_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":SharedWithYouCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYou",
+    module_name = "SharedWithYou",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYou.framework/Modules/module.modulemap",
+    deps = [
+        ":SharedWithYouCore",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYouCore_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYouCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYouCore",
+    module_name = "SharedWithYouCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYouCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedApp_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "VisionKit_swift",
+    testonly = False,
+    deps = [
+        ":VisionKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VisionKit",
+    module_name = "VisionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VisionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudioKit_swift",
+    testonly = False,
+    deps = [
+        ":AudioToolbox",
+        ":AudioUnit",
+        ":CoreAudioKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioKit",
+    module_name = "CoreAudioKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AudioUnit",
+        ":Foundation",
+        ":UIKit",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AudioUnit",
+    module_name = "AudioUnit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioUnit.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "AutomatedDeviceEnrollment_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceDiscoveryExtension_swift",
+    testonly = False,
+    deps = [
+        ":DeviceDiscoveryExtension",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceDiscoveryExtension",
+    module_name = "DeviceDiscoveryExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceDiscoveryExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Cinematic_swift",
+    testonly = False,
+    deps = [
+        ":Cinematic",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Cinematic",
+    module_name = "Cinematic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Cinematic.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreMedia",
+        ":Metal",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "IdentityLookup_swift",
+    testonly = False,
+    deps = [
+        ":IdentityLookup",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookup",
+    module_name = "IdentityLookup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AssetsLibrary_swift",
+    testonly = False,
+    deps = [
+        ":AssetsLibrary",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AssetsLibrary",
+    module_name = "AssetsLibrary",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AssetsLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "SecureElementCredential_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "WebKit_swift",
+    testonly = False,
+    deps = [
+        ":WebKit",
+        ":_SwiftConcurrencyShims",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WebKit",
+    module_name = "WebKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+        ":CoreGraphics",
+        ":Network",
+    ],
+)
+
+swift_library_group(
+    name = "BackgroundAssets_swift",
+    testonly = False,
+    deps = [
+        ":BackgroundAssets",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundAssets",
+    module_name = "BackgroundAssets",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundAssets.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettingsUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AccessorySetupKit_swift",
+    testonly = False,
+    deps = [
+        ":AccessorySetupKit",
+        ":CoreBluetooth",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AccessorySetupKit",
+    module_name = "AccessorySetupKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AccessorySetupKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "VideoSubscriberAccount_swift",
+    testonly = False,
+    deps = [
+        ":VideoSubscriberAccount",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoSubscriberAccount",
+    module_name = "VideoSubscriberAccount",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoSubscriberAccount.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "TranslationUIProvider_swift",
+    testonly = False,
+    deps = [
+        ":TranslationUIProvider",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "TranslationUIProvider",
+    module_name = "TranslationUIProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/TranslationUIProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ImagePlayground_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+        ":ImagePlayground",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":PencilKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ImagePlayground",
+    module_name = "ImagePlayground",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImagePlayground.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PencilKit_swift",
+    testonly = False,
+    deps = [
+        ":PencilKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":MetalKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PencilKit",
+    module_name = "PencilKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PencilKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "AdAttributionKit_swift",
+    testonly = False,
+    deps = [
+        ":AdAttributionKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AdAttributionKit",
+    module_name = "AdAttributionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdAttributionKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "RoomPlan_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":MetalPerformanceShaders",
+        ":RoomPlan",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":AVFoundation_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":GLKit_swift",
+        ":Metal_swift",
+        ":MetalKit_swift",
+        ":ModelIO_swift",
+        ":OSLog_swift",
+        ":ObjectiveC_swift",
+        ":QuartzCore_swift",
+        ":RealityKit_swift",
+        ":SceneKit_swift",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "RoomPlan",
+    module_name = "RoomPlan",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/RoomPlan.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShaders",
+    module_name = "MetalPerformanceShaders",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShaders.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+        ":simd",
+        ":_Builtin_stdint",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Photos_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":Photos",
+    ],
+)
+
+swift_library_group(
+    name = "Photos_swift",
+    testonly = False,
+    deps = [
+        ":Photos",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Photos",
+    module_name = "Photos",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Photos.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ImageIO",
+        ":CoreLocation",
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "RealityKit_swift",
+    testonly = False,
+    deps = [
+        ":MultipeerConnectivity",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Metal_swift",
+        ":RealityFoundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MultipeerConnectivity",
+    module_name = "MultipeerConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MultipeerConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RealityFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "GroupActivities_swift",
+    testonly = False,
+    deps = [
+        ":GroupActivities",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CloudKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreTransferable_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GroupActivities",
+    module_name = "GroupActivities",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GroupActivities.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CarPlay_swift",
+    testonly = False,
+    deps = [
+        ":CarPlay",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CarPlay",
+    module_name = "CarPlay",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CarPlay.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+        ":MapKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LockedCameraCapture_swift",
+    testonly = False,
+    deps = [
+        ":LockedCameraCapture",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LockedCameraCapture",
+    module_name = "LockedCameraCapture",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LockedCameraCapture.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensorKit_swift",
+    testonly = False,
+    deps = [
+        ":SensorKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":Speech_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":SoundAnalysis_swift",
+        ":CoreML_swift",
+        ":ARKit_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+        ":QuickLook_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":SceneKit_swift",
+        ":ModelIO_swift",
+        ":GLKit_swift",
+        ":SpriteKit_swift",
+        ":Vision_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensorKit",
+    module_name = "SensorKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensorKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreLocation",
+        ":Speech",
+        ":SoundAnalysis",
+        ":CoreMedia",
+        ":ARKit",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "DockKit_swift",
+    testonly = False,
+    deps = [
+        ":DockKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DockKit",
+    module_name = "DockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensitiveContentAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":SensitiveContentAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensitiveContentAnalysis",
+    module_name = "SensitiveContentAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensitiveContentAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "MLCompute_swift",
+    testonly = False,
+    deps = [
+        ":MLCompute",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MLCompute",
+    module_name = "MLCompute",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MLCompute.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreNFC_swift",
+    testonly = False,
+    deps = [
+        ":CoreNFC",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreNFC",
+    module_name = "CoreNFC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreNFC.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "MessageUI_swift",
+    testonly = False,
+    deps = [
+        ":MessageUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MessageUI",
+    module_name = "MessageUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MessageUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LinkPresentation_swift",
+    testonly = False,
+    deps = [
+        ":LinkPresentation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LinkPresentation",
+    module_name = "LinkPresentation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LinkPresentation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Assignables_swift",
+    testonly = False,
+    deps = [
+        ":Assignables",
+        ":_SwiftConcurrencyShims",
+        ":AppleArchive_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":PDFKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":System_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Assignables",
+    module_name = "Assignables",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Assignables.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LightweightCodeRequirements_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ARKit_swift",
+    testonly = False,
+    deps = [
+        ":ARKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":CoreLocation_swift",
+        ":QuickLook_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":SceneKit_swift",
+        ":ModelIO_swift",
+        ":GLKit_swift",
+        ":SpriteKit_swift",
+        ":Vision_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ARKit",
+    module_name = "ARKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ARKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":UIKit",
+        ":AVFoundation",
+        ":CoreLocation",
+        ":CoreVideo",
+        ":Metal",
+        ":QuickLook",
+        ":ImageIO",
+        ":SceneKit",
+        ":SpriteKit",
+        ":Vision",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLook_swift",
+    testonly = False,
+    deps = [
+        ":QuickLook",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLook",
+    module_name = "QuickLook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+        ":CoreGraphics",
+        ":PDFKit",
+        ":QuickLookThumbnailing",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookThumbnailing_swift",
+    testonly = False,
+    deps = [
+        ":QuickLookThumbnailing",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookThumbnailing",
+    module_name = "QuickLookThumbnailing",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLookThumbnailing.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "PDFKit_swift",
+    testonly = False,
+    deps = [
+        ":PDFKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PDFKit",
+    module_name = "PDFKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PDFKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKitUI_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKitUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionKit_swift",
+        ":FinanceKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":WidgetKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKitUI",
+    module_name = "FinanceKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKitUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":ActivityKit_swift",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreSpotlight_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreSpotlight_swift",
+    testonly = False,
+    deps = [
+        ":CoreSpotlight",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreSpotlight",
+    module_name = "CoreSpotlight",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreSpotlight.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "ActivityKit_swift",
+    testonly = False,
+    deps = [
+        ":ActivityKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ActivityKit",
+    module_name = "ActivityKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ActivityKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ProximityReader_swift",
+    testonly = False,
+    deps = [
+        ":ProximityReader",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ProximityReader",
+    module_name = "ProximityReader",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ProximityReader.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SafariServices_swift",
+    testonly = False,
+    deps = [
+        ":SafariServices",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafariServices",
+    module_name = "SafariServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Speech_swift",
+    testonly = False,
+    deps = [
+        ":Speech",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Speech",
+    module_name = "Speech",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Speech.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateML_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":CreateMLComponents_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":NaturalLanguage_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":VideoToolbox_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "VideoToolbox_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":VideoToolbox",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoToolbox",
+    module_name = "VideoToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":CoreMedia",
+        ":CoreFoundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":RegexBuilder_swift",
+        ":SoundAnalysis_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Vision_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":MachO",
+        ":Vision",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Vision",
+    module_name = "Vision",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Vision.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreML",
+        ":CoreGraphics",
+        ":simd",
+        ":CoreVideo",
+        ":CoreMedia",
+        ":Metal",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":Foundation_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_math_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":MetalKit_swift",
+        ":ModelIO_swift",
+        ":SpriteKit_swift",
+        ":GLKit_swift",
+        ":SceneKit_swift",
+        ":GameplayKit_swift",
+        ":GameController_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":UIKit",
+        ":Metal",
+        ":MetalKit",
+        ":SpriteKit",
+        ":SceneKit",
+        ":GameplayKit",
+        ":GameController",
+        ":ModelIO",
+        ":ReplayKit",
+        ":Foundation",
+        ":CoreGraphics",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_c_module(
+    name = "ReplayKit",
+    module_name = "ReplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ReplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":MediaToolbox",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "MediaToolbox",
+    module_name = "MediaToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "AudioToolbox",
+    module_name = "AudioToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":_stdio",
+        ":Foundation",
+        ":CoreMIDI",
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":os_workgroup",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMIDI_swift",
+    testonly = False,
+    deps = [
+        ":CoreMIDI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GameController_swift",
+    testonly = False,
+    deps = [
+        ":GameController",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameController",
+    module_name = "GameController",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameController.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "GameplayKit_swift",
+    testonly = False,
+    deps = [
+        ":GameplayKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":SpriteKit_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+        ":SceneKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameplayKit",
+    module_name = "GameplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":SpriteKit",
+        ":Foundation",
+        ":simd",
+        ":os_availability",
+        ":TargetConditionals",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":ModelIO_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+        ":GLKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ModelIO",
+        ":QuartzCore",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":UIKit",
+        ":CoreGraphics",
+        ":simd",
+        ":Metal",
+        ":GLKit",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":Metal",
+        ":GLKit",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GLKit_swift",
+    testonly = False,
+    deps = [
+        ":GLKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":ModelIO_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GLKit",
+    module_name = "GLKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GLKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OpenGLES",
+        ":_math",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_string",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":os_availability",
+        ":ModelIO",
+        ":CoreGraphics",
+        ":UIKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "MetalKit_swift",
+    testonly = False,
+    deps = [
+        ":MetalKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":ModelIO_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalKit",
+    module_name = "MetalKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":ModelIO",
+        ":Metal",
+        ":simd",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "ModelIO_swift",
+    testonly = False,
+    deps = [
+        ":ModelIO",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ModelIO",
+    module_name = "ModelIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ModelIO.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":FileProvider_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":FileProvider",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Symbols",
+        ":QuartzCore",
+        ":CoreImage",
+        ":os_availability",
+        ":UserNotifications",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreImage_swift",
+    testonly = False,
+    deps = [
+        ":CoreImage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreImage",
+    module_name = "CoreImage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreImage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":TargetConditionals",
+        ":ImageIO",
+        ":IOSurface",
+        ":ObjectiveC",
+        ":Metal",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "FileProvider_swift",
+    testonly = False,
+    deps = [
+        ":FileProvider",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FileProvider",
+    module_name = "FileProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "QuartzCore_swift",
+    testonly = False,
+    deps = [
+        ":QuartzCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":OpenGLES",
+        ":ObjectiveC",
+        ":Metal",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+        ":Metal",
+        ":OpenGLES",
+        ":IOSurface",
+    ],
+)
+
+swift_c_module(
+    name = "OpenGLES",
+    module_name = "OpenGLES",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenGLES.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":IOSurface",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "Metal_swift",
+    testonly = False,
+    deps = [
+        ":Metal",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Metal",
+    module_name = "Metal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Metal.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_math",
+        ":os_availability",
+        ":TargetConditionals",
+        ":IOSurface",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "IOSurface",
+    module_name = "IOSurface",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IOSurface.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "DataDetection_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "ContactProvider_swift",
+    testonly = False,
+    deps = [
+        ":ContactProvider",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactProvider",
+    module_name = "ContactProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetricKit_swift",
+    testonly = False,
+    deps = [
+        ":MetricKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetricKit",
+    module_name = "MetricKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetricKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":CFNetwork",
+        ":Darwin",
+        ":XPC",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "CFNetwork",
+    module_name = "CFNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CFNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":XPC",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "XPC_swift",
+    testonly = False,
+    deps = [
+        ":XPC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XPC",
+    module_name = "XPC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/xpc.modulemap",
+    deps = [
+        ":os_object",
+        ":Dispatch",
+        ":Darwin",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_stdio",
+        ":_string",
+        ":unistd",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "CommonCrypto",
+    module_name = "CommonCrypto",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/CommonCrypto/module.modulemap",
+)
+
+swift_library_group(
+    name = "IOKit",
+    testonly = False,
+)
+
+swift_library_group(
+    name = "CommonCrypto_swift",
+    testonly = False,
+    deps = [
+        ":CommonCrypto",
+    ],
+)
+
+swift_library_group(
+    name = "ImageIO_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "AppTrackingTransparency_swift",
+    testonly = False,
+    deps = [
+        ":AppTrackingTransparency",
+    ],
+)
+
+swift_library_group(
+    name = "notify_swift",
+    testonly = False,
+    deps = [
+        ":notify",
+    ],
+)
+
+swift_library_group(
+    name = "AdSupport_swift",
+    testonly = False,
+    deps = [
+        ":AdSupport",
+    ],
+)
+
+swift_library_group(
+    name = "UserNotifications_swift",
+    testonly = False,
+    deps = [
+        ":UserNotifications",
+    ],
+)
+
+swift_library_group(
+    name = "Security_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "CoreVideo_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+    ],
+)
+
+swift_library_group(
+    name = "CoreServices_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "MobileCoreServices_swift",
+    testonly = False,
+    deps = [
+        ":MobileCoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "ReplayKit_swift",
+    testonly = False,
+    deps = [
+        ":ReplayKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTelephony_swift",
+    testonly = False,
+    deps = [
+        ":CoreTelephony",
+    ],
+)
+
+swift_library_group(
+    name = "MachO_swift",
+    testonly = False,
+    deps = [
+        ":MachO",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":AdServices",
+        ":ImageCaptureCore",
+        ":PushToTalk",
+        ":JavaScriptCore",
+        ":AVRouting",
+        ":AppTrackingTransparency",
+        ":iAd",
+        ":OpenAL",
+        ":PushKit",
+        ":AdSupport",
+        ":BrowserKit",
+        ":SystemExtensions",
+        ":FileProviderUI",
+        ":Accounts",
+        ":MetalPerformanceShadersGraph",
+        ":PHASE",
+        ":ClassKit",
+        ":ExposureNotification",
+        ":MediaSetup",
+        ":Social",
+        ":CoreTelephony",
+        ":SystemConfiguration",
+        ":NotificationCenter",
+        ":ColorSync",
+        ":BusinessChat",
+        ":IntentsUI",
+        ":MobileCoreServices",
+        ":StickerFoundation",
+        ":ThreadNetwork",
+        ":BackgroundTasks",
+        ":DeviceCheck",
+        ":ScreenTime",
+        ":MetalFX",
+        ":IdentityLookupUI",
+        ":ExternalAccessory",
+        ":AutomaticAssessmentConfiguration",
+        ":CoreMediaIO",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":GSS",
+        ":AppClip",
+        ":AddressBookUI",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_MapKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_ManagedAppDistribution_SwiftUI_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":CoreHaptics",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":EventKitUI_swift",
+        ":EventKitUI",
+        ":ManagedAppDistribution_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":MarketplaceKit_swift",
+        ":MarketplaceKit",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":AVKit_swift",
+        ":AVKit",
+        ":StickerKit_swift",
+        ":StickerKit",
+        ":_PhotosUI_SwiftUI_swift",
+        ":Messages_swift",
+        ":Messages",
+        ":JournalingSuggestions_swift",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":MediaAccessibility_swift",
+        ":MediaAccessibility",
+        ":EventKit_swift",
+        ":EventKit",
+        ":AddressBook",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":ContactsUI_swift",
+        ":ContactsUI",
+        ":TipKit_swift",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":SharedWithYou_swift",
+        ":SharedWithYou",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYouCore",
+        ":ManagedApp_swift",
+        ":VisionKit_swift",
+        ":VisionKit",
+        ":CoreAudioKit_swift",
+        ":CoreAudioKit",
+        ":AudioUnit",
+        ":AutomatedDeviceEnrollment_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":DeviceDiscoveryExtension",
+        ":MusicKit_swift",
+        ":Cinematic_swift",
+        ":Cinematic",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":IdentityLookup_swift",
+        ":IdentityLookup",
+        ":DeviceActivity_swift",
+        ":AssetsLibrary_swift",
+        ":AssetsLibrary",
+        ":SecureElementCredential_swift",
+        ":WebKit_swift",
+        ":WebKit",
+        ":BackgroundAssets_swift",
+        ":BackgroundAssets",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":ManagedSettingsUI_swift",
+        ":AccessorySetupKit_swift",
+        ":CoreBluetooth",
+        ":AccessorySetupKit",
+        ":VideoSubscriberAccount_swift",
+        ":VideoSubscriberAccount",
+        ":TranslationUIProvider_swift",
+        ":TranslationUIProvider",
+        ":ImagePlayground_swift",
+        ":ImagePlayground",
+        ":PencilKit_swift",
+        ":PencilKit",
+        ":AdAttributionKit_swift",
+        ":AdAttributionKit",
+        ":RoomPlan_swift",
+        ":RoomPlan",
+        ":MetalPerformanceShaders",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":Photos_swift",
+        ":Photos",
+        ":RealityKit_swift",
+        ":MultipeerConnectivity",
+        ":RealityFoundation_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":GroupActivities_swift",
+        ":GroupActivities",
+        ":CarPlay_swift",
+        ":CarPlay",
+        ":MapKit_swift",
+        ":MapKit",
+        ":LockedCameraCapture_swift",
+        ":LockedCameraCapture",
+        ":SensorKit_swift",
+        ":SensorKit",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":DockKit_swift",
+        ":DockKit",
+        ":SensitiveContentAnalysis_swift",
+        ":SensitiveContentAnalysis",
+        ":MLCompute_swift",
+        ":MLCompute",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":CoreNFC_swift",
+        ":CoreNFC",
+        ":MessageUI_swift",
+        ":MessageUI",
+        ":LinkPresentation_swift",
+        ":LinkPresentation",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":Assignables_swift",
+        ":Assignables",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":LightweightCodeRequirements_swift",
+        ":ARKit_swift",
+        ":ARKit",
+        ":QuickLook_swift",
+        ":QuickLook",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookThumbnailing",
+        ":PDFKit_swift",
+        ":PDFKit",
+        ":FinanceKitUI_swift",
+        ":FinanceKitUI",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":Intents_swift",
+        ":Intents",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreSpotlight_swift",
+        ":CoreSpotlight",
+        ":ActivityKit_swift",
+        ":ActivityKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":ProximityReader_swift",
+        ":ProximityReader",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":Spatial_swift",
+        ":Spatial",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":SafariServices_swift",
+        ":SafariServices",
+        ":Speech_swift",
+        ":Speech",
+        ":CreateML_swift",
+        ":VideoToolbox_swift",
+        ":VideoToolbox",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":CreateMLComponents_swift",
+        ":Vision_swift",
+        ":Vision",
+        ":TabularData_swift",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":RegexBuilder_swift",
+        ":CoreML_swift",
+        ":CoreML",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":GameKit_swift",
+        ":GameKit",
+        ":ReplayKit",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":MediaToolbox",
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreMIDI_swift",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":GameController_swift",
+        ":GameController",
+        ":GameplayKit_swift",
+        ":GameplayKit",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":GLKit_swift",
+        ":GLKit",
+        ":MetalKit_swift",
+        ":MetalKit",
+        ":ModelIO_swift",
+        ":ModelIO",
+        ":UIKit_swift",
+        ":UIKit",
+        ":UserNotifications",
+        ":CoreImage_swift",
+        ":CoreImage",
+        ":ImageIO",
+        ":FileProvider_swift",
+        ":FileProvider",
+        ":Symbols_swift",
+        ":Symbols",
+        ":QuartzCore_swift",
+        ":QuartzCore",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":Metal_swift",
+        ":Metal",
+        ":IOSurface",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":DataDetection_swift",
+        ":DataDetection",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":ContactProvider_swift",
+        ":ContactProvider",
+        ":OSLog_swift",
+        ":OSLog",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Distributed_swift",
+        ":MetricKit_swift",
+        ":MetricKit",
+        ":Foundation_swift",
+        ":Foundation",
+        ":CFNetwork",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":XPC_swift",
+        ":XPC",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":Combine_swift",
+        ":ObjectiveC_swift",
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+        ":CommonCrypto",
+        ":IOKit",
+        ":CommonCrypto_swift",
+        ":ImageIO_swift",
+        ":AppTrackingTransparency_swift",
+        ":notify_swift",
+        ":AdSupport_swift",
+        ":UserNotifications_swift",
+        ":Security_swift",
+        ":CoreVideo_swift",
+        ":CoreServices_swift",
+        ":MobileCoreServices_swift",
+        ":ReplayKit_swift",
+        ":CoreTelephony_swift",
+        ":MachO_swift",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+        ":StoreKitTest_swift",
+        ":StoreKitTest",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/iPhoneSimulator/arm64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/iPhoneSimulator/arm64/BUILD.bazel
@@ -1,0 +1,8973 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":AddressBookUI",
+        ":AppClip",
+        ":GSS",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreLocationUI",
+        ":MetalPerformanceShaders",
+        ":AutomaticAssessmentConfiguration",
+        ":ExternalAccessory",
+        ":IdentityLookupUI",
+        ":MediaToolbox",
+        ":ScreenTime",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":BackgroundTasks",
+        ":CoreBluetooth",
+        ":Security",
+        ":ReplayKit",
+        ":IOSurface",
+        ":MobileCoreServices",
+        ":IntentsUI",
+        ":BusinessChat",
+        ":ColorSync",
+        ":CoreServices",
+        ":MultipeerConnectivity",
+        ":NotificationCenter",
+        ":SystemConfiguration",
+        ":CoreTelephony",
+        ":AVFAudio",
+        ":AudioUnit",
+        ":Social",
+        ":Matter",
+        ":ExposureNotification",
+        ":ClassKit",
+        ":PHASE",
+        ":OpenGLES",
+        ":MetalPerformanceShadersGraph",
+        ":Accounts",
+        ":FileProviderUI",
+        ":AudioToolbox",
+        ":SystemExtensions",
+        ":BrowserKit",
+        ":AdSupport",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":OpenAL",
+        ":iAd",
+        ":AppTrackingTransparency",
+        ":CoreHaptics",
+        ":AVRouting",
+        ":AddressBook",
+        ":CFNetwork",
+        ":JavaScriptCore",
+        ":PushToTalk",
+        ":ImageCaptureCore",
+        ":AdServices",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":MetricKit_swift",
+        ":Network_swift",
+        ":ContactProvider_swift",
+        ":GameKit_swift",
+        ":Speech_swift",
+        ":SafariServices_swift",
+        ":ProximityReader_swift",
+        ":Metal_swift",
+        ":QuartzCore_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":FinanceKitUI_swift",
+        ":ARKit_swift",
+        ":Symbols_swift",
+        ":MediaPlayer_swift",
+        ":LinkPresentation_swift",
+        ":UIKit_swift",
+        ":MessageUI_swift",
+        ":CoreNFC_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":NaturalLanguage_swift",
+        ":SensitiveContentAnalysis_swift",
+        ":MetalKit_swift",
+        ":OSLog_swift",
+        ":PDFKit_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":SensorKit_swift",
+        ":Contacts_swift",
+        ":LockedCameraCapture_swift",
+        ":CarPlay_swift",
+        ":ExtensionFoundation_swift",
+        ":RealityKit_swift",
+        ":PhotosUI_swift",
+        ":RoomPlan_swift",
+        ":AdAttributionKit_swift",
+        ":ImagePlayground_swift",
+        ":TranslationUIProvider_swift",
+        ":SpriteKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":VideoSubscriberAccount_swift",
+        ":AccessorySetupKit_swift",
+        ":PencilKit_swift",
+        ":FinanceKit_swift",
+        ":ManagedSettingsUI_swift",
+        ":HealthKit_swift",
+        ":BackgroundAssets_swift",
+        ":WebKit_swift",
+        ":GameController_swift",
+        ":SecureElementCredential_swift",
+        ":ActivityKit_swift",
+        ":AssetsLibrary_swift",
+        ":SwiftUICore_swift",
+        ":FileProvider_swift",
+        ":DeviceActivity_swift",
+        ":IdentityLookup_swift",
+        ":CoreImage_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":MusicKit_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":AutomatedDeviceEnrollment_swift",
+        ":CoreAudioKit_swift",
+        ":VisionKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":ModelIO_swift",
+        ":ManagedApp_swift",
+        ":SharedWithYou_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":RealityFoundation_swift",
+        ":QuickLook_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":DataDetection_swift",
+        ":NearbyInteraction_swift",
+        ":ContactsUI_swift",
+        ":CoreSpotlight_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":Vision_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":MediaAccessibility_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":WidgetKit_swift",
+        ":AVKit_swift",
+        ":SoundAnalysis_swift",
+        ":GroupActivities_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":SharedWithYouCore_swift",
+        ":BrowserEngineCore_swift",
+        ":Photos_swift",
+        ":GameplayKit_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":CoreMIDI_swift",
+        ":PassKit_swift",
+        ":MarketplaceKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":GLKit_swift",
+        ":Messages_swift",
+        ":CryptoTokenKit_swift",
+        ":VideoToolbox_swift",
+        ":Translation_swift",
+        ":ManagedAppDistribution_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":EventKitUI_swift",
+        ":SceneKit_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AdServices",
+    module_name = "AdServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ImageCaptureCore",
+    module_name = "ImageCaptureCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageCaptureCore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "PushToTalk",
+    module_name = "PushToTalk",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushToTalk.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "JavaScriptCore",
+    module_name = "JavaScriptCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdbool",
+        ":Foundation",
+        ":_Builtin_stddef",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "AVRouting",
+    module_name = "AVRouting",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVRouting.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+    ],
+)
+
+swift_c_module(
+    name = "CoreHaptics",
+    module_name = "CoreHaptics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreHaptics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppTrackingTransparency",
+    module_name = "AppTrackingTransparency",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppTrackingTransparency.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "iAd",
+    module_name = "iAd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/iAd.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "OpenAL",
+    module_name = "OpenAL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenAL.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AdSupport",
+    module_name = "AdSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemExtensions",
+    module_name = "SystemExtensions",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemExtensions.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "FileProviderUI",
+    module_name = "FileProviderUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProviderUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":FileProvider",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "Accounts",
+    module_name = "Accounts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accounts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShadersGraph",
+    module_name = "MetalPerformanceShadersGraph",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":MetalPerformanceShaders",
+    ],
+)
+
+swift_c_module(
+    name = "PHASE",
+    module_name = "PHASE",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PHASE.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":AVFAudio",
+        ":simd",
+        ":AVFoundation",
+        ":ModelIO",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ClassKit",
+    module_name = "ClassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ExposureNotification",
+    module_name = "ExposureNotification",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExposureNotification.framework/Modules/module.modulemap",
+    deps = [
+        ":Dispatch",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Social",
+    module_name = "Social",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Social.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTelephony",
+    module_name = "CoreTelephony",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTelephony.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemConfiguration",
+    module_name = "SystemConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":Dispatch",
+        ":sys_types",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "NotificationCenter",
+    module_name = "NotificationCenter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NotificationCenter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "BusinessChat",
+    module_name = "BusinessChat",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BusinessChat.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "IntentsUI",
+    module_name = "IntentsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IntentsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Intents",
+        ":CoreGraphics",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundTasks",
+    module_name = "BackgroundTasks",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundTasks.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenTime",
+    module_name = "ScreenTime",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ScreenTime.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookupUI",
+    module_name = "IdentityLookupUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookupUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IdentityLookup",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "ExternalAccessory",
+    module_name = "ExternalAccessory",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExternalAccessory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AutomaticAssessmentConfiguration",
+    module_name = "AutomaticAssessmentConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AutomaticAssessmentConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShaders",
+    module_name = "MetalPerformanceShaders",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShaders.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+        ":simd",
+        ":_Builtin_stdint",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "GSS",
+    module_name = "GSS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GSS.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_inttypes",
+        ":unistd",
+        ":_Builtin_stdarg",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppClip",
+    module_name = "AppClip",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppClip.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBookUI",
+    module_name = "AddressBookUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBookUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AddressBook",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_Translation_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":Translation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_MarketplaceKit_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":MarketplaceKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GroupActivities_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":AVKit_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_QuickLook_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":QuickLook_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_DeviceActivity_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeviceActivity_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GameController_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":GameController_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AdAttributionKit_StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AdAttributionKit_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_RealityKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":SwiftUICore_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreNFC_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreNFC_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "EventKitUI_swift",
+    testonly = False,
+    deps = [
+        ":EventKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":EventKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKitUI",
+    module_name = "EventKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":EventKit",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedAppDistribution_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "VideoToolbox_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":VideoToolbox",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoToolbox",
+    module_name = "VideoToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":CoreMedia",
+        ":CoreFoundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "Messages_swift",
+    testonly = False,
+    deps = [
+        ":Messages",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Messages",
+    module_name = "Messages",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Messages.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "MarketplaceKit_swift",
+    testonly = False,
+    deps = [
+        ":MarketplaceKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MarketplaceKit",
+    module_name = "MarketplaceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MarketplaceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+        ":CoreGraphics",
+        ":Contacts",
+        ":AddressBook",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+        ":XPC",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "AVKit_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":CoreMedia",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MediaAccessibility_swift",
+    testonly = False,
+    deps = [
+        ":MediaAccessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaAccessibility",
+    module_name = "MediaAccessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaAccessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":AvailabilityMacros",
+        ":CoreText",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":IOSurface",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AddressBook",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBook",
+    module_name = "AddressBook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthenticationEmbeddedUI_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthenticationEmbeddedUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":LocalAuthentication_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthenticationEmbeddedUI",
+    module_name = "LocalAuthenticationEmbeddedUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":LocalAuthentication",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ContactsUI_swift",
+    testonly = False,
+    deps = [
+        ":ContactsUI",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactsUI",
+    module_name = "ContactsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":RegexBuilder_swift",
+        ":SoundAnalysis_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYou_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYou",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreTransferable_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":SharedWithYouCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYou",
+    module_name = "SharedWithYou",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYou.framework/Modules/module.modulemap",
+    deps = [
+        ":SharedWithYouCore",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYouCore_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYouCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYouCore",
+    module_name = "SharedWithYouCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYouCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedApp_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "VisionKit_swift",
+    testonly = False,
+    deps = [
+        ":VisionKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VisionKit",
+    module_name = "VisionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VisionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudioKit_swift",
+    testonly = False,
+    deps = [
+        ":AudioToolbox",
+        ":AudioUnit",
+        ":CoreAudioKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioKit",
+    module_name = "CoreAudioKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AudioUnit",
+        ":Foundation",
+        ":UIKit",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AudioUnit",
+    module_name = "AudioUnit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioUnit.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "AutomatedDeviceEnrollment_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceDiscoveryExtension_swift",
+    testonly = False,
+    deps = [
+        ":DeviceDiscoveryExtension",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceDiscoveryExtension",
+    module_name = "DeviceDiscoveryExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceDiscoveryExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "IdentityLookup_swift",
+    testonly = False,
+    deps = [
+        ":IdentityLookup",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookup",
+    module_name = "IdentityLookup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AssetsLibrary_swift",
+    testonly = False,
+    deps = [
+        ":AssetsLibrary",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AssetsLibrary",
+    module_name = "AssetsLibrary",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AssetsLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "SecureElementCredential_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "WebKit_swift",
+    testonly = False,
+    deps = [
+        ":WebKit",
+        ":_SwiftConcurrencyShims",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WebKit",
+    module_name = "WebKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+        ":CoreGraphics",
+        ":Network",
+    ],
+)
+
+swift_library_group(
+    name = "BackgroundAssets_swift",
+    testonly = False,
+    deps = [
+        ":BackgroundAssets",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundAssets",
+    module_name = "BackgroundAssets",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundAssets.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettingsUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AccessorySetupKit_swift",
+    testonly = False,
+    deps = [
+        ":AccessorySetupKit",
+        ":CoreBluetooth",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AccessorySetupKit",
+    module_name = "AccessorySetupKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AccessorySetupKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "VideoSubscriberAccount_swift",
+    testonly = False,
+    deps = [
+        ":VideoSubscriberAccount",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoSubscriberAccount",
+    module_name = "VideoSubscriberAccount",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoSubscriberAccount.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "TranslationUIProvider_swift",
+    testonly = False,
+    deps = [
+        ":TranslationUIProvider",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "TranslationUIProvider",
+    module_name = "TranslationUIProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/TranslationUIProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ImagePlayground_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+        ":ImagePlayground",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":PencilKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ImagePlayground",
+    module_name = "ImagePlayground",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImagePlayground.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PencilKit_swift",
+    testonly = False,
+    deps = [
+        ":PencilKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":MetalKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PencilKit",
+    module_name = "PencilKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PencilKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "AdAttributionKit_swift",
+    testonly = False,
+    deps = [
+        ":AdAttributionKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AdAttributionKit",
+    module_name = "AdAttributionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdAttributionKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "RoomPlan_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":RoomPlan",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":ModelIO_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "RoomPlan",
+    module_name = "RoomPlan",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/RoomPlan.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Photos_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":Photos",
+    ],
+)
+
+swift_library_group(
+    name = "Photos_swift",
+    testonly = False,
+    deps = [
+        ":Photos",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Photos",
+    module_name = "Photos",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Photos.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ImageIO",
+        ":CoreLocation",
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "RealityKit_swift",
+    testonly = False,
+    deps = [
+        ":MultipeerConnectivity",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Metal_swift",
+        ":RealityFoundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MultipeerConnectivity",
+    module_name = "MultipeerConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MultipeerConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RealityFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":AVFoundation_swift",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "GroupActivities_swift",
+    testonly = False,
+    deps = [
+        ":GroupActivities",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CloudKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreTransferable_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GroupActivities",
+    module_name = "GroupActivities",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GroupActivities.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CarPlay_swift",
+    testonly = False,
+    deps = [
+        ":CarPlay",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CarPlay",
+    module_name = "CarPlay",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CarPlay.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+        ":MapKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LockedCameraCapture_swift",
+    testonly = False,
+    deps = [
+        ":LockedCameraCapture",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LockedCameraCapture",
+    module_name = "LockedCameraCapture",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LockedCameraCapture.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensorKit_swift",
+    testonly = False,
+    deps = [
+        ":SensorKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":Speech_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":SoundAnalysis_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensorKit",
+    module_name = "SensorKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensorKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreLocation",
+        ":Speech",
+        ":SoundAnalysis",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetalKit_swift",
+    testonly = False,
+    deps = [
+        ":MetalKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":ModelIO_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalKit",
+    module_name = "MetalKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":ModelIO",
+        ":Metal",
+        ":simd",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "SensitiveContentAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":SensitiveContentAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensitiveContentAnalysis",
+    module_name = "SensitiveContentAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensitiveContentAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreNFC_swift",
+    testonly = False,
+    deps = [
+        ":CoreNFC",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreNFC",
+    module_name = "CoreNFC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreNFC.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "MessageUI_swift",
+    testonly = False,
+    deps = [
+        ":MessageUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MessageUI",
+    module_name = "MessageUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MessageUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LinkPresentation_swift",
+    testonly = False,
+    deps = [
+        ":LinkPresentation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LinkPresentation",
+    module_name = "LinkPresentation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LinkPresentation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ARKit_swift",
+    testonly = False,
+    deps = [
+        ":ARKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":CoreLocation_swift",
+        ":QuickLook_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":SceneKit_swift",
+        ":ModelIO_swift",
+        ":GLKit_swift",
+        ":SpriteKit_swift",
+        ":Vision_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ARKit",
+    module_name = "ARKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ARKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":UIKit",
+        ":AVFoundation",
+        ":CoreLocation",
+        ":CoreVideo",
+        ":Metal",
+        ":QuickLook",
+        ":ImageIO",
+        ":SceneKit",
+        ":SpriteKit",
+        ":Vision",
+    ],
+)
+
+swift_library_group(
+    name = "Vision_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":MachO",
+        ":Vision",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Vision",
+    module_name = "Vision",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Vision.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreML",
+        ":CoreGraphics",
+        ":simd",
+        ":CoreVideo",
+        ":CoreMedia",
+        ":Metal",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":Foundation_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLook_swift",
+    testonly = False,
+    deps = [
+        ":QuickLook",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLook",
+    module_name = "QuickLook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+        ":CoreGraphics",
+        ":PDFKit",
+        ":QuickLookThumbnailing",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookThumbnailing_swift",
+    testonly = False,
+    deps = [
+        ":QuickLookThumbnailing",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookThumbnailing",
+    module_name = "QuickLookThumbnailing",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLookThumbnailing.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "PDFKit_swift",
+    testonly = False,
+    deps = [
+        ":PDFKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PDFKit",
+    module_name = "PDFKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PDFKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKitUI_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKitUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionKit_swift",
+        ":FinanceKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":WidgetKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKitUI",
+    module_name = "FinanceKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKitUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":ActivityKit_swift",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreSpotlight_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreSpotlight_swift",
+    testonly = False,
+    deps = [
+        ":CoreSpotlight",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreSpotlight",
+    module_name = "CoreSpotlight",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreSpotlight.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "ActivityKit_swift",
+    testonly = False,
+    deps = [
+        ":ActivityKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ActivityKit",
+    module_name = "ActivityKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ActivityKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ProximityReader_swift",
+    testonly = False,
+    deps = [
+        ":ProximityReader",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ProximityReader",
+    module_name = "ProximityReader",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ProximityReader.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SafariServices_swift",
+    testonly = False,
+    deps = [
+        ":SafariServices",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafariServices",
+    module_name = "SafariServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Speech_swift",
+    testonly = False,
+    deps = [
+        ":Speech",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Speech",
+    module_name = "Speech",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Speech.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_math_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":SpriteKit_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":SceneKit_swift",
+        ":GameplayKit_swift",
+        ":GameController_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":UIKit",
+        ":SpriteKit",
+        ":SceneKit",
+        ":GameplayKit",
+        ":GameController",
+        ":ModelIO",
+        ":ReplayKit",
+        ":Foundation",
+        ":CoreGraphics",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_c_module(
+    name = "ReplayKit",
+    module_name = "ReplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ReplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":MediaToolbox",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "MediaToolbox",
+    module_name = "MediaToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "AudioToolbox",
+    module_name = "AudioToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":_stdio",
+        ":Foundation",
+        ":CoreMIDI",
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":os_workgroup",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMIDI_swift",
+    testonly = False,
+    deps = [
+        ":CoreMIDI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GameController_swift",
+    testonly = False,
+    deps = [
+        ":GameController",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameController",
+    module_name = "GameController",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameController.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "GameplayKit_swift",
+    testonly = False,
+    deps = [
+        ":GameplayKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":SpriteKit_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+        ":SceneKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameplayKit",
+    module_name = "GameplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":SpriteKit",
+        ":Foundation",
+        ":simd",
+        ":os_availability",
+        ":TargetConditionals",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":ModelIO_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+        ":GLKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ModelIO",
+        ":QuartzCore",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":UIKit",
+        ":CoreGraphics",
+        ":simd",
+        ":Metal",
+        ":GLKit",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":Metal",
+        ":GLKit",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GLKit_swift",
+    testonly = False,
+    deps = [
+        ":GLKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":ModelIO_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GLKit",
+    module_name = "GLKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GLKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OpenGLES",
+        ":_math",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_string",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":os_availability",
+        ":ModelIO",
+        ":CoreGraphics",
+        ":UIKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "ModelIO_swift",
+    testonly = False,
+    deps = [
+        ":ModelIO",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ModelIO",
+    module_name = "ModelIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ModelIO.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":FileProvider_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":FileProvider",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Symbols",
+        ":QuartzCore",
+        ":CoreImage",
+        ":os_availability",
+        ":UserNotifications",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreImage_swift",
+    testonly = False,
+    deps = [
+        ":CoreImage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreImage",
+    module_name = "CoreImage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreImage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":TargetConditionals",
+        ":ImageIO",
+        ":IOSurface",
+        ":ObjectiveC",
+        ":Metal",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "FileProvider_swift",
+    testonly = False,
+    deps = [
+        ":FileProvider",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FileProvider",
+    module_name = "FileProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "QuartzCore_swift",
+    testonly = False,
+    deps = [
+        ":QuartzCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":OpenGLES",
+        ":ObjectiveC",
+        ":Metal",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+        ":Metal",
+        ":OpenGLES",
+        ":IOSurface",
+    ],
+)
+
+swift_c_module(
+    name = "OpenGLES",
+    module_name = "OpenGLES",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenGLES.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "Metal_swift",
+    testonly = False,
+    deps = [
+        ":Metal",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Metal",
+    module_name = "Metal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Metal.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_math",
+        ":os_availability",
+        ":TargetConditionals",
+        ":IOSurface",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "IOSurface",
+    module_name = "IOSurface",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IOSurface.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "DataDetection_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "ContactProvider_swift",
+    testonly = False,
+    deps = [
+        ":ContactProvider",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactProvider",
+    module_name = "ContactProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetricKit_swift",
+    testonly = False,
+    deps = [
+        ":MetricKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetricKit",
+    module_name = "MetricKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetricKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":CFNetwork",
+        ":Darwin",
+        ":XPC",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "CFNetwork",
+    module_name = "CFNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CFNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":XPC",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "XPC_swift",
+    testonly = False,
+    deps = [
+        ":XPC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XPC",
+    module_name = "XPC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/xpc.modulemap",
+    deps = [
+        ":os_object",
+        ":Dispatch",
+        ":Darwin",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_stdio",
+        ":_string",
+        ":unistd",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "CommonCrypto",
+    module_name = "CommonCrypto",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/CommonCrypto/module.modulemap",
+)
+
+swift_library_group(
+    name = "IOKit",
+    testonly = False,
+)
+
+swift_library_group(
+    name = "CommonCrypto_swift",
+    testonly = False,
+    deps = [
+        ":CommonCrypto",
+    ],
+)
+
+swift_library_group(
+    name = "ImageIO_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "AppTrackingTransparency_swift",
+    testonly = False,
+    deps = [
+        ":AppTrackingTransparency",
+    ],
+)
+
+swift_library_group(
+    name = "notify_swift",
+    testonly = False,
+    deps = [
+        ":notify",
+    ],
+)
+
+swift_library_group(
+    name = "AdSupport_swift",
+    testonly = False,
+    deps = [
+        ":AdSupport",
+    ],
+)
+
+swift_library_group(
+    name = "UserNotifications_swift",
+    testonly = False,
+    deps = [
+        ":UserNotifications",
+    ],
+)
+
+swift_library_group(
+    name = "Security_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "CoreVideo_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+    ],
+)
+
+swift_library_group(
+    name = "CoreServices_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "MobileCoreServices_swift",
+    testonly = False,
+    deps = [
+        ":MobileCoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "ReplayKit_swift",
+    testonly = False,
+    deps = [
+        ":ReplayKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTelephony_swift",
+    testonly = False,
+    deps = [
+        ":CoreTelephony",
+    ],
+)
+
+swift_library_group(
+    name = "MachO_swift",
+    testonly = False,
+    deps = [
+        ":MachO",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":AdServices",
+        ":ImageCaptureCore",
+        ":PushToTalk",
+        ":JavaScriptCore",
+        ":AVRouting",
+        ":CoreHaptics",
+        ":AppTrackingTransparency",
+        ":iAd",
+        ":OpenAL",
+        ":PushKit",
+        ":AdSupport",
+        ":BrowserKit",
+        ":SystemExtensions",
+        ":FileProviderUI",
+        ":Accounts",
+        ":MetalPerformanceShadersGraph",
+        ":PHASE",
+        ":ClassKit",
+        ":ExposureNotification",
+        ":Social",
+        ":CoreTelephony",
+        ":SystemConfiguration",
+        ":NotificationCenter",
+        ":ColorSync",
+        ":BusinessChat",
+        ":IntentsUI",
+        ":MobileCoreServices",
+        ":BackgroundTasks",
+        ":DeviceCheck",
+        ":ScreenTime",
+        ":IdentityLookupUI",
+        ":ExternalAccessory",
+        ":AutomaticAssessmentConfiguration",
+        ":MetalPerformanceShaders",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":GSS",
+        ":AppClip",
+        ":AddressBookUI",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_MapKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":EventKitUI_swift",
+        ":EventKitUI",
+        ":ManagedAppDistribution_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":VideoToolbox_swift",
+        ":VideoToolbox",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":Messages_swift",
+        ":Messages",
+        ":MarketplaceKit_swift",
+        ":MarketplaceKit",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":AVKit_swift",
+        ":AVKit",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":MediaAccessibility_swift",
+        ":MediaAccessibility",
+        ":EventKit_swift",
+        ":EventKit",
+        ":AddressBook",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":ContactsUI_swift",
+        ":ContactsUI",
+        ":TipKit_swift",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":CreateMLComponents_swift",
+        ":TabularData_swift",
+        ":RegexBuilder_swift",
+        ":SharedWithYou_swift",
+        ":SharedWithYou",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYouCore",
+        ":ManagedApp_swift",
+        ":VisionKit_swift",
+        ":VisionKit",
+        ":CoreAudioKit_swift",
+        ":CoreAudioKit",
+        ":AudioUnit",
+        ":AutomatedDeviceEnrollment_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":DeviceDiscoveryExtension",
+        ":MusicKit_swift",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":IdentityLookup_swift",
+        ":IdentityLookup",
+        ":DeviceActivity_swift",
+        ":AssetsLibrary_swift",
+        ":AssetsLibrary",
+        ":SecureElementCredential_swift",
+        ":WebKit_swift",
+        ":WebKit",
+        ":BackgroundAssets_swift",
+        ":BackgroundAssets",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":ManagedSettingsUI_swift",
+        ":AccessorySetupKit_swift",
+        ":CoreBluetooth",
+        ":AccessorySetupKit",
+        ":VideoSubscriberAccount_swift",
+        ":VideoSubscriberAccount",
+        ":TranslationUIProvider_swift",
+        ":TranslationUIProvider",
+        ":ImagePlayground_swift",
+        ":ImagePlayground",
+        ":PencilKit_swift",
+        ":PencilKit",
+        ":AdAttributionKit_swift",
+        ":AdAttributionKit",
+        ":RoomPlan_swift",
+        ":RoomPlan",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":Photos_swift",
+        ":Photos",
+        ":RealityKit_swift",
+        ":MultipeerConnectivity",
+        ":RealityFoundation_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":GroupActivities_swift",
+        ":GroupActivities",
+        ":CarPlay_swift",
+        ":CarPlay",
+        ":MapKit_swift",
+        ":MapKit",
+        ":LockedCameraCapture_swift",
+        ":LockedCameraCapture",
+        ":SensorKit_swift",
+        ":SensorKit",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":MetalKit_swift",
+        ":MetalKit",
+        ":SensitiveContentAnalysis_swift",
+        ":SensitiveContentAnalysis",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":CoreNFC_swift",
+        ":CoreNFC",
+        ":MessageUI_swift",
+        ":MessageUI",
+        ":LinkPresentation_swift",
+        ":LinkPresentation",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":ARKit_swift",
+        ":ARKit",
+        ":Vision_swift",
+        ":Vision",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":QuickLook_swift",
+        ":QuickLook",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookThumbnailing",
+        ":PDFKit_swift",
+        ":PDFKit",
+        ":FinanceKitUI_swift",
+        ":FinanceKitUI",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":Intents_swift",
+        ":Intents",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreSpotlight_swift",
+        ":CoreSpotlight",
+        ":ActivityKit_swift",
+        ":ActivityKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":CoreML_swift",
+        ":CoreML",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":ProximityReader_swift",
+        ":ProximityReader",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":Spatial_swift",
+        ":Spatial",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":SafariServices_swift",
+        ":SafariServices",
+        ":Speech_swift",
+        ":Speech",
+        ":GameKit_swift",
+        ":GameKit",
+        ":ReplayKit",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":MediaToolbox",
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreMIDI_swift",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":GameController_swift",
+        ":GameController",
+        ":GameplayKit_swift",
+        ":GameplayKit",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":GLKit_swift",
+        ":GLKit",
+        ":ModelIO_swift",
+        ":ModelIO",
+        ":UIKit_swift",
+        ":UIKit",
+        ":UserNotifications",
+        ":CoreImage_swift",
+        ":CoreImage",
+        ":ImageIO",
+        ":FileProvider_swift",
+        ":FileProvider",
+        ":Symbols_swift",
+        ":Symbols",
+        ":QuartzCore_swift",
+        ":QuartzCore",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":Metal_swift",
+        ":Metal",
+        ":IOSurface",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":DataDetection_swift",
+        ":DataDetection",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":ContactProvider_swift",
+        ":ContactProvider",
+        ":OSLog_swift",
+        ":OSLog",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Distributed_swift",
+        ":MetricKit_swift",
+        ":MetricKit",
+        ":Foundation_swift",
+        ":Foundation",
+        ":CFNetwork",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":XPC_swift",
+        ":XPC",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":Combine_swift",
+        ":ObjectiveC_swift",
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+        ":CommonCrypto",
+        ":IOKit",
+        ":CommonCrypto_swift",
+        ":ImageIO_swift",
+        ":AppTrackingTransparency_swift",
+        ":notify_swift",
+        ":AdSupport_swift",
+        ":UserNotifications_swift",
+        ":Security_swift",
+        ":CoreVideo_swift",
+        ":CoreServices_swift",
+        ":MobileCoreServices_swift",
+        ":ReplayKit_swift",
+        ":CoreTelephony_swift",
+        ":MachO_swift",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+    ],
+)

--- a/system_sdks/16.3.0.16E140/iPhoneSimulator/x86_64/BUILD.bazel
+++ b/system_sdks/16.3.0.16E140/iPhoneSimulator/x86_64/BUILD.bazel
@@ -1,0 +1,8979 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+load("@build_bazel_rules_swift//system_sdks:swift_c_module.bzl", "swift_c_module")
+
+package(default_visibility = ["//visibility:public"])
+
+swift_library_group(
+    name = "imports_swift",
+    testonly = True,
+    deps = [
+        ":_Darwin_xlocale",
+        ":_SwiftConcurrencyShims",
+        ":AddressBookUI",
+        ":AppClip",
+        ":GSS",
+        ":WatchConnectivity",
+        ":UserNotificationsUI",
+        ":CoreLocationUI",
+        ":MetalPerformanceShaders",
+        ":AutomaticAssessmentConfiguration",
+        ":ExternalAccessory",
+        ":IdentityLookupUI",
+        ":MediaToolbox",
+        ":ScreenTime",
+        ":CoreVideo",
+        ":DeviceCheck",
+        ":ImageIO",
+        ":BackgroundTasks",
+        ":CoreBluetooth",
+        ":Security",
+        ":ReplayKit",
+        ":IOSurface",
+        ":MobileCoreServices",
+        ":IntentsUI",
+        ":BusinessChat",
+        ":ColorSync",
+        ":CoreServices",
+        ":MultipeerConnectivity",
+        ":NotificationCenter",
+        ":SystemConfiguration",
+        ":CoreTelephony",
+        ":AVFAudio",
+        ":AudioUnit",
+        ":Social",
+        ":Matter",
+        ":ExposureNotification",
+        ":ClassKit",
+        ":PHASE",
+        ":OpenGLES",
+        ":MetalPerformanceShadersGraph",
+        ":Accounts",
+        ":FileProviderUI",
+        ":AudioToolbox",
+        ":SystemExtensions",
+        ":BrowserKit",
+        ":AdSupport",
+        ":PushKit",
+        ":CoreAudioTypes",
+        ":OpenAL",
+        ":iAd",
+        ":AppTrackingTransparency",
+        ":CoreHaptics",
+        ":AVRouting",
+        ":AddressBook",
+        ":CFNetwork",
+        ":JavaScriptCore",
+        ":PushToTalk",
+        ":ImageCaptureCore",
+        ":AdServices",
+        ":SafetyKit",
+        ":UserNotifications",
+        ":Swift_swift",
+        ":SwiftOnoneSupport_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":MetricKit_swift",
+        ":Network_swift",
+        ":ContactProvider_swift",
+        ":GameKit_swift",
+        ":Speech_swift",
+        ":SafariServices_swift",
+        ":ProximityReader_swift",
+        ":Metal_swift",
+        ":QuartzCore_swift",
+        ":CoreGraphics_swift",
+        ":StoreKit_swift",
+        ":CoreML_swift",
+        ":FinanceKitUI_swift",
+        ":ARKit_swift",
+        ":Symbols_swift",
+        ":MediaPlayer_swift",
+        ":LinkPresentation_swift",
+        ":UIKit_swift",
+        ":MessageUI_swift",
+        ":CoreNFC_swift",
+        ":HomeKit_swift",
+        ":CryptoKit_swift",
+        ":NaturalLanguage_swift",
+        ":SensitiveContentAnalysis_swift",
+        ":MetalKit_swift",
+        ":OSLog_swift",
+        ":PDFKit_swift",
+        ":CoreText_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":SwiftData_swift",
+        ":ManagedSettings_swift",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":FamilyControls_swift",
+        ":ClockKit_swift",
+        ":SensorKit_swift",
+        ":Contacts_swift",
+        ":LockedCameraCapture_swift",
+        ":CarPlay_swift",
+        ":ExtensionFoundation_swift",
+        ":RealityKit_swift",
+        ":PhotosUI_swift",
+        ":RoomPlan_swift",
+        ":AdAttributionKit_swift",
+        ":ImagePlayground_swift",
+        ":TranslationUIProvider_swift",
+        ":SpriteKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":CoreMedia_swift",
+        ":Intents_swift",
+        ":VideoSubscriberAccount_swift",
+        ":AccessorySetupKit_swift",
+        ":PencilKit_swift",
+        ":FinanceKit_swift",
+        ":ManagedSettingsUI_swift",
+        ":HealthKit_swift",
+        ":BackgroundAssets_swift",
+        ":WebKit_swift",
+        ":GameController_swift",
+        ":SecureElementCredential_swift",
+        ":ActivityKit_swift",
+        ":AssetsLibrary_swift",
+        ":SwiftUICore_swift",
+        ":FileProvider_swift",
+        ":DeviceActivity_swift",
+        ":IdentityLookup_swift",
+        ":CoreImage_swift",
+        ":CoreAudio_swift",
+        ":SecurityUI_swift",
+        ":MusicKit_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":AutomatedDeviceEnrollment_swift",
+        ":CoreAudioKit_swift",
+        ":VisionKit_swift",
+        ":SwiftUI_swift",
+        ":Combine_swift",
+        ":ModelIO_swift",
+        ":ManagedApp_swift",
+        ":SharedWithYou_swift",
+        ":CreateMLComponents_swift",
+        ":ShazamKit_swift",
+        ":CarKey_swift",
+        ":RealityFoundation_swift",
+        ":QuickLook_swift",
+        ":AppIntents_swift",
+        ":AuthenticationServices_swift",
+        ":LiveCommunicationKit_swift",
+        ":WeatherKit_swift",
+        ":DataDetection_swift",
+        ":NearbyInteraction_swift",
+        ":ContactsUI_swift",
+        ":CoreSpotlight_swift",
+        ":LocalAuthentication_swift",
+        ":MatterSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":Accessibility_swift",
+        ":HealthKitUI_swift",
+        ":Vision_swift",
+        ":NetworkExtension_swift",
+        ":ExtensionKit_swift",
+        ":EventKit_swift",
+        ":MediaAccessibility_swift",
+        ":Charts_swift",
+        ":MapKit_swift",
+        ":CallKit_swift",
+        ":CoreFoundation_swift",
+        ":TabularData_swift",
+        ":CoreMotion_swift",
+        ":WidgetKit_swift",
+        ":AVKit_swift",
+        ":SoundAnalysis_swift",
+        ":GroupActivities_swift",
+        ":CoreLocation_swift",
+        ":CloudKit_swift",
+        ":SharedWithYouCore_swift",
+        ":BrowserEngineCore_swift",
+        ":Photos_swift",
+        ":GameplayKit_swift",
+        ":WorkoutKit_swift",
+        ":BrowserEngineKit_swift",
+        ":CoreMIDI_swift",
+        ":PassKit_swift",
+        ":MarketplaceKit_swift",
+        ":TipKit_swift",
+        ":CoreData_swift",
+        ":GLKit_swift",
+        ":Messages_swift",
+        ":CryptoTokenKit_swift",
+        ":VideoToolbox_swift",
+        ":Translation_swift",
+        ":ManagedAppDistribution_swift",
+        ":DeveloperToolsSupport_swift",
+        ":CoreTransferable_swift",
+        ":EventKitUI_swift",
+        ":SceneKit_swift",
+        ":XCUIAutomation_swift",
+        ":XCTest_swift",
+        ":Testing_swift",
+        ":LiveExecutionResultsLogger_swift",
+        ":unistd_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":RegexBuilder_swift",
+        ":System_swift",
+        ":AppleArchive_swift",
+        ":Observation_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Synchronization_swift",
+        ":hvf_swift",
+        ":Dispatch_swift",
+        ":simd_swift",
+        ":Compression_swift",
+        ":Distributed_swift",
+        ":Spatial_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_MapKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafetyKit",
+    module_name = "SafetyKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SafetyKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AdServices",
+    module_name = "AdServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ImageCaptureCore",
+    module_name = "ImageCaptureCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageCaptureCore.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "PushToTalk",
+    module_name = "PushToTalk",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushToTalk.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "JavaScriptCore",
+    module_name = "JavaScriptCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/JavaScriptCore.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stdbool",
+        ":Foundation",
+        ":_Builtin_stddef",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+    ],
+)
+
+swift_c_module(
+    name = "AVRouting",
+    module_name = "AVRouting",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVRouting.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+    ],
+)
+
+swift_c_module(
+    name = "CoreHaptics",
+    module_name = "CoreHaptics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreHaptics.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppTrackingTransparency",
+    module_name = "AppTrackingTransparency",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppTrackingTransparency.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "iAd",
+    module_name = "iAd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/iAd.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "OpenAL",
+    module_name = "OpenAL",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenAL.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "PushKit",
+    module_name = "PushKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PushKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AdSupport",
+    module_name = "AdSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserKit",
+    module_name = "BrowserKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/BrowserKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemExtensions",
+    module_name = "SystemExtensions",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemExtensions.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "FileProviderUI",
+    module_name = "FileProviderUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProviderUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":FileProvider",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "Accounts",
+    module_name = "Accounts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accounts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShadersGraph",
+    module_name = "MetalPerformanceShadersGraph",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShadersGraph.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":MetalPerformanceShaders",
+    ],
+)
+
+swift_c_module(
+    name = "PHASE",
+    module_name = "PHASE",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PHASE.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+        ":AVFAudio",
+        ":simd",
+        ":AVFoundation",
+        ":ModelIO",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ClassKit",
+    module_name = "ClassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ExposureNotification",
+    module_name = "ExposureNotification",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExposureNotification.framework/Modules/module.modulemap",
+    deps = [
+        ":Dispatch",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Social",
+    module_name = "Social",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Social.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTelephony",
+    module_name = "CoreTelephony",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTelephony.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "SystemConfiguration",
+    module_name = "SystemConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SystemConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":Dispatch",
+        ":sys_types",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "NotificationCenter",
+    module_name = "NotificationCenter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NotificationCenter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "ColorSync",
+    module_name = "ColorSync",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ColorSync.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "BusinessChat",
+    module_name = "BusinessChat",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BusinessChat.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "IntentsUI",
+    module_name = "IntentsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IntentsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Intents",
+        ":CoreGraphics",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MobileCoreServices",
+    module_name = "MobileCoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MobileCoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundTasks",
+    module_name = "BackgroundTasks",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundTasks.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceCheck",
+    module_name = "DeviceCheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceCheck.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "ScreenTime",
+    module_name = "ScreenTime",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ScreenTime.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookupUI",
+    module_name = "IdentityLookupUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookupUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":IdentityLookup",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "ExternalAccessory",
+    module_name = "ExternalAccessory",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExternalAccessory.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AutomaticAssessmentConfiguration",
+    module_name = "AutomaticAssessmentConfiguration",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AutomaticAssessmentConfiguration.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "MetalPerformanceShaders",
+    module_name = "MetalPerformanceShaders",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalPerformanceShaders.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Metal",
+        ":simd",
+        ":_Builtin_stdint",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotificationsUI",
+    module_name = "UserNotificationsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotificationsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "WatchConnectivity",
+    module_name = "WatchConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WatchConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "GSS",
+    module_name = "GSS",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GSS.framework/Modules/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_inttypes",
+        ":unistd",
+        ":_Builtin_stdarg",
+        ":CoreFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "AppClip",
+    module_name = "AppClip",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppClip.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBookUI",
+    module_name = "AddressBookUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBookUI.framework/Modules/module.modulemap",
+    deps = [
+        ":AddressBook",
+        ":UIKit",
+    ],
+)
+
+swift_c_module(
+    name = "_Darwin_xlocale",
+    module_name = "_Darwin_xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":Darwin",
+        ":xlocale",
+    ],
+)
+
+swift_library_group(
+    name = "_PassKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_PassKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":PassKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_PassKit_SwiftUI",
+    module_name = "_PassKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_PassKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "_MapKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":MapKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SceneKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SceneKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SpriteKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SpriteKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Intents_TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":TipKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreLocationUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocationUI",
+        ":_CoreLocationUI_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreLocationUI_SwiftUI",
+    module_name = "_CoreLocationUI_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreLocationUI_SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocationUI",
+    module_name = "CoreLocationUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocationUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "_Translation_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":Translation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreData_CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":_CoreData_CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_CoreData_CloudKit",
+    module_name = "_CoreData_CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_CoreData_CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreData",
+    ],
+)
+
+swift_library_group(
+    name = "_MarketplaceKit_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":MarketplaceKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_WorkoutKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":WorkoutKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GroupActivities_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AVKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":AVKit_swift",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AuthenticationServices_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AuthenticationServices_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_QuickLook_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":QuickLook_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_MusicKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_DeviceActivity_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":DeviceActivity_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SecureElementCredential_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":SecureElementCredential_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_GameController_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":GameController_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_AdAttributionKit_StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AdAttributionKit_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_PhotosUI_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":PhotosUI_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_RealityKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":RealityFoundation_swift",
+        ":RealityKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":SwiftUICore_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_CoreData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_SwiftData_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":SwiftData_swift",
+        ":SwiftUI_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_HomeKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":HomeKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_CoreNFC_UIKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreNFC_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_StoreKit_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_StoreKit_SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":StoreKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_StoreKit_SwiftUI",
+    module_name = "_StoreKit_SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/_StoreKit_SwiftUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "hvf_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Synchronization_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AppleArchive_swift",
+    testonly = False,
+    deps = [
+        ":AppleArchive",
+        ":_SwiftConcurrencyShims",
+        ":Compression_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_time_swift",
+        ":_errno_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AppleArchive",
+    module_name = "AppleArchive",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/AppleArchive/module.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_time",
+        ":Darwin",
+        ":unistd",
+        ":_string",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Compression_swift",
+    testonly = False,
+    deps = [
+        ":Compression",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Compression",
+    module_name = "Compression",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/compression.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LiveExecutionResultsLogger_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Testing_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "XCTest_swift",
+    testonly = True,
+    deps = [
+        ":XCTest",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":XCUIAutomation_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCTest",
+    module_name = "XCTest",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":XCUIAutomation",
+    ],
+)
+
+swift_library_group(
+    name = "XCUIAutomation_swift",
+    testonly = True,
+    deps = [
+        ":XCUIAutomation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XCUIAutomation",
+    module_name = "XCUIAutomation",
+    testonly = True,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCUIAutomation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "EventKitUI_swift",
+    testonly = False,
+    deps = [
+        ":EventKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":EventKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKitUI",
+    module_name = "EventKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":EventKit",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedAppDistribution_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Translation_swift",
+    testonly = False,
+    deps = [
+        ":Translation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Translation",
+    module_name = "Translation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Translation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "VideoToolbox_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":VideoToolbox",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoToolbox",
+    module_name = "VideoToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":CoreMedia",
+        ":CoreFoundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoTokenKit_swift",
+    testonly = False,
+    deps = [
+        ":CryptoTokenKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CryptoTokenKit",
+    module_name = "CryptoTokenKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CryptoTokenKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "Messages_swift",
+    testonly = False,
+    deps = [
+        ":Messages",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Messages",
+    module_name = "Messages",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Messages.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "MarketplaceKit_swift",
+    testonly = False,
+    deps = [
+        ":MarketplaceKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MarketplaceKit",
+    module_name = "MarketplaceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MarketplaceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PassKit_swift",
+    testonly = False,
+    deps = [
+        ":PassKit",
+        ":_SwiftConcurrencyShims",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PassKit",
+    module_name = "PassKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PassKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+        ":CoreGraphics",
+        ":Contacts",
+        ":AddressBook",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineKit_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":BrowserEngineCore_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":XPC_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineKit",
+    module_name = "BrowserEngineKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":BrowserEngineCore",
+        ":UIKit",
+        ":XPC",
+    ],
+)
+
+swift_library_group(
+    name = "WorkoutKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "BrowserEngineCore_swift",
+    testonly = False,
+    deps = [
+        ":BrowserEngineCore",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BrowserEngineCore",
+    module_name = "BrowserEngineCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BrowserEngineCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "AVKit_swift",
+    testonly = False,
+    deps = [
+        ":AVKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVKit",
+    module_name = "AVKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":CoreMedia",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "CallKit_swift",
+    testonly = False,
+    deps = [
+        ":CallKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CallKit",
+    module_name = "CallKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CallKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "Charts_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MediaAccessibility_swift",
+    testonly = False,
+    deps = [
+        ":MediaAccessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaAccessibility",
+    module_name = "MediaAccessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaAccessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":AvailabilityMacros",
+        ":CoreText",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Foundation",
+        ":IOSurface",
+    ],
+)
+
+swift_library_group(
+    name = "EventKit_swift",
+    testonly = False,
+    deps = [
+        ":EventKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "EventKit",
+    module_name = "EventKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/EventKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":Foundation",
+        ":CoreGraphics",
+        ":AddressBook",
+        ":CoreLocation",
+    ],
+)
+
+swift_c_module(
+    name = "AddressBook",
+    module_name = "AddressBook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AddressBook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "NetworkExtension_swift",
+    testonly = False,
+    deps = [
+        ":NetworkExtension",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NetworkExtension",
+    module_name = "NetworkExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NetworkExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":os_availability",
+        ":Darwin",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKitUI_swift",
+    testonly = False,
+    deps = [
+        ":HealthKitUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":HealthKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKitUI",
+    module_name = "HealthKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKitUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":HealthKit",
+        ":os_availability",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthenticationEmbeddedUI_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthenticationEmbeddedUI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":LocalAuthentication_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthenticationEmbeddedUI",
+    module_name = "LocalAuthenticationEmbeddedUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthenticationEmbeddedUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":LocalAuthentication",
+    ],
+)
+
+swift_library_group(
+    name = "MatterSupport_swift",
+    testonly = False,
+    deps = [
+        ":Matter",
+        ":MatterSupport",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MatterSupport",
+    module_name = "MatterSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MatterSupport.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "Matter",
+    module_name = "Matter",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Matter.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ContactsUI_swift",
+    testonly = False,
+    deps = [
+        ":ContactsUI",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":TipKit_swift",
+        ":UIKit_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactsUI",
+    module_name = "ContactsUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactsUI.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Contacts",
+    ],
+)
+
+swift_library_group(
+    name = "TipKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "NearbyInteraction_swift",
+    testonly = False,
+    deps = [
+        ":NearbyInteraction",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NearbyInteraction",
+    module_name = "NearbyInteraction",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NearbyInteraction.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+    ],
+)
+
+swift_library_group(
+    name = "WeatherKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LiveCommunicationKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AuthenticationServices_swift",
+    testonly = False,
+    deps = [
+        ":AuthenticationServices",
+        ":_SwiftConcurrencyShims",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AuthenticationServices",
+    module_name = "AuthenticationServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/AuthenticationServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CarKey_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ShazamKit_swift",
+    testonly = False,
+    deps = [
+        ":ShazamKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":MusicKit_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":AVFoundation_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ShazamKit",
+    module_name = "ShazamKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ShazamKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":AVFAudio",
+        ":AVFoundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "CreateMLComponents_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":RegexBuilder_swift",
+        ":SoundAnalysis_swift",
+        ":Swift_swift",
+        ":TabularData_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_library_group(
+    name = "TabularData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "RegexBuilder_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYou_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYou",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreTransferable_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":SharedWithYouCore_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYou",
+    module_name = "SharedWithYou",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYou.framework/Modules/module.modulemap",
+    deps = [
+        ":SharedWithYouCore",
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "SharedWithYouCore_swift",
+    testonly = False,
+    deps = [
+        ":SharedWithYouCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SharedWithYouCore",
+    module_name = "SharedWithYouCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SharedWithYouCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedApp_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "VisionKit_swift",
+    testonly = False,
+    deps = [
+        ":VisionKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VisionKit",
+    module_name = "VisionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VisionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudioKit_swift",
+    testonly = False,
+    deps = [
+        ":AudioToolbox",
+        ":AudioUnit",
+        ":CoreAudioKit",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioKit",
+    module_name = "CoreAudioKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioKit.framework/Modules/module.modulemap",
+    deps = [
+        ":AVFoundation",
+        ":AudioUnit",
+        ":Foundation",
+        ":UIKit",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AudioUnit",
+    module_name = "AudioUnit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioUnit.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+    ],
+)
+
+swift_library_group(
+    name = "AutomatedDeviceEnrollment_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceDiscoveryExtension_swift",
+    testonly = False,
+    deps = [
+        ":DeviceDiscoveryExtension",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeviceDiscoveryExtension",
+    module_name = "DeviceDiscoveryExtension",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeviceDiscoveryExtension.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Network",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "MusicKit_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SecurityUI_swift",
+    testonly = False,
+    deps = [
+        ":SecurityUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SecurityUI",
+    module_name = "SecurityUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SecurityUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "IdentityLookup_swift",
+    testonly = False,
+    deps = [
+        ":IdentityLookup",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "IdentityLookup",
+    module_name = "IdentityLookup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IdentityLookup.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeviceActivity_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AssetsLibrary_swift",
+    testonly = False,
+    deps = [
+        ":AssetsLibrary",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AssetsLibrary",
+    module_name = "AssetsLibrary",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AssetsLibrary.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "SecureElementCredential_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "WebKit_swift",
+    testonly = False,
+    deps = [
+        ":WebKit",
+        ":_SwiftConcurrencyShims",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WebKit",
+    module_name = "WebKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/WebKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+        ":CoreGraphics",
+        ":Network",
+    ],
+)
+
+swift_library_group(
+    name = "BackgroundAssets_swift",
+    testonly = False,
+    deps = [
+        ":BackgroundAssets",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "BackgroundAssets",
+    module_name = "BackgroundAssets",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/BackgroundAssets.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HealthKit_swift",
+    testonly = False,
+    deps = [
+        ":HealthKit",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreLocation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HealthKit",
+    module_name = "HealthKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HealthKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettingsUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "AccessorySetupKit_swift",
+    testonly = False,
+    deps = [
+        ":AccessorySetupKit",
+        ":CoreBluetooth",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreBluetooth",
+    module_name = "CoreBluetooth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreBluetooth.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "AccessorySetupKit",
+    module_name = "AccessorySetupKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AccessorySetupKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "VideoSubscriberAccount_swift",
+    testonly = False,
+    deps = [
+        ":VideoSubscriberAccount",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "VideoSubscriberAccount",
+    module_name = "VideoSubscriberAccount",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/VideoSubscriberAccount.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "TranslationUIProvider_swift",
+    testonly = False,
+    deps = [
+        ":TranslationUIProvider",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "TranslationUIProvider",
+    module_name = "TranslationUIProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/TranslationUIProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ImagePlayground_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+        ":ImagePlayground",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":PencilKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ImagePlayground",
+    module_name = "ImagePlayground",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImagePlayground.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "PencilKit_swift",
+    testonly = False,
+    deps = [
+        ":PencilKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":MetalKit_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PencilKit",
+    module_name = "PencilKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PencilKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "AdAttributionKit_swift",
+    testonly = False,
+    deps = [
+        ":AdAttributionKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AdAttributionKit",
+    module_name = "AdAttributionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AdAttributionKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "RoomPlan_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":RoomPlan",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":CoreGraphics_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":ModelIO_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "RoomPlan",
+    module_name = "RoomPlan",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/RoomPlan.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "PhotosUI_swift",
+    testonly = False,
+    deps = [
+        ":PhotosUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Photos_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PhotosUI",
+    module_name = "PhotosUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PhotosUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+        ":Photos",
+    ],
+)
+
+swift_library_group(
+    name = "Photos_swift",
+    testonly = False,
+    deps = [
+        ":Photos",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Photos",
+    module_name = "Photos",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Photos.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ImageIO",
+        ":CoreLocation",
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":CoreGraphics",
+        ":CoreImage",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "RealityKit_swift",
+    testonly = False,
+    deps = [
+        ":MultipeerConnectivity",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":GroupActivities_swift",
+        ":Metal_swift",
+        ":RealityFoundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MultipeerConnectivity",
+    module_name = "MultipeerConnectivity",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MultipeerConnectivity.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "RealityFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":ARKit_swift",
+        ":AVFoundation_swift",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreMotion_swift",
+        ":CoreText_swift",
+        ":Foundation_swift",
+        ":Metal_swift",
+        ":OSLog_swift",
+        ":QuartzCore_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMotion_swift",
+    testonly = False,
+    deps = [
+        ":CoreMotion",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMotion",
+    module_name = "CoreMotion",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMotion.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "GroupActivities_swift",
+    testonly = False,
+    deps = [
+        ":GroupActivities",
+        ":ImageIO",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":CloudKit_swift",
+        ":Combine_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreTransferable_swift",
+        ":CryptoKit_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GroupActivities",
+    module_name = "GroupActivities",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GroupActivities.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CarPlay_swift",
+    testonly = False,
+    deps = [
+        ":CarPlay",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":MapKit_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CarPlay",
+    module_name = "CarPlay",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CarPlay.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+        ":MapKit",
+    ],
+)
+
+swift_library_group(
+    name = "MapKit_swift",
+    testonly = False,
+    deps = [
+        ":MapKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreLocation_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MapKit",
+    module_name = "MapKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MapKit.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":CoreLocation",
+        ":UIKit",
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "LockedCameraCapture_swift",
+    testonly = False,
+    deps = [
+        ":LockedCameraCapture",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionKit_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LockedCameraCapture",
+    module_name = "LockedCameraCapture",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LockedCameraCapture.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SensorKit_swift",
+    testonly = False,
+    deps = [
+        ":SensorKit",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":Speech_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":SoundAnalysis_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensorKit",
+    module_name = "SensorKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensorKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreLocation",
+        ":Speech",
+        ":SoundAnalysis",
+        ":CoreMedia",
+    ],
+)
+
+swift_library_group(
+    name = "SoundAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":AVFAudio",
+        ":SoundAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreMIDI_swift",
+        ":CoreAudio_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SoundAnalysis",
+    module_name = "SoundAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SoundAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFAudio",
+        ":CoreMedia",
+        ":CoreML",
+    ],
+)
+
+swift_library_group(
+    name = "ClockKit_swift",
+    testonly = False,
+    deps = [
+        ":ClockKit",
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CryptoKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ClockKit",
+    module_name = "ClockKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ClockKit.framework/Modules/module.modulemap",
+    deps = [
+        ":UIKit",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "FamilyControls_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":ManagedSettings_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreServices",
+    module_name = "CoreServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreServices.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ManagedSettings_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftData_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetalKit_swift",
+    testonly = False,
+    deps = [
+        ":MetalKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":ModelIO_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetalKit",
+    module_name = "MetalKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetalKit.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":ModelIO",
+        ":Metal",
+        ":simd",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "SensitiveContentAnalysis_swift",
+    testonly = False,
+    deps = [
+        ":SensitiveContentAnalysis",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SensitiveContentAnalysis",
+    module_name = "SensitiveContentAnalysis",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SensitiveContentAnalysis.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "NaturalLanguage_swift",
+    testonly = False,
+    deps = [
+        ":NaturalLanguage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "NaturalLanguage",
+    module_name = "NaturalLanguage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/NaturalLanguage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "HomeKit_swift",
+    testonly = False,
+    deps = [
+        ":HomeKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "HomeKit",
+    module_name = "HomeKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/HomeKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreNFC_swift",
+    testonly = False,
+    deps = [
+        ":CoreNFC",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreNFC",
+    module_name = "CoreNFC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreNFC.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "MessageUI_swift",
+    testonly = False,
+    deps = [
+        ":MessageUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":SwiftOnoneSupport_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MessageUI",
+    module_name = "MessageUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MessageUI.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "LinkPresentation_swift",
+    testonly = False,
+    deps = [
+        ":LinkPresentation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":Vision_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LinkPresentation",
+    module_name = "LinkPresentation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LinkPresentation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "MediaPlayer_swift",
+    testonly = False,
+    deps = [
+        ":MediaPlayer",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":AVFoundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MediaPlayer",
+    module_name = "MediaPlayer",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaPlayer.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":AVFoundation",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UIKit",
+        ":CoreMedia",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ARKit_swift",
+    testonly = False,
+    deps = [
+        ":ARKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":CoreLocation_swift",
+        ":QuickLook_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+        ":SceneKit_swift",
+        ":ModelIO_swift",
+        ":GLKit_swift",
+        ":SpriteKit_swift",
+        ":Vision_swift",
+        ":CoreML_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ARKit",
+    module_name = "ARKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ARKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":UIKit",
+        ":AVFoundation",
+        ":CoreLocation",
+        ":CoreVideo",
+        ":Metal",
+        ":QuickLook",
+        ":ImageIO",
+        ":SceneKit",
+        ":SpriteKit",
+        ":Vision",
+    ],
+)
+
+swift_library_group(
+    name = "Vision_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+        ":ImageIO",
+        ":MachO",
+        ":Vision",
+        ":_SwiftConcurrencyShims",
+        ":AVFoundation_swift",
+        ":Accelerate_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreImage_swift",
+        ":CoreML_swift",
+        ":CoreMedia_swift",
+        ":Darwin_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Vision",
+    module_name = "Vision",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Vision.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreML",
+        ":CoreGraphics",
+        ":simd",
+        ":CoreVideo",
+        ":CoreMedia",
+        ":Metal",
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "Accelerate_swift",
+    testonly = False,
+    deps = [
+        ":Accelerate",
+        ":_SwiftConcurrencyShims",
+        ":os_availability",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":Foundation_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accelerate",
+    module_name = "Accelerate",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accelerate.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":CoreVideo",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":unistd",
+        ":os_availability",
+        ":CoreGraphics",
+        ":sys_types",
+        ":os_object",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":_stdio",
+        ":os",
+        ":_Builtin_intrinsics",
+        ":CoreFoundation",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLook_swift",
+    testonly = False,
+    deps = [
+        ":QuickLook",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionFoundation_swift",
+        ":ExtensionKit_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":PDFKit_swift",
+        ":QuickLookThumbnailing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLook",
+    module_name = "QuickLook",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLook.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":UIKit",
+        ":UniformTypeIdentifiers",
+        ":CoreGraphics",
+        ":PDFKit",
+        ":QuickLookThumbnailing",
+    ],
+)
+
+swift_library_group(
+    name = "QuickLookThumbnailing_swift",
+    testonly = False,
+    deps = [
+        ":QuickLookThumbnailing",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuickLookThumbnailing",
+    module_name = "QuickLookThumbnailing",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuickLookThumbnailing.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "PDFKit_swift",
+    testonly = False,
+    deps = [
+        ":PDFKit",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "PDFKit",
+    module_name = "PDFKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/PDFKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "FinanceKitUI_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKitUI",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":ExtensionKit_swift",
+        ":FinanceKit_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":WidgetKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKitUI",
+    module_name = "FinanceKitUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKitUI.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "WidgetKit_swift",
+    testonly = False,
+    deps = [
+        ":WidgetKit",
+        ":_SwiftConcurrencyShims",
+        ":ActivityKit_swift",
+        ":AppIntents_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Intents_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_AppIntents_SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "WidgetKit",
+    module_name = "WidgetKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/WidgetKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "_AppIntents_SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":AppIntents_swift",
+        ":CoreSpotlight_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Intents_swift",
+    testonly = False,
+    deps = [
+        ":Intents",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Intents",
+    module_name = "Intents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Intents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+        ":CoreGraphics",
+        ":UserNotifications",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "AppIntents_swift",
+    testonly = False,
+    deps = [
+        ":AppIntents",
+        ":_SwiftConcurrencyShims",
+        ":notify",
+        ":CoreGraphics_swift",
+        ":CoreLocation_swift",
+        ":CoreSpotlight_swift",
+        ":CoreTransferable_swift",
+        ":Dispatch_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "notify",
+    module_name = "notify",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/notify.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "AppIntents",
+    module_name = "AppIntents",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AppIntents.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreSpotlight_swift",
+    testonly = False,
+    deps = [
+        ":CoreSpotlight",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UniformTypeIdentifiers_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreSpotlight",
+    module_name = "CoreSpotlight",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreSpotlight.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UniformTypeIdentifiers",
+    ],
+)
+
+swift_library_group(
+    name = "ActivityKit_swift",
+    testonly = False,
+    deps = [
+        ":ActivityKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ActivityKit",
+    module_name = "ActivityKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ActivityKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "FinanceKit_swift",
+    testonly = False,
+    deps = [
+        ":FinanceKit",
+        ":_SwiftConcurrencyShims",
+        ":CloudKit_swift",
+        ":CoreData_swift",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FinanceKit",
+    module_name = "FinanceKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FinanceKit.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "CloudKit_swift",
+    testonly = False,
+    deps = [
+        ":CloudKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreTransferable_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreLocation_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CloudKit",
+    module_name = "CloudKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CloudKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreLocation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreLocation_swift",
+    testonly = False,
+    deps = [
+        ":CoreLocation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreLocation",
+    module_name = "CoreLocation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreLocation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionKit_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionKit",
+        ":_SwiftConcurrencyShims",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionKit",
+    module_name = "ExtensionKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":ExtensionFoundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreML_swift",
+    testonly = False,
+    deps = [
+        ":CoreML",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreML",
+    module_name = "CoreML",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreML.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":CoreGraphics",
+        ":ImageIO",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":os_availability_internal",
+    ],
+)
+
+swift_library_group(
+    name = "StoreKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":StoreKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CryptoKit_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "StoreKit",
+    module_name = "StoreKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/StoreKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CryptoKit_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":LocalAuthentication_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_library_group(
+    name = "LocalAuthentication_swift",
+    testonly = False,
+    deps = [
+        ":LocalAuthentication",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "LocalAuthentication",
+    module_name = "LocalAuthentication",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/LocalAuthentication.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "ProximityReader_swift",
+    testonly = False,
+    deps = [
+        ":ProximityReader",
+        ":_SwiftConcurrencyShims",
+        ":Contacts_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":SwiftUI_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ProximityReader",
+    module_name = "ProximityReader",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ProximityReader.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUI_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUI",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreData_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Observation_swift",
+        ":Spatial_swift",
+        ":Swift_swift",
+        ":SwiftUICore_swift",
+        ":Symbols_swift",
+        ":UIKit_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUI",
+    module_name = "SwiftUI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUI.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftUICore_swift",
+    testonly = False,
+    deps = [
+        ":SwiftUICore",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":CoreTransferable_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftUICore",
+    module_name = "SwiftUICore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SwiftUICore.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":Foundation",
+        ":CoreGraphics",
+        ":CoreText",
+        ":QuartzCore",
+    ],
+)
+
+swift_library_group(
+    name = "Spatial_swift",
+    testonly = False,
+    deps = [
+        ":Spatial",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_math_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":simd_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Spatial",
+    module_name = "Spatial",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Spatial/module.modulemap",
+    deps = [
+        ":_math",
+        ":_stdio",
+        ":simd",
+        ":_Builtin_stdbool",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTransferable_swift",
+    testonly = False,
+    deps = [
+        ":CoreTransferable",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreTransferable",
+    module_name = "CoreTransferable",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreTransferable.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "SafariServices_swift",
+    testonly = False,
+    deps = [
+        ":SafariServices",
+        ":_SwiftConcurrencyShims",
+        ":DeveloperToolsSupport_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SafariServices",
+    module_name = "SafariServices",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Cryptexes/OS/System/Library/Frameworks/SafariServices.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "Speech_swift",
+    testonly = False,
+    deps = [
+        ":Speech",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":AVFoundation_swift",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Speech",
+    module_name = "Speech",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Speech.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "GameKit_swift",
+    testonly = False,
+    deps = [
+        ":GameKit",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":simd_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_math_swift",
+        ":UIKit_swift",
+        ":CoreFoundation_swift",
+        ":_Builtin_float_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+        ":SpriteKit_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":SceneKit_swift",
+        ":GameplayKit_swift",
+        ":GameController_swift",
+        ":AVFoundation_swift",
+        ":CoreMedia_swift",
+        ":CoreAudio_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":Contacts_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameKit",
+    module_name = "GameKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":simd",
+        ":UIKit",
+        ":SpriteKit",
+        ":SceneKit",
+        ":GameplayKit",
+        ":GameController",
+        ":ModelIO",
+        ":ReplayKit",
+        ":Foundation",
+        ":CoreGraphics",
+        ":Contacts",
+        ":ObjectiveC",
+    ],
+)
+
+swift_c_module(
+    name = "ReplayKit",
+    module_name = "ReplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ReplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":UIKit",
+        ":Foundation",
+        ":AVFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "AVFoundation_swift",
+    testonly = False,
+    deps = [
+        ":AVFoundation",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":CoreMedia_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreAudio_swift",
+        ":Metal_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":CoreMIDI_swift",
+        ":simd_swift",
+        ":QuartzCore_swift",
+    ],
+)
+
+swift_c_module(
+    name = "AVFoundation",
+    module_name = "AVFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":CoreMedia",
+        ":UniformTypeIdentifiers",
+        ":CoreVideo",
+        ":AVFAudio",
+        ":MediaToolbox",
+        ":TargetConditionals",
+        ":os_availability",
+        ":simd",
+        ":QuartzCore",
+        ":ImageIO",
+    ],
+)
+
+swift_c_module(
+    name = "MediaToolbox",
+    module_name = "MediaToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MediaToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":CoreMedia",
+        ":AudioToolbox",
+    ],
+)
+
+swift_c_module(
+    name = "AVFAudio",
+    module_name = "AVFAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AVFAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":AudioToolbox",
+        ":CoreMedia",
+        ":Foundation",
+        ":CoreMIDI",
+        ":os_availability",
+        ":CoreAudioTypes",
+        ":Darwin",
+        ":TargetConditionals",
+    ],
+)
+
+swift_c_module(
+    name = "AudioToolbox",
+    module_name = "AudioToolbox",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/AudioToolbox.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":_stdio",
+        ":Foundation",
+        ":CoreMIDI",
+        ":CoreAudioTypes",
+        ":CoreFoundation",
+        ":Dispatch",
+        ":os_workgroup",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMIDI_swift",
+    testonly = False,
+    deps = [
+        ":CoreMIDI",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMIDI",
+    module_name = "CoreMIDI",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMIDI.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Foundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_library_group(
+    name = "CoreMedia_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudioTypes",
+        ":CoreMedia",
+        ":CoreVideo",
+        ":_SwiftConcurrencyShims",
+        ":CoreAudio_swift",
+        ":CoreFoundation_swift",
+        ":CoreGraphics_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Metal_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreMedia",
+    module_name = "CoreMedia",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreMedia.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+        ":CoreFoundation",
+        ":TargetConditionals",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreAudio",
+        ":CoreGraphics",
+        ":CoreVideo",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "CoreAudio_swift",
+    testonly = False,
+    deps = [
+        ":CoreAudio",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudio",
+    module_name = "CoreAudio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudio.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreAudioTypes",
+    ],
+)
+
+swift_c_module(
+    name = "CoreAudioTypes",
+    module_name = "CoreAudioTypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreAudioTypes.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GameController_swift",
+    testonly = False,
+    deps = [
+        ":GameController",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":UIKit_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreText_swift",
+        ":CoreGraphics_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameController",
+    module_name = "GameController",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameController.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":TargetConditionals",
+        ":UIKit",
+    ],
+)
+
+swift_library_group(
+    name = "GameplayKit_swift",
+    testonly = False,
+    deps = [
+        ":GameplayKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":SpriteKit_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+        ":SceneKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GameplayKit",
+    module_name = "GameplayKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GameplayKit.framework/Modules/module.modulemap",
+    deps = [
+        ":SpriteKit",
+        ":Foundation",
+        ":simd",
+        ":os_availability",
+        ":TargetConditionals",
+        ":SceneKit",
+    ],
+)
+
+swift_library_group(
+    name = "SceneKit_swift",
+    testonly = False,
+    deps = [
+        ":SceneKit",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":ModelIO_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":CoreImage_swift",
+        ":GLKit_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SceneKit",
+    module_name = "SceneKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SceneKit.framework/Modules/module.modulemap",
+    deps = [
+        ":ModelIO",
+        ":QuartzCore",
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":UIKit",
+        ":CoreGraphics",
+        ":simd",
+        ":Metal",
+        ":GLKit",
+    ],
+)
+
+swift_library_group(
+    name = "SpriteKit_swift",
+    testonly = False,
+    deps = [
+        ":SpriteKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+        ":GLKit_swift",
+        ":ModelIO_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "SpriteKit",
+    module_name = "SpriteKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/SpriteKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":Metal",
+        ":GLKit",
+        ":UIKit",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "GLKit_swift",
+    testonly = False,
+    deps = [
+        ":GLKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":ModelIO_swift",
+        ":simd_swift",
+        ":CoreGraphics_swift",
+        ":UIKit_swift",
+        ":CoreText_swift",
+        ":FileProvider_swift",
+        ":Symbols_swift",
+        ":QuartzCore_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "GLKit",
+    module_name = "GLKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/GLKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":OpenGLES",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_math",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_string",
+        ":CoreFoundation",
+        ":os_availability",
+        ":ModelIO",
+        ":CoreGraphics",
+        ":UIKit",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "ModelIO_swift",
+    testonly = False,
+    deps = [
+        ":ModelIO",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":simd_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ModelIO",
+    module_name = "ModelIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ModelIO.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":simd",
+        ":CoreGraphics",
+        ":_math",
+    ],
+)
+
+swift_library_group(
+    name = "UIKit_swift",
+    testonly = False,
+    deps = [
+        ":UIKit",
+        ":_SwiftConcurrencyShims",
+        ":Accessibility_swift",
+        ":CoreGraphics_swift",
+        ":CoreText_swift",
+        ":DataDetection_swift",
+        ":DeveloperToolsSupport_swift",
+        ":Dispatch_swift",
+        ":Foundation_swift",
+        ":QuartzCore_swift",
+        ":Swift_swift",
+        ":Symbols_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":FileProvider_swift",
+        ":Metal_swift",
+        ":CoreImage_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UIKit",
+    module_name = "UIKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UIKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreText",
+        ":FileProvider",
+        ":CoreGraphics",
+        ":TargetConditionals",
+        ":Symbols",
+        ":QuartzCore",
+        ":CoreImage",
+        ":os_availability",
+        ":UserNotifications",
+    ],
+)
+
+swift_c_module(
+    name = "UserNotifications",
+    module_name = "UserNotifications",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UserNotifications.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreImage_swift",
+    testonly = False,
+    deps = [
+        ":CoreImage",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreImage",
+    module_name = "CoreImage",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreImage.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":TargetConditionals",
+        ":ImageIO",
+        ":IOSurface",
+        ":ObjectiveC",
+        ":Metal",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+    ],
+)
+
+swift_c_module(
+    name = "ImageIO",
+    module_name = "ImageIO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ImageIO.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreGraphics",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "FileProvider_swift",
+    testonly = False,
+    deps = [
+        ":FileProvider",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "FileProvider",
+    module_name = "FileProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/FileProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+    ],
+)
+
+swift_library_group(
+    name = "Symbols_swift",
+    testonly = False,
+    deps = [
+        ":Symbols",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Symbols",
+    module_name = "Symbols",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Symbols.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "QuartzCore_swift",
+    testonly = False,
+    deps = [
+        ":QuartzCore",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+        ":Metal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "QuartzCore",
+    module_name = "QuartzCore",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/QuartzCore.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_float",
+        ":CoreFoundation",
+        ":CoreGraphics",
+        ":os_availability",
+        ":TargetConditionals",
+        ":OpenGLES",
+        ":ObjectiveC",
+        ":Metal",
+        ":CoreVideo",
+    ],
+)
+
+swift_c_module(
+    name = "CoreVideo",
+    module_name = "CoreVideo",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreVideo.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":_Builtin_stddef",
+        ":CoreGraphics",
+        ":Metal",
+        ":OpenGLES",
+        ":IOSurface",
+    ],
+)
+
+swift_c_module(
+    name = "OpenGLES",
+    module_name = "OpenGLES",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OpenGLES.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_library_group(
+    name = "Metal_swift",
+    testonly = False,
+    deps = [
+        ":Metal",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Metal",
+    module_name = "Metal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Metal.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":_math",
+        ":os_availability",
+        ":TargetConditionals",
+        ":IOSurface",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "IOSurface",
+    module_name = "IOSurface",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/IOSurface.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":CoreFoundation",
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "DeveloperToolsSupport_swift",
+    testonly = False,
+    deps = [
+        ":DeveloperToolsSupport",
+        ":_SwiftConcurrencyShims",
+        ":CoreGraphics_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DeveloperToolsSupport",
+    module_name = "DeveloperToolsSupport",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DeveloperToolsSupport.framework/Modules/module.modulemap",
+)
+
+swift_library_group(
+    name = "DataDetection_swift",
+    testonly = False,
+    deps = [
+        ":DataDetection",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "DataDetection",
+    module_name = "DataDetection",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/DataDetection.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "CoreText_swift",
+    testonly = False,
+    deps = [
+        ":CoreText",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":UniformTypeIdentifiers_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreGraphics_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreText",
+    module_name = "CoreText",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreText.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":CoreGraphics",
+        ":CoreFoundation",
+        ":Darwin",
+    ],
+)
+
+swift_library_group(
+    name = "UniformTypeIdentifiers_swift",
+    testonly = False,
+    deps = [
+        ":UniformTypeIdentifiers",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "UniformTypeIdentifiers",
+    module_name = "UniformTypeIdentifiers",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/UniformTypeIdentifiers.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Accessibility_swift",
+    testonly = False,
+    deps = [
+        ":Accessibility",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":CoreGraphics_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Accessibility",
+    module_name = "Accessibility",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Accessibility.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":CoreGraphics",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "CoreGraphics_swift",
+    testonly = False,
+    deps = [
+        ":CoreGraphics",
+        ":_SwiftConcurrencyShims",
+        ":CoreFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreGraphics",
+    module_name = "CoreGraphics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreGraphics.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_Builtin_float",
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "simd_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":simd",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_math_swift",
+    ],
+)
+
+swift_c_module(
+    name = "simd",
+    module_name = "simd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/simd/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":os_availability",
+        ":_Builtin_intrinsics",
+        ":_Builtin_stdint",
+        ":_Builtin_tgmath",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_intrinsics",
+    module_name = "_Builtin_intrinsics",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdlib",
+    ],
+)
+
+swift_library_group(
+    name = "ContactProvider_swift",
+    testonly = False,
+    deps = [
+        ":ContactProvider",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Contacts_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":OSLog_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ContactProvider",
+    module_name = "ContactProvider",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ContactProvider.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+    ],
+)
+
+swift_library_group(
+    name = "OSLog_swift",
+    testonly = False,
+    deps = [
+        ":OSLog",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "OSLog",
+    module_name = "OSLog",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/OSLog.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Contacts_swift",
+    testonly = False,
+    deps = [
+        ":Contacts",
+        ":_SwiftConcurrencyShims",
+        ":CoreData_swift",
+        ":ExtensionFoundation_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Contacts",
+    module_name = "Contacts",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Contacts.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "ExtensionFoundation_swift",
+    testonly = False,
+    deps = [
+        ":ExtensionFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Foundation_swift",
+        ":Network_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+    ],
+)
+
+swift_c_module(
+    name = "ExtensionFoundation",
+    module_name = "ExtensionFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/ExtensionFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "CoreData_swift",
+    testonly = False,
+    deps = [
+        ":CoreData",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreData",
+    module_name = "CoreData",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreData.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":AvailabilityMacros",
+        ":os_availability",
+        ":TargetConditionals",
+    ],
+)
+
+swift_library_group(
+    name = "Network_swift",
+    testonly = False,
+    deps = [
+        ":Network",
+        ":Security",
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":Distributed_swift",
+        ":Foundation_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":CoreFoundation_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Network",
+    module_name = "Network",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Network.framework/Modules/module.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_object",
+        ":TargetConditionals",
+        ":_stdlib",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":sys_types",
+        ":Darwin",
+        ":Dispatch",
+        ":dnssd",
+        ":CoreFoundation",
+        ":Security",
+        ":Foundation",
+    ],
+)
+
+swift_c_module(
+    name = "dnssd",
+    module_name = "dnssd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dnssd.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Dispatch",
+    ],
+)
+
+swift_library_group(
+    name = "Distributed_swift",
+    testonly = False,
+    deps = [
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+    ],
+)
+
+swift_library_group(
+    name = "MetricKit_swift",
+    testonly = False,
+    deps = [
+        ":MetricKit",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":os_swift",
+        ":Foundation_swift",
+        ":CoreFoundation_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "MetricKit",
+    module_name = "MetricKit",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/MetricKit.framework/Modules/module.modulemap",
+    deps = [
+        ":Foundation",
+        ":os_availability",
+        ":os",
+    ],
+)
+
+swift_library_group(
+    name = "Foundation_swift",
+    testonly = False,
+    deps = [
+        ":Foundation",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":CoreFoundation_swift",
+        ":Darwin_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+        ":Observation_swift",
+        ":Swift_swift",
+        ":System_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":XPC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Foundation",
+    module_name = "Foundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Foundation.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":Dispatch",
+        ":_Builtin_limits",
+        ":_Builtin_stdarg",
+        ":_setjmp",
+        ":TargetConditionals",
+        ":os_availability",
+        ":ObjectiveC",
+        ":_Builtin_stdint",
+        ":AvailabilityMacros",
+        ":ptrauth",
+        ":DarwinFoundation",
+        ":Security",
+        ":CFNetwork",
+        ":Darwin",
+        ":XPC",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "CFNetwork",
+    module_name = "CFNetwork",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CFNetwork.framework/Modules/module.modulemap",
+    deps = [
+        ":CoreFoundation",
+        ":_Builtin_stdint",
+        ":Darwin",
+    ],
+)
+
+swift_c_module(
+    name = "Security",
+    module_name = "Security",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/Security.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_stdint",
+        ":CoreFoundation",
+        ":DarwinFoundation",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Dispatch",
+        ":sys_types",
+        ":os_object",
+    ],
+)
+
+swift_library_group(
+    name = "System_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Observation_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "CoreFoundation_swift",
+    testonly = False,
+    deps = [
+        ":CoreFoundation",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":Darwin_swift",
+        ":unistd_swift",
+        ":Dispatch_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "CoreFoundation",
+    module_name = "CoreFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks/CoreFoundation.framework/Modules/module.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":sys_types",
+        ":_Builtin_stdarg",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_ctype",
+        ":_errno",
+        ":_Builtin_float",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stddef",
+        ":_stdio",
+        ":_stdlib",
+        ":_string",
+        ":_time",
+        ":_Builtin_inttypes",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":os_availability",
+        ":AvailabilityMacros",
+        ":Darwin",
+        ":ptrauth",
+        ":Dispatch",
+    ],
+)
+
+swift_c_module(
+    name = "ptrauth",
+    module_name = "ptrauth",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "os_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":os",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":XPC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "os",
+    module_name = "os",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":Darwin",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":MachO",
+        ":os_availability",
+        ":os_object",
+        ":DarwinFoundation",
+        ":XPC",
+        ":_Builtin_stdarg",
+        ":sys_types",
+        ":unistd",
+        ":os_workgroup",
+    ],
+)
+
+swift_c_module(
+    name = "MachO",
+    module_name = "MachO",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_Builtin_stdint",
+        ":Darwin",
+        ":os_availability",
+        ":TargetConditionals",
+        ":_Builtin_stddef",
+        ":_Builtin_stdbool",
+        ":unistd",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "XPC_swift",
+    testonly = False,
+    deps = [
+        ":XPC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+        ":Dispatch_swift",
+    ],
+)
+
+swift_c_module(
+    name = "XPC",
+    module_name = "XPC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/xpc.modulemap",
+    deps = [
+        ":os_object",
+        ":Dispatch",
+        ":Darwin",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdint",
+        ":_stdlib",
+        ":_stdio",
+        ":_string",
+        ":unistd",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Dispatch_swift",
+    testonly = False,
+    deps = [
+        ":Dispatch",
+        ":_SwiftConcurrencyShims",
+        ":Combine_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_errno_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":_time_swift",
+        ":unistd_swift",
+        ":ObjectiveC_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Dispatch",
+    module_name = "Dispatch",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/dispatch.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdarg",
+        ":_string",
+        ":unistd",
+        ":os_object",
+        ":os_workgroup",
+        ":DarwinFoundation",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "os_workgroup",
+    module_name = "os_workgroup",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":sys_types",
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+        ":_Builtin_stdbool",
+        ":_string",
+        ":_stdlib",
+        ":Darwin",
+        ":os_availability",
+        ":os_object",
+    ],
+)
+
+swift_c_module(
+    name = "os_object",
+    module_name = "os_object",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os.modulemap",
+    deps = [
+        ":os_availability",
+        ":TargetConditionals",
+        ":Darwin",
+        ":ObjectiveC",
+    ],
+)
+
+swift_library_group(
+    name = "Combine_swift",
+    testonly = False,
+    deps = [
+        ":_SwiftConcurrencyShims",
+        ":Darwin_swift",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+    ],
+)
+
+swift_library_group(
+    name = "ObjectiveC_swift",
+    testonly = False,
+    deps = [
+        ":ObjectiveC",
+        ":_SwiftConcurrencyShims",
+        ":Swift_swift",
+        ":_Concurrency_swift",
+        ":_StringProcessing_swift",
+        ":_errno_swift",
+        ":_signal_swift",
+        ":sys_time_swift",
+        ":Darwin_swift",
+        ":_stdio_swift",
+        ":_Builtin_float_swift",
+        ":_math_swift",
+        ":_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_SwiftConcurrencyShims",
+    module_name = "_SwiftConcurrencyShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "ObjectiveC",
+    module_name = "ObjectiveC",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/ObjectiveC.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_Builtin_limits",
+        ":_stdlib",
+        ":os_availability",
+        ":_Builtin_stdbool",
+        ":AvailabilityMacros",
+        ":_Builtin_stddef",
+        ":sys_types",
+        ":_Builtin_stdint",
+        ":_string",
+        ":Darwin",
+        ":_Builtin_stdarg",
+    ],
+)
+
+swift_c_module(
+    name = "AvailabilityMacros",
+    module_name = "AvailabilityMacros",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+        ":TargetConditionals",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "Darwin_swift",
+    testonly = False,
+    deps = [
+        ":Darwin",
+        ":Swift_swift",
+        ":_Builtin_float_swift",
+        ":_errno_swift",
+        ":_math_swift",
+        ":_signal_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":unistd_swift",
+    ],
+)
+
+swift_c_module(
+    name = "Darwin",
+    module_name = "Darwin",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/Darwin.modulemap",
+    deps = [
+        ":TargetConditionals",
+        ":_stdio",
+        ":DarwinFoundation",
+        ":_assert",
+        ":_complex",
+        ":_Builtin_stdint",
+        ":_ctype",
+        ":os_availability",
+        ":_errno",
+        ":_fenv",
+        ":_Builtin_float",
+        ":_Builtin_inttypes",
+        ":_Builtin_iso646",
+        ":_Builtin_limits",
+        ":_locale",
+        ":_math",
+        ":_setjmp",
+        ":_signal",
+        ":_Builtin_stdarg",
+        ":_Builtin_stdatomic",
+        ":_Builtin_stdbool",
+        ":_Builtin_stddef",
+        ":_stdlib",
+        ":_string",
+        ":_Builtin_tgmath",
+        ":_time",
+        ":sys_types",
+        ":_wchar",
+        ":_wctype",
+        ":xlocale",
+        ":__wctype",
+        ":_inttypes",
+        ":uuid",
+        ":mach",
+        ":_limits",
+        ":nl_types",
+        ":netinet_in",
+        ":pthread",
+        ":_strings",
+        ":sys_resource",
+        ":sys_select",
+        ":_sys_select",
+        ":sys_time",
+        ":sys_wait",
+        ":unistd",
+    ],
+)
+
+swift_c_module(
+    name = "pthread",
+    module_name = "pthread",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_time",
+        ":sys_types",
+        ":mach",
+        ":_signal",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "nl_types",
+    module_name = "nl_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "xlocale",
+    module_name = "xlocale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_locale",
+    ],
+)
+
+swift_c_module(
+    name = "_wctype",
+    module_name = "_wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":__wctype",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_wchar",
+    module_name = "_wchar",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":__wctype",
+        ":runetype",
+        ":_Builtin_stdarg",
+        ":_stdio",
+        ":_time",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "__wctype",
+    module_name = "__wctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_ctype",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_tgmath",
+    module_name = "_Builtin_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_math",
+        ":_tgmath",
+    ],
+)
+
+swift_c_module(
+    name = "_tgmath",
+    module_name = "_tgmath",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":_math",
+        ":_complex",
+    ],
+)
+
+swift_c_module(
+    name = "_string",
+    module_name = "_string",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_errno",
+        ":sys_types",
+        ":_strings",
+    ],
+)
+
+swift_c_module(
+    name = "_strings",
+    module_name = "_strings",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_stdlib",
+    module_name = "_stdlib",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":os_availability",
+        ":DarwinFoundation",
+        ":sys_wait",
+        ":alloca",
+        ":runetype",
+        ":sys_types",
+        ":ptrcheck",
+    ],
+)
+
+swift_c_module(
+    name = "alloca",
+    module_name = "alloca",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_wait",
+    module_name = "sys_wait",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":sys_types",
+        ":_signal",
+        ":sys_resource",
+    ],
+)
+
+swift_c_module(
+    name = "sys_resource",
+    module_name = "sys_resource",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_Builtin_stdint",
+        ":os_availability",
+        ":sys_time",
+        ":sys_types",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdbool",
+    module_name = "_Builtin_stdbool",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdatomic",
+    module_name = "_Builtin_stdatomic",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_Builtin_stddef",
+        ":_Builtin_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_setjmp",
+    module_name = "_setjmp",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_locale",
+    module_name = "_locale",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_limits",
+    module_name = "_Builtin_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_limits",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_iso646",
+    module_name = "_Builtin_iso646",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_inttypes",
+    module_name = "_Builtin_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_inttypes",
+    ],
+)
+
+swift_c_module(
+    name = "_inttypes",
+    module_name = "_inttypes",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_Builtin_stdint",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_fenv",
+    module_name = "_fenv",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_c_module(
+    name = "_ctype",
+    module_name = "_ctype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":runetype",
+    ],
+)
+
+swift_c_module(
+    name = "runetype",
+    module_name = "runetype",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stdint",
+    module_name = "_Builtin_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_stdint",
+    ],
+)
+
+swift_c_module(
+    name = "_stdint",
+    module_name = "_stdint",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_complex",
+    module_name = "_complex",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "_assert",
+    module_name = "_assert",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "TargetConditionals",
+    module_name = "TargetConditionals",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/TargetConditionals.modulemap",
+)
+
+swift_library_group(
+    name = "unistd_swift",
+    testonly = False,
+    deps = [
+        ":unistd",
+        ":Swift_swift",
+        ":_errno_swift",
+        ":_stdio_swift",
+        ":_time_swift",
+        ":sys_time_swift",
+        ":_signal_swift",
+    ],
+)
+
+swift_c_module(
+    name = "unistd",
+    module_name = "unistd",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":_limits",
+        ":sys_types",
+        ":_useconds_t",
+        ":_stdio",
+        ":sys_select",
+        ":uuid",
+        ":gethostuuid",
+    ],
+)
+
+swift_c_module(
+    name = "gethostuuid",
+    module_name = "gethostuuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":_time",
+        ":uuid",
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "uuid",
+    module_name = "uuid",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "sys_select",
+    module_name = "sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":_sys_select",
+        ":_time",
+        ":sys_time",
+        ":sys_types",
+        ":_signal",
+    ],
+)
+
+swift_c_module(
+    name = "_limits",
+    module_name = "_limits",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "sys_time_swift",
+    testonly = False,
+    deps = [
+        ":sys_time",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "sys_time",
+    module_name = "sys_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_time_swift",
+    testonly = False,
+    deps = [
+        ":_time",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_time",
+    module_name = "_time",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_stdio_swift",
+    testonly = False,
+    deps = [
+        ":_stdio",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_stdio",
+    module_name = "_stdio",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+        ":sys_types",
+    ],
+)
+
+swift_library_group(
+    name = "_signal_swift",
+    testonly = False,
+    deps = [
+        ":_signal",
+        ":Swift_swift",
+        ":_errno_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_signal",
+    module_name = "_signal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":mach",
+        ":sys_types",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "sys_types",
+    module_name = "sys_types",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinBasic.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":netinet_in",
+        ":_useconds_t",
+        ":_errno",
+        ":_sys_select",
+    ],
+)
+
+swift_c_module(
+    name = "_sys_select",
+    module_name = "_sys_select",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_c_module(
+    name = "_useconds_t",
+    module_name = "_useconds_t",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "netinet_in",
+    module_name = "netinet_in",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "mach",
+    module_name = "mach",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_library_group(
+    name = "_math_swift",
+    testonly = False,
+    deps = [
+        ":_math",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_math",
+    module_name = "_math",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+        ":os_availability",
+    ],
+)
+
+swift_library_group(
+    name = "_errno_swift",
+    testonly = False,
+    deps = [
+        ":_errno",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_errno",
+    module_name = "_errno",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+    deps = [
+        ":DarwinFoundation",
+    ],
+)
+
+swift_c_module(
+    name = "DarwinFoundation",
+    module_name = "DarwinFoundation",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/DarwinFoundation.modulemap",
+    deps = [
+        ":ptrcheck",
+        ":os_availability",
+        ":_Builtin_stdarg",
+        ":_Builtin_stddef",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_stddef",
+    module_name = "_Builtin_stddef",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "_Builtin_stdarg",
+    module_name = "_Builtin_stdarg",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_c_module(
+    name = "os_availability",
+    module_name = "os_availability",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+    deps = [
+        ":os_availability_internal",
+    ],
+)
+
+swift_c_module(
+    name = "os_availability_internal",
+    module_name = "os_availability_internal",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/os_availability.modulemap",
+)
+
+swift_c_module(
+    name = "ptrcheck",
+    module_name = "ptrcheck",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+)
+
+swift_library_group(
+    name = "_Builtin_float_swift",
+    testonly = False,
+    deps = [
+        ":_Builtin_float",
+        ":Swift_swift",
+    ],
+)
+
+swift_c_module(
+    name = "_Builtin_float",
+    module_name = "_Builtin_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_DEVELOPER_DIR__/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/module.modulemap",
+    deps = [
+        ":_float",
+    ],
+)
+
+swift_c_module(
+    name = "_float",
+    module_name = "_float",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/c_standard_library.modulemap",
+)
+
+swift_library_group(
+    name = "_StringProcessing_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "_Concurrency_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "SwiftOnoneSupport_swift",
+    testonly = False,
+    deps = [
+        ":Swift_swift",
+    ],
+)
+
+swift_library_group(
+    name = "Swift_swift",
+    testonly = False,
+    deps = [
+        ":SwiftShims",
+        ":_SwiftConcurrencyShims",
+    ],
+)
+
+swift_c_module(
+    name = "SwiftShims",
+    module_name = "SwiftShims",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/lib/swift/shims/module.modulemap",
+)
+
+swift_c_module(
+    name = "CommonCrypto",
+    module_name = "CommonCrypto",
+    testonly = False,
+    system_module_map = "__BAZEL_XCODE_SDKROOT__/usr/include/CommonCrypto/module.modulemap",
+)
+
+swift_library_group(
+    name = "IOKit",
+    testonly = False,
+)
+
+swift_library_group(
+    name = "CommonCrypto_swift",
+    testonly = False,
+    deps = [
+        ":CommonCrypto",
+    ],
+)
+
+swift_library_group(
+    name = "ImageIO_swift",
+    testonly = False,
+    deps = [
+        ":ImageIO",
+    ],
+)
+
+swift_library_group(
+    name = "AppTrackingTransparency_swift",
+    testonly = False,
+    deps = [
+        ":AppTrackingTransparency",
+    ],
+)
+
+swift_library_group(
+    name = "notify_swift",
+    testonly = False,
+    deps = [
+        ":notify",
+    ],
+)
+
+swift_library_group(
+    name = "AdSupport_swift",
+    testonly = False,
+    deps = [
+        ":AdSupport",
+    ],
+)
+
+swift_library_group(
+    name = "UserNotifications_swift",
+    testonly = False,
+    deps = [
+        ":UserNotifications",
+    ],
+)
+
+swift_library_group(
+    name = "Security_swift",
+    testonly = False,
+    deps = [
+        ":Security",
+    ],
+)
+
+swift_library_group(
+    name = "CoreVideo_swift",
+    testonly = False,
+    deps = [
+        ":CoreVideo",
+    ],
+)
+
+swift_library_group(
+    name = "CoreServices_swift",
+    testonly = False,
+    deps = [
+        ":CoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "MobileCoreServices_swift",
+    testonly = False,
+    deps = [
+        ":MobileCoreServices",
+    ],
+)
+
+swift_library_group(
+    name = "ReplayKit_swift",
+    testonly = False,
+    deps = [
+        ":ReplayKit",
+    ],
+)
+
+swift_library_group(
+    name = "CoreTelephony_swift",
+    testonly = False,
+    deps = [
+        ":CoreTelephony",
+    ],
+)
+
+swift_library_group(
+    name = "MachO_swift",
+    testonly = False,
+    deps = [
+        ":MachO",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_targets",
+    deps = [
+        ":SafetyKit",
+        ":AdServices",
+        ":ImageCaptureCore",
+        ":PushToTalk",
+        ":JavaScriptCore",
+        ":AVRouting",
+        ":CoreHaptics",
+        ":AppTrackingTransparency",
+        ":iAd",
+        ":OpenAL",
+        ":PushKit",
+        ":AdSupport",
+        ":BrowserKit",
+        ":SystemExtensions",
+        ":FileProviderUI",
+        ":Accounts",
+        ":MetalPerformanceShadersGraph",
+        ":PHASE",
+        ":ClassKit",
+        ":ExposureNotification",
+        ":Social",
+        ":CoreTelephony",
+        ":SystemConfiguration",
+        ":NotificationCenter",
+        ":ColorSync",
+        ":BusinessChat",
+        ":IntentsUI",
+        ":MobileCoreServices",
+        ":BackgroundTasks",
+        ":DeviceCheck",
+        ":ScreenTime",
+        ":IdentityLookupUI",
+        ":ExternalAccessory",
+        ":AutomaticAssessmentConfiguration",
+        ":MetalPerformanceShaders",
+        ":UserNotificationsUI",
+        ":WatchConnectivity",
+        ":GSS",
+        ":AppClip",
+        ":AddressBookUI",
+        ":_Darwin_xlocale",
+        ":_PassKit_SwiftUI_swift",
+        ":_PassKit_SwiftUI",
+        ":_MapKit_SwiftUI_swift",
+        ":_SceneKit_SwiftUI_swift",
+        ":_SpriteKit_SwiftUI_swift",
+        ":_Intents_TipKit_swift",
+        ":_CoreLocationUI_SwiftUI_swift",
+        ":_CoreLocationUI_SwiftUI",
+        ":CoreLocationUI",
+        ":_Translation_SwiftUI_swift",
+        ":_CoreData_CloudKit_swift",
+        ":_CoreData_CloudKit",
+        ":_MarketplaceKit_UIKit_swift",
+        ":_WorkoutKit_SwiftUI_swift",
+        ":_GroupActivities_UIKit_swift",
+        ":_AVKit_SwiftUI_swift",
+        ":_AuthenticationServices_SwiftUI_swift",
+        ":_AppIntents_UIKit_swift",
+        ":_QuickLook_SwiftUI_swift",
+        ":_MusicKit_SwiftUI_swift",
+        ":_DeviceActivity_SwiftUI_swift",
+        ":_SecureElementCredential_SwiftUI_swift",
+        ":_SecureElementCredential_UIKit_swift",
+        ":_GameController_SwiftUI_swift",
+        ":_AdAttributionKit_StoreKit_swift",
+        ":_PhotosUI_SwiftUI_swift",
+        ":_RealityKit_SwiftUI_swift",
+        ":_SwiftData_CoreData_swift",
+        ":_SwiftData_SwiftUI_swift",
+        ":_HomeKit_SwiftUI_swift",
+        ":_CoreNFC_UIKit_swift",
+        ":_StoreKit_SwiftUI_swift",
+        ":_StoreKit_SwiftUI",
+        ":hvf_swift",
+        ":Synchronization_swift",
+        ":AppleArchive_swift",
+        ":AppleArchive",
+        ":Compression_swift",
+        ":Compression",
+        ":LiveExecutionResultsLogger_swift",
+        ":Testing_swift",
+        ":EventKitUI_swift",
+        ":EventKitUI",
+        ":ManagedAppDistribution_swift",
+        ":Translation_swift",
+        ":Translation",
+        ":VideoToolbox_swift",
+        ":VideoToolbox",
+        ":CryptoTokenKit_swift",
+        ":CryptoTokenKit",
+        ":Messages_swift",
+        ":Messages",
+        ":MarketplaceKit_swift",
+        ":MarketplaceKit",
+        ":PassKit_swift",
+        ":PassKit",
+        ":BrowserEngineKit_swift",
+        ":BrowserEngineKit",
+        ":WorkoutKit_swift",
+        ":BrowserEngineCore_swift",
+        ":BrowserEngineCore",
+        ":AVKit_swift",
+        ":AVKit",
+        ":CallKit_swift",
+        ":CallKit",
+        ":Charts_swift",
+        ":MediaAccessibility_swift",
+        ":MediaAccessibility",
+        ":EventKit_swift",
+        ":EventKit",
+        ":AddressBook",
+        ":NetworkExtension_swift",
+        ":NetworkExtension",
+        ":HealthKitUI_swift",
+        ":HealthKitUI",
+        ":LocalAuthenticationEmbeddedUI_swift",
+        ":LocalAuthenticationEmbeddedUI",
+        ":MatterSupport_swift",
+        ":MatterSupport",
+        ":Matter",
+        ":ContactsUI_swift",
+        ":ContactsUI",
+        ":TipKit_swift",
+        ":NearbyInteraction_swift",
+        ":NearbyInteraction",
+        ":WeatherKit_swift",
+        ":LiveCommunicationKit_swift",
+        ":AuthenticationServices_swift",
+        ":AuthenticationServices",
+        ":CarKey_swift",
+        ":ShazamKit_swift",
+        ":ShazamKit",
+        ":CreateMLComponents_swift",
+        ":TabularData_swift",
+        ":RegexBuilder_swift",
+        ":SharedWithYou_swift",
+        ":SharedWithYou",
+        ":SharedWithYouCore_swift",
+        ":SharedWithYouCore",
+        ":ManagedApp_swift",
+        ":VisionKit_swift",
+        ":VisionKit",
+        ":CoreAudioKit_swift",
+        ":CoreAudioKit",
+        ":AudioUnit",
+        ":AutomatedDeviceEnrollment_swift",
+        ":DeviceDiscoveryExtension_swift",
+        ":DeviceDiscoveryExtension",
+        ":MusicKit_swift",
+        ":SecurityUI_swift",
+        ":SecurityUI",
+        ":IdentityLookup_swift",
+        ":IdentityLookup",
+        ":DeviceActivity_swift",
+        ":AssetsLibrary_swift",
+        ":AssetsLibrary",
+        ":SecureElementCredential_swift",
+        ":WebKit_swift",
+        ":WebKit",
+        ":BackgroundAssets_swift",
+        ":BackgroundAssets",
+        ":HealthKit_swift",
+        ":HealthKit",
+        ":ManagedSettingsUI_swift",
+        ":AccessorySetupKit_swift",
+        ":CoreBluetooth",
+        ":AccessorySetupKit",
+        ":VideoSubscriberAccount_swift",
+        ":VideoSubscriberAccount",
+        ":TranslationUIProvider_swift",
+        ":TranslationUIProvider",
+        ":ImagePlayground_swift",
+        ":ImagePlayground",
+        ":PencilKit_swift",
+        ":PencilKit",
+        ":AdAttributionKit_swift",
+        ":AdAttributionKit",
+        ":RoomPlan_swift",
+        ":RoomPlan",
+        ":PhotosUI_swift",
+        ":PhotosUI",
+        ":Photos_swift",
+        ":Photos",
+        ":RealityKit_swift",
+        ":MultipeerConnectivity",
+        ":RealityFoundation_swift",
+        ":CoreMotion_swift",
+        ":CoreMotion",
+        ":GroupActivities_swift",
+        ":GroupActivities",
+        ":CarPlay_swift",
+        ":CarPlay",
+        ":MapKit_swift",
+        ":MapKit",
+        ":LockedCameraCapture_swift",
+        ":LockedCameraCapture",
+        ":SensorKit_swift",
+        ":SensorKit",
+        ":SoundAnalysis_swift",
+        ":SoundAnalysis",
+        ":ClockKit_swift",
+        ":ClockKit",
+        ":FamilyControls_swift",
+        ":CoreServices",
+        ":ManagedSettings_swift",
+        ":SwiftData_swift",
+        ":MetalKit_swift",
+        ":MetalKit",
+        ":SensitiveContentAnalysis_swift",
+        ":SensitiveContentAnalysis",
+        ":NaturalLanguage_swift",
+        ":NaturalLanguage",
+        ":HomeKit_swift",
+        ":HomeKit",
+        ":CoreNFC_swift",
+        ":CoreNFC",
+        ":MessageUI_swift",
+        ":MessageUI",
+        ":LinkPresentation_swift",
+        ":LinkPresentation",
+        ":MediaPlayer_swift",
+        ":MediaPlayer",
+        ":ARKit_swift",
+        ":ARKit",
+        ":Vision_swift",
+        ":Vision",
+        ":Accelerate_swift",
+        ":Accelerate",
+        ":QuickLook_swift",
+        ":QuickLook",
+        ":QuickLookThumbnailing_swift",
+        ":QuickLookThumbnailing",
+        ":PDFKit_swift",
+        ":PDFKit",
+        ":FinanceKitUI_swift",
+        ":FinanceKitUI",
+        ":WidgetKit_swift",
+        ":WidgetKit",
+        ":_AppIntents_SwiftUI_swift",
+        ":Intents_swift",
+        ":Intents",
+        ":AppIntents_swift",
+        ":notify",
+        ":AppIntents",
+        ":CoreSpotlight_swift",
+        ":CoreSpotlight",
+        ":ActivityKit_swift",
+        ":ActivityKit",
+        ":FinanceKit_swift",
+        ":FinanceKit",
+        ":CloudKit_swift",
+        ":CloudKit",
+        ":CoreLocation_swift",
+        ":CoreLocation",
+        ":ExtensionKit_swift",
+        ":ExtensionKit",
+        ":CoreML_swift",
+        ":CoreML",
+        ":StoreKit_swift",
+        ":StoreKit",
+        ":CryptoKit_swift",
+        ":LocalAuthentication_swift",
+        ":LocalAuthentication",
+        ":ProximityReader_swift",
+        ":ProximityReader",
+        ":SwiftUI_swift",
+        ":SwiftUI",
+        ":SwiftUICore_swift",
+        ":SwiftUICore",
+        ":Spatial_swift",
+        ":Spatial",
+        ":CoreTransferable_swift",
+        ":CoreTransferable",
+        ":SafariServices_swift",
+        ":SafariServices",
+        ":Speech_swift",
+        ":Speech",
+        ":GameKit_swift",
+        ":GameKit",
+        ":ReplayKit",
+        ":AVFoundation_swift",
+        ":AVFoundation",
+        ":MediaToolbox",
+        ":AVFAudio",
+        ":AudioToolbox",
+        ":CoreMIDI_swift",
+        ":CoreMIDI",
+        ":CoreMedia_swift",
+        ":CoreMedia",
+        ":CoreAudio_swift",
+        ":CoreAudio",
+        ":CoreAudioTypes",
+        ":GameController_swift",
+        ":GameController",
+        ":GameplayKit_swift",
+        ":GameplayKit",
+        ":SceneKit_swift",
+        ":SceneKit",
+        ":SpriteKit_swift",
+        ":SpriteKit",
+        ":GLKit_swift",
+        ":GLKit",
+        ":ModelIO_swift",
+        ":ModelIO",
+        ":UIKit_swift",
+        ":UIKit",
+        ":UserNotifications",
+        ":CoreImage_swift",
+        ":CoreImage",
+        ":ImageIO",
+        ":FileProvider_swift",
+        ":FileProvider",
+        ":Symbols_swift",
+        ":Symbols",
+        ":QuartzCore_swift",
+        ":QuartzCore",
+        ":CoreVideo",
+        ":OpenGLES",
+        ":Metal_swift",
+        ":Metal",
+        ":IOSurface",
+        ":DeveloperToolsSupport_swift",
+        ":DeveloperToolsSupport",
+        ":DataDetection_swift",
+        ":DataDetection",
+        ":CoreText_swift",
+        ":CoreText",
+        ":UniformTypeIdentifiers_swift",
+        ":UniformTypeIdentifiers",
+        ":Accessibility_swift",
+        ":Accessibility",
+        ":CoreGraphics_swift",
+        ":CoreGraphics",
+        ":simd_swift",
+        ":simd",
+        ":_Builtin_intrinsics",
+        ":ContactProvider_swift",
+        ":ContactProvider",
+        ":OSLog_swift",
+        ":OSLog",
+        ":Contacts_swift",
+        ":Contacts",
+        ":ExtensionFoundation_swift",
+        ":ExtensionFoundation",
+        ":CoreData_swift",
+        ":CoreData",
+        ":Network_swift",
+        ":Network",
+        ":dnssd",
+        ":Distributed_swift",
+        ":MetricKit_swift",
+        ":MetricKit",
+        ":Foundation_swift",
+        ":Foundation",
+        ":CFNetwork",
+        ":Security",
+        ":System_swift",
+        ":Observation_swift",
+        ":CoreFoundation_swift",
+        ":CoreFoundation",
+        ":ptrauth",
+        ":os_swift",
+        ":os",
+        ":MachO",
+        ":XPC_swift",
+        ":XPC",
+        ":Dispatch_swift",
+        ":Dispatch",
+        ":os_workgroup",
+        ":os_object",
+        ":Combine_swift",
+        ":ObjectiveC_swift",
+        ":_SwiftConcurrencyShims",
+        ":ObjectiveC",
+        ":AvailabilityMacros",
+        ":Darwin_swift",
+        ":Darwin",
+        ":pthread",
+        ":nl_types",
+        ":xlocale",
+        ":_wctype",
+        ":_wchar",
+        ":__wctype",
+        ":_Builtin_tgmath",
+        ":_tgmath",
+        ":_string",
+        ":_strings",
+        ":_stdlib",
+        ":alloca",
+        ":sys_wait",
+        ":sys_resource",
+        ":_Builtin_stdbool",
+        ":_Builtin_stdatomic",
+        ":_setjmp",
+        ":_locale",
+        ":_Builtin_limits",
+        ":_Builtin_iso646",
+        ":_Builtin_inttypes",
+        ":_inttypes",
+        ":_fenv",
+        ":_ctype",
+        ":runetype",
+        ":_Builtin_stdint",
+        ":_stdint",
+        ":_complex",
+        ":_assert",
+        ":TargetConditionals",
+        ":unistd_swift",
+        ":unistd",
+        ":gethostuuid",
+        ":uuid",
+        ":sys_select",
+        ":_limits",
+        ":sys_time_swift",
+        ":sys_time",
+        ":_time_swift",
+        ":_time",
+        ":_stdio_swift",
+        ":_stdio",
+        ":_signal_swift",
+        ":_signal",
+        ":sys_types",
+        ":_sys_select",
+        ":_useconds_t",
+        ":netinet_in",
+        ":mach",
+        ":_math_swift",
+        ":_math",
+        ":_errno_swift",
+        ":_errno",
+        ":DarwinFoundation",
+        ":_Builtin_stddef",
+        ":_Builtin_stdarg",
+        ":os_availability",
+        ":os_availability_internal",
+        ":ptrcheck",
+        ":_Builtin_float_swift",
+        ":_Builtin_float",
+        ":_float",
+        ":_StringProcessing_swift",
+        ":_Concurrency_swift",
+        ":SwiftOnoneSupport_swift",
+        ":Swift_swift",
+        ":SwiftShims",
+        ":CommonCrypto",
+        ":IOKit",
+        ":CommonCrypto_swift",
+        ":ImageIO_swift",
+        ":AppTrackingTransparency_swift",
+        ":notify_swift",
+        ":AdSupport_swift",
+        ":UserNotifications_swift",
+        ":Security_swift",
+        ":CoreVideo_swift",
+        ":CoreServices_swift",
+        ":MobileCoreServices_swift",
+        ":ReplayKit_swift",
+        ":CoreTelephony_swift",
+        ":MachO_swift",
+    ],
+)
+
+swift_library_group(
+    name = "all_generated_testonly_targets",
+    testonly = True,
+    deps = [
+        ":imports_swift",
+        ":XCTest_swift",
+        ":XCTest",
+        ":XCUIAutomation_swift",
+        ":XCUIAutomation",
+    ],
+)

--- a/system_sdks/BUILD
+++ b/system_sdks/BUILD
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library_group")
+package(default_visibility = ["//visibility:public"])
+
+config_setting(
+    name = "xcode_16_3_0_16E140",
+    flag_values = {
+        "@bazel_tools//tools/osx:xcode_version_flag_exact": "16.3.0.16E140",
+    },
+)
+
+swift_library_group(
+    name = "system_sdks",
+    deps = select({
+        ":xcode_16_3_0_16E140": ["//system_sdks/16.3.0.16E140:system_sdks"],
+        "//conditions:default": [],
+    }),
+)
+
+swift_library_group(
+    name = "testonly_system_sdks",
+    testonly = True,
+    deps = select({
+        ":xcode_16_3_0_16E140": ["//system_sdks/16.3.0.16E140:testonly_system_sdks"],
+        "//conditions:default": [],
+    }),
+)

--- a/system_sdks/README.md
+++ b/system_sdks/README.md
@@ -1,0 +1,1 @@
+TODO : convert sdk discovery repo rule into python script and add instructions on how to update the BUILD files.

--- a/system_sdks/swift_c_module.bzl
+++ b/system_sdks/swift_c_module.bzl
@@ -1,0 +1,194 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the `swift_c_module` rule."""
+
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@build_bazel_rules_swift//swift:providers.bzl", "SwiftInfo", "create_clang_module_inputs", "create_swift_module_context")
+load("@build_bazel_rules_swift//swift:swift_common.bzl", "swift_common")
+load("@build_bazel_rules_swift//swift/internal:compiling.bzl", "precompile_clang_module")
+load("@build_bazel_rules_swift//swift/internal:feature_names.bzl", "SWIFT_FEATURE_SYSTEM_MODULE")
+load("@build_bazel_rules_swift//swift/internal:utils.bzl", "merge_runfiles")
+load("@build_bazel_rules_swift//swift/internal:toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
+
+def _swift_c_module_impl(ctx):
+    if (
+        (ctx.file.module_map and ctx.attr.system_module_map) or
+        (not ctx.file.module_map and not ctx.attr.system_module_map)
+    ):
+        fail("Must specify one (and only one) of module_map and system_module_map.")
+    swift_toolchain = swift_common.get_toolchain(ctx)
+    module_map = ctx.file.module_map or ctx.attr.system_module_map
+    is_system = True if ctx.attr.system_module_map else False
+
+    deps = ctx.attr.deps
+
+    if ctx.attr.module_name in ("XCTest", "XCUIAutomation", "StoreKitTest"):
+        framework_dir = paths.dirname(paths.dirname(paths.dirname(module_map)))
+        compilation_context_for_system_module = cc_common.create_compilation_context(framework_includes = depset([framework_dir]),)
+    else:
+        compilation_context_for_system_module = cc_common.create_compilation_context()
+
+    cc_info_for_system_module = CcInfo(compilation_context = compilation_context_for_system_module)
+
+    cc_infos = [cc_info_for_system_module] + [dep[CcInfo] for dep in deps]
+    swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
+    data_runfiles = [dep[DefaultInfo].data_runfiles for dep in deps]
+    default_runfiles = [dep[DefaultInfo].default_runfiles for dep in deps]
+
+    if cc_infos:
+        cc_info = cc_common.merge_cc_infos(cc_infos = cc_infos)
+        compilation_context = cc_info.compilation_context
+    else:
+        compilation_context = cc_common.create_compilation_context()
+        cc_info = CcInfo(compilation_context = compilation_context)
+
+    requested_features = ctx.features
+    if is_system:
+        requested_features.append(SWIFT_FEATURE_SYSTEM_MODULE)
+
+    feature_configuration = swift_common.configure_features(
+        ctx = ctx,
+        requested_features = requested_features,
+        swift_toolchain = swift_toolchain,
+    )
+
+    module_name = ctx.attr.module_name
+
+    pcm_outputs = precompile_clang_module(
+        actions = ctx.actions,
+        cc_compilation_context = compilation_context,
+        feature_configuration = feature_configuration,
+        module_map_file = module_map,
+        module_name = module_name,
+        swift_infos = swift_infos,
+        swift_toolchain = swift_toolchain,
+        target_name = ctx.attr.name,
+        toolchain_type = SWIFT_TOOLCHAIN_TYPE,
+    )
+    precompiled_module = getattr(pcm_outputs, "pcm_file", None)
+
+    clang_module_context = create_clang_module_inputs(
+        compilation_context = cc_info.compilation_context,
+        module_map = module_map,
+        precompiled_module = precompiled_module,
+    )
+    providers = [
+        # We must repropagate the dependencies' DefaultInfos, otherwise we
+        # will lose runtime dependencies that the library expects to be
+        # there during a test (or a regular `bazel run`).
+        DefaultInfo(
+            data_runfiles = merge_runfiles(data_runfiles),
+            default_runfiles = merge_runfiles(default_runfiles),
+            files = depset([module_map]) if not is_system else None,
+        ),
+        SwiftInfo(
+            modules = [
+                create_swift_module_context(
+                    name = module_name,
+                    clang = clang_module_context,
+                ),
+            ],
+            swift_infos = swift_infos,
+        ),
+        cc_info,
+    ]
+
+    return providers
+
+swift_c_module = rule(
+    attrs = dicts.add(
+        {
+            "deps": attr.label_list(
+                allow_empty = True,
+                doc = """\
+A list of C targets (or anything propagating `CcInfo`) that are dependencies of
+this target and whose headers may be referenced by the module map.
+""",
+                mandatory = False,
+                providers = [[CcInfo]],
+            ),
+            "module_map": attr.label(
+                allow_single_file = True,
+                doc = """\
+The module map file that should be loaded to import the C library dependency
+into Swift. This is mutally exclusive with `system_module_map`.
+""",
+                mandatory = False,
+            ),
+            "module_name": attr.string(
+                doc = """\
+The name of the top-level module in the module map that this target represents.
+
+A single `module.modulemap` file can define multiple top-level modules. When
+building with implicit modules, the presence of that module map allows any of
+the modules defined in it to be imported. When building explicit modules,
+however, there is a one-to-one correspondence between top-level modules and
+BUILD targets and the module name must be known without reading the module map
+file, so it must be provided directly. Therefore, one may have multiple
+`swift_c_module` targets that reference the same `module.modulemap` file but
+with different module names and headers.
+""",
+                mandatory = True,
+            ),
+            "system_module_map": attr.string(
+                doc = """\
+The path to a system framework module map. This is mutually exclusive with `module_map`.
+
+Variables `__BAZEL_XCODE_SDKROOT__` and `__BAZEL_XCODE_DEVELOPER_DIR__` will be substitued
+appropriately for, i.e.
+`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`
+and
+`/Applications/Xcode.app/Contents/Developer` respectively.
+""",
+                mandatory = False,
+            ),
+        },
+    ),
+    doc = """\
+Wraps one or more C targets in a new module map that allows it to be imported
+into Swift to access its C interfaces.
+
+The `cc_library` rule in Bazel does not produce module maps that are compatible
+with Swift. In order to make interop between Swift and C possible, users have
+one of two options:
+
+1.  **Use an auto-generated module map.** In this case, the `swift_c_module`
+    rule is not needed. If a `cc_library` is a direct dependency of a
+    `swift_{binary,library,test}` target, a module map will be automatically
+    generated for it and the module's name will be derived from the Bazel target
+    label (in the same fashion that module names for Swift targets are derived).
+    The module name can be overridden by setting the `swift_module` tag on the
+    `cc_library`; e.g., `tags = ["swift_module=MyModule"]`.
+
+2.  **Use a custom module map.** For finer control over the headers that are
+    exported by the module, use the `swift_c_module` rule to provide a custom
+    module map that specifies the name of the module, its headers, and any other
+    module information. The `cc_library` targets that contain the headers that
+    you wish to expose to Swift should be listed in the `deps` of your
+    `swift_c_module` (and by listing multiple targets, you can export multiple
+    libraries under a single module if desired). Then, your
+    `swift_{binary,library,test}` targets should depend on the `swift_c_module`
+    target, not on the underlying `cc_library` target(s).
+
+NOTE: Swift at this time does not support interop directly with C++. Any headers
+referenced by a module map that is imported into Swift must have only C features
+visible, often by using preprocessor conditions like `#if __cplusplus` to hide
+any C++ declarations.
+""",
+    implementation = _swift_c_module_impl,
+    toolchains = swift_common.use_toolchain(),
+    fragments = ["cpp"],
+)


### PR DESCRIPTION
## **Why should we adopt explicit modules?**
1. Faster build speed : Having explicit clang modules lets Bazel schedule actions more efficiently. 
2. Faster LLDB debugger : Having explicit clang modules lets LLDB reuse bazel build outputs 
3. Apple 🍏 : explicit modules are enabled for swift targets by default starting from Xcode 26.  

## Example for explicit clang module usage

This pull request introduces partial support for explicit system C module dependencies in Swift builds using Bazel (feature request can be found here https://github.com/bazelbuild/rules_swift/issues/1475). The changes add new rules and attributes to propagate and manage system C modules, making it easier to handle Swift interop with C/Objective-C code, particularly when using explicit modules. It also introduces new build targets to represent system SDKs for different platforms and Xcode versions.

### Key changes include:

**System SDKs and C Module Support:**
- Added previously deleted `swift_c_module` rule to wrap C targets with custom module maps for Swift interop, supporting both user-supplied and system module maps. This enables explicit C module usage in Swift targets.
- Introduced new `system_sdks` and `testonly_system_sdks` targets in `system_sdks/BUILD` and `system_sdks/16.3.0.16E140/BUILD` to represent platform-specific system SDKs, selected by Xcode version and platform constraints. 

**Swift Rule and Attribute Changes:**
- Added a `system_deps` attribute to `swift_library`, allowing explicit specification of system module dependencies. These are automatically set to include `//system_sdks:system_sdks` for migration convenience.
- Updated `swift_library` implementation to propagate system module dependencies' `SwiftInfo` when the relevant features are enabled, integrating system modules into the build graph.
- Updated feature handling to support new C module features (`SWIFT_FEATURE_USE_C_MODULES`, `SWIFT_FEATURE_EMIT_C_MODULE`).

**Interop Hint and Info Propagation:**
- Extended `swift_interop_hint` and `swift_interop_info` to accept and propagate `system_pcms`, a list of precompiled Clang modules for system modules, ensuring these dependencies are correctly wired into Swift compilation.
- Updated the aspect logic to append `system_pcms` to the set of propagated `SwiftInfo` providers, ensuring system modules are available where needed.
- Added use of `swift_interop_hint` in example targets to demonstrate system PCM wiring.

**Build and Toolchain Integration:**
- Integrated new action for precompiling C modules into the toolchain configuration.

These changes lay the groundwork for robust, explicit Swift-C interop in Bazel builds, particularly as the ecosystem moves toward explicit C module adoption.

### **Couple things to note**
1. I used `swift_c_module` rules which was deleted in this [commit](https://github.com/bazelbuild/rules_swift/commit/2cfb111db3e9c5792cf02208b47b9ca9fc1a4745) to expose system sdks to swift libraries. This rule does extra stuff and a new rule should be written for providing only necessary information to the provider. 
2. I originally used @dierksen's repo rule for generating system sdks BUILD file, but moved on to adding static BUILD file for each SDK type and each Xcode type because a) the repo rule generates partially correct output which needs manual postprocessing b) even for one Xcode version, running the repo rule for each sdk takes 60 seconds on a clean slate. Ideally, we should have a rule that can create system sdks BUILD files completely and quickly. Having a standalone script that does the work would be also a good first step. 
3. Also note that I only created the BUILD file for Xcode 16.3 so if you want to try out, you should have Xcode 16.3 installed locally.
4. I made some changes to `swift_interop_hint` and `swift_library` to add all found system sdks as dependencies because a) make the transition to explicit module incur less friction b) in swift objc interop, both swift library and objc library needs to depend on the same system sdk targets (otherwise, compilation fails due to duplicate definition)

### **What needs to be done**
1. Write a rule as an alternative to `swift_c_module`
2. Create a programmatic way to performantly generate complete system sdks build files for an arbitrary Xcode version and sdk target platform
3. Move away from bulk passing all system sdks as deps, and pass individual system sdk target as dependencies 
