### PR TITLE
Add needed features for hermetic builds on linux.

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -353,8 +353,8 @@ void PosixSpawnIORedirector::ConsumeAllSubprocessOutput(
 // are controlled by the lifetime of the strings in args.
 std::vector<const char *> ConvertToCArgs(const std::vector<std::string> &args) {
   std::vector<const char *> c_args;
-  std::string filename = std::filesystem::path(args[0]).filename().string();
-  c_args.push_back(&*std::next(args[0].rbegin(), filename.length() - 1));
+  // Keep full path so Swift driver can find swift-frontend relative to argv[0]
+  c_args.push_back(args[0].c_str());
   for (int i = 1; i < args.size(); i++) {
     c_args.push_back(args[i].c_str());
   }


### PR DESCRIPTION
1. `tools/common/process.cc`** - Keep full path in argv[0]
```cpp
// Keep full path so Swift driver can find swift-frontend relative to argv[0]
c_args.push_back(args[0].c_str());
```

**2. `swift/toolchains/swift_toolchain.bzl`** - Enable sandboxed builds with hermetic toolchain
- Added `toolchain_files` attribute to pass toolchain files as tracked dependencies
- Pass `toolchain_files` to `additional_tools` for compile actions
- Pass `toolchain_files` to `additional_inputs` in linker's `CcInfo`

I ran the tests, and got some failures, but they were the same as on the main branch. I'm not attached to this approach, but it works for me. Here's an excerpt from my MODULE.bazel:

```
###############################################################################
# Swift toolchains
###############################################################################

http_archive(
    name = "swift_linux_x86_64",
    build_file_content = """
package(default_visibility = ["//visibility:public"])

filegroup(
    name = "usr",
    srcs = glob(["usr/**/*"]),
)

# Runtime libraries needed at execution time
filegroup(
    name = "runtime_libs",
    srcs = glob(["usr/lib/swift/linux/*.so"]),
)

# Create a version file for the toolchain
genrule(
    name = "version_file",
    outs = ["swift_version.txt"],
    cmd = "echo '6.0.3' > $@",
    visibility = ["//visibility:public"],
)

exports_files(glob(["usr/**/*"]))
""",
    sha256 = "09d0a53fbddf2878673dd12c1504e7143c788f195caec9f2329740946eba525c",
    strip_prefix = "swift-6.0.3-RELEASE-ubuntu22.04",
    urls = ["https://download.swift.org/swift-6.0.3-release/ubuntu2204/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE-ubuntu22.04.tar.gz"],
)

# Register hermetic Swift toolchain (overrides auto-detected system Swift)
register_toolchains("//tools/swift:hermetic_swift_linux_x86_64_toolchain")

###############################################################################
# Hermetic LLVM wrapper
###############################################################################

bazel_dep(name = "toolchains_llvm", version = "1.5.0")

# Configure and register the toolchain.
llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
llvm.toolchain(
    llvm_version = "17.0.6",
)
use_repo(llvm, "llvm_toolchain")
use_repo(llvm, "llvm_toolchain_llvm")

register_toolchains("@llvm_toolchain//:all")
```