### PR TITLE
Avoid emitting `-LNone` in `developer_dirs_linkopts` on Linux

### DIFF
--- a/swift/internal/developer_dirs.bzl
+++ b/swift/internal/developer_dirs.bzl
@@ -39,9 +39,12 @@ def developer_dirs_linkopts(developer_dirs):
     swift_developer_lib_dir_path = swift_developer_lib_dir(
         developer_dirs,
     )
-    return [
-        "-L%s" % swift_developer_lib_dir_path,
-    ] + [
+    linkopts = [
         "-F%s" % developer_framework.path
         for developer_framework in developer_dirs
     ]
+    if swift_developer_lib_dir_path:
+        linkopts = [
+            "-L%s" % swift_developer_lib_dir_path,
+        ] + linkopts
+    return linkopts

--- a/test/utils_tests.bzl
+++ b/test/utils_tests.bzl
@@ -3,10 +3,10 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:extensions/standalone_toolchain.bzl", "get_download_url")
+load("//swift/internal:developer_dirs.bzl", "developer_dirs_linkopts")
 
 # buildifier: disable=bzl-visibility
-load("//swift/internal:developer_dirs.bzl", "developer_dirs_linkopts")
+load("//swift/internal:extensions/standalone_toolchain.bzl", "get_download_url")
 
 # buildifier: disable=bzl-visibility
 load("//swift/internal:utils.bzl", "include_developer_search_paths")

--- a/test/utils_tests.bzl
+++ b/test/utils_tests.bzl
@@ -6,6 +6,9 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//swift/internal:extensions/standalone_toolchain.bzl", "get_download_url")
 
 # buildifier: disable=bzl-visibility
+load("//swift/internal:developer_dirs.bzl", "developer_dirs_linkopts")
+
+# buildifier: disable=bzl-visibility
 load("//swift/internal:utils.bzl", "include_developer_search_paths")
 
 def _include_developer_search_paths_test(ctx):
@@ -76,6 +79,50 @@ testonly is true, always_include_developer_search_paths is true\
 
 include_developer_search_paths_test = unittest.make(_include_developer_search_paths_test)
 
+def _developer_dirs_linkopts_test(ctx):
+    env = unittest.begin(ctx)
+
+    tests = [
+        struct(
+            msg = "Empty developer dirs should not emit any linker flags",
+            developer_dirs = [],
+            exp = [],
+        ),
+        struct(
+            msg = "Non-platform developer dirs should emit only framework search paths",
+            developer_dirs = [
+                struct(
+                    developer_path_label = "developer",
+                    path = "/tmp/dev-frameworks",
+                ),
+            ],
+            exp = [
+                "-F/tmp/dev-frameworks",
+            ],
+        ),
+        struct(
+            msg = "Platform developer dirs should emit swift lib and framework search paths",
+            developer_dirs = [
+                struct(
+                    developer_path_label = "platform",
+                    path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+                ),
+            ],
+            exp = [
+                "-L/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib",
+                "-F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks",
+            ],
+        ),
+    ]
+
+    for t in tests:
+        actual = developer_dirs_linkopts(t.developer_dirs)
+        asserts.equals(env, t.exp, actual, t.msg)
+
+    return unittest.end(env)
+
+developer_dirs_linkopts_test = unittest.make(_developer_dirs_linkopts_test)
+
 def _standalone_toolchain_download_url_test(ctx):
     env = unittest.begin(ctx)
 
@@ -124,6 +171,7 @@ standalone_toolchain_download_url_test = unittest.make(_standalone_toolchain_dow
 def utils_test_suite(name):
     return unittest.suite(
         name,
+        developer_dirs_linkopts_test,
         include_developer_search_paths_test,
         standalone_toolchain_download_url_test,
     )


### PR DESCRIPTION
When `developer_dirs` is empty, `swift_developer_lib_dir(...)` returns `None`. `developer_dirs_linkopts(...)` was still formatting that value as a library search path, which produced `-LNone` in the final link command.

Fix this by only adding the `-L...` flag when a real Swift developer library directory exists, and add unit tests covering empty, non-platform, and platform developer dir cases.

Fixes #1669 