### PR TITLE
Use linker placeholder for custom Xcode toolchains

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -780,13 +780,11 @@ def _xcode_swift_toolchain_impl(ctx):
     toolchain_root = ctx.var.get("SWIFT_USE_TOOLCHAIN_ROOT")
 
     custom_toolchain = ctx.configuration.default_shell_env.get("TOOLCHAINS")
-    custom_xcode_swift_toolchain_root = None
     custom_xcode_linker_toolchain_root = None
     if toolchain_root and custom_toolchain:
         fail("Do not use SWIFT_USE_TOOLCHAIN_ROOT and TOOLCHAINS" +
              "in the same build.")
     elif custom_toolchain:
-        custom_xcode_swift_toolchain_root = "__BAZEL_SWIFT_TOOLCHAIN_PATH__"
         custom_xcode_linker_toolchain_root = "__BAZEL_CUSTOM_XCODE_TOOLCHAIN_PATH__"
 
     swift_linkopts_cc_info = _swift_linkopts_cc_info(

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -780,18 +780,20 @@ def _xcode_swift_toolchain_impl(ctx):
     toolchain_root = ctx.var.get("SWIFT_USE_TOOLCHAIN_ROOT")
 
     custom_toolchain = ctx.configuration.default_shell_env.get("TOOLCHAINS")
-    custom_xcode_toolchain_root = None
+    custom_xcode_swift_toolchain_root = None
+    custom_xcode_linker_toolchain_root = None
     if toolchain_root and custom_toolchain:
         fail("Do not use SWIFT_USE_TOOLCHAIN_ROOT and TOOLCHAINS" +
              "in the same build.")
     elif custom_toolchain:
-        custom_xcode_toolchain_root = "__BAZEL_SWIFT_TOOLCHAIN_PATH__"
+        custom_xcode_swift_toolchain_root = "__BAZEL_SWIFT_TOOLCHAIN_PATH__"
+        custom_xcode_linker_toolchain_root = "__BAZEL_CUSTOM_XCODE_TOOLCHAIN_PATH__"
 
     swift_linkopts_cc_info = _swift_linkopts_cc_info(
         apple_toolchain = apple_toolchain,
         target_triple = target_triple,
         toolchain_label = ctx.label,
-        toolchain_root = toolchain_root or custom_xcode_toolchain_root,
+        toolchain_root = toolchain_root or custom_xcode_linker_toolchain_root,
         xcode_config = xcode_config,
     )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -6,6 +6,7 @@ load(":cc_library_tests.bzl", "cc_library_test_suite")
 load(":compiler_arguments_tests.bzl", "compiler_arguments_test_suite")
 load(":const_values_tests.bzl", "const_values_test_suite")
 load(":coverage_settings_tests.bzl", "coverage_settings_test_suite")
+load(":custom_toolchain_linking_tests.bzl", "custom_toolchain_linking_test_suite")
 load(":debug_settings_tests.bzl", "debug_settings_test_suite")
 load(":environment_tests.bzl", "environment_test_suite")
 load(":features_tests.bzl", "features_test_suite")
@@ -43,6 +44,8 @@ compiler_arguments_test_suite(name = "compiler_arguments")
 const_values_test_suite(name = "const_values")
 
 coverage_settings_test_suite(name = "coverage_settings")
+
+custom_toolchain_linking_test_suite(name = "custom_toolchain_linking")
 
 debug_settings_test_suite(name = "debug_settings")
 

--- a/test/custom_toolchain_linking_tests.bzl
+++ b/test/custom_toolchain_linking_tests.bzl
@@ -32,6 +32,22 @@ def custom_toolchain_linking_test_suite(name, tags = []):
             "__BAZEL_SWIFT_TOOLCHAIN_PATH__/usr/lib/swift/macosx",
         ],
         tags = all_tags,
+        target_compatible_with = ["@platforms//os:macos"],
+        target_under_test = "//test/fixtures/linking:bin",
+    )
+
+    custom_toolchain_linking_test(
+        name = "{}_uses_local_linux_toolchain".format(name),
+        expected_argv = [
+            "/usr/lib/swift/linux",
+        ],
+        mnemonic = "CppLink",
+        not_expected_argv = [
+            "__BAZEL_SWIFT_TOOLCHAIN_PATH__/usr/lib/swift/macosx",
+            "__BAZEL_CUSTOM_XCODE_TOOLCHAIN_PATH__",
+        ],
+        tags = all_tags,
+        target_compatible_with = ["@platforms//os:linux"],
         target_under_test = "//test/fixtures/linking:bin",
     )
 

--- a/test/custom_toolchain_linking_tests.bzl
+++ b/test/custom_toolchain_linking_tests.bzl
@@ -1,0 +1,41 @@
+"""Tests for custom toolchain linker placeholder handling."""
+
+load(
+    "//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
+
+custom_toolchain_linking_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:action_env": [
+            "TOOLCHAINS=test.toolchain.id",
+        ],
+    },
+)
+
+def custom_toolchain_linking_test_suite(name, tags = []):
+    """Test suite for custom toolchain linker placeholders.
+
+    Args:
+        name: The base name to be used in targets created by this macro.
+        tags: Additional tags to apply to each test.
+    """
+    all_tags = [name] + tags
+
+    custom_toolchain_linking_test(
+        name = "{}_uses_linker_placeholder".format(name),
+        expected_argv = [
+            "-L__BAZEL_CUSTOM_XCODE_TOOLCHAIN_PATH__/usr/lib/swift/macosx",
+        ],
+        mnemonic = "CppLink",
+        not_expected_argv = [
+            "__BAZEL_SWIFT_TOOLCHAIN_PATH__/usr/lib/swift/macosx",
+        ],
+        tags = all_tags,
+        target_under_test = "//test/fixtures/linking:bin",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = all_tags,
+    )


### PR DESCRIPTION
rules_swift currently reuses the Swift worker placeholder for linker search paths when `TOOLCHAINS` selects a custom macOS toolchain. That leaves `__BAZEL_SWIFT_TOOLCHAIN_PATH__` unresolved in CppLink actions, which produces a warning during linking.

Split the custom toolchain placeholders so Swift-side behavior keeps using `__BAZEL_SWIFT_TOOLCHAIN_PATH__` while linker flags use `__BAZEL_CUSTOM_XCODE_TOOLCHAIN_PATH__`, which `apple_support` already substitutes for link actions.

Fixes #1672