### PR TITLE
3.x: Explicitly pass .swiftmodule and .swiftinterface files as action inputs

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -4,7 +4,7 @@ x_defaults:
   # it doesn't know about; so that is used to avoid repeating common subparts.
   mac_common: &mac_common
     platform: macos_arm64
-    xcode_version: "16.4"
+    xcode_version: "26.2"
     build_targets:
       - "//examples/..."
     test_targets:

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -88,6 +88,35 @@ load(":wmo.bzl", "find_num_threads_flag_value", "is_wmo_manually_requested")
 # SWIFT_FEATURE_VFSOVERLAY is enabled.
 _SWIFTMODULES_VFS_ROOT = "/__build_bazel_rules_swift/swiftmodules"
 
+def transitive_swift_dependency_inputs(transitive_modules):
+    """Returns Swift dependency artifacts that must be present in the sandbox.
+
+    Args:
+        transitive_modules: A list of transitive Swift module contexts.
+
+    Returns:
+        A list of `.swiftmodule` files and the preferred textual interface file
+        for each Swift dependency.
+    """
+    inputs = []
+
+    for module in transitive_modules:
+        swift_module = module.swift
+        if not swift_module:
+            continue
+
+        if swift_module.swiftmodule:
+            inputs.append(swift_module.swiftmodule)
+
+        interface_file = (
+            swift_module.private_swiftinterface or
+            swift_module.swiftinterface
+        )
+        if interface_file:
+            inputs.append(interface_file)
+
+    return inputs
+
 def create_compilation_context(defines, srcs, transitive_modules):
     """Cretes a compilation context for a Swift target.
 
@@ -219,6 +248,9 @@ def compile_module_interface(
         if not swift_module:
             continue
         transitive_swiftmodules.append(swift_module.swiftmodule)
+    transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
+        transitive_modules,
+    )
 
     if clang_module:
         transitive_modules.append(create_swift_module_context(
@@ -275,6 +307,7 @@ def compile_module_interface(
         swiftmodule_file = swiftmodule_file,
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
+        transitive_swift_dependency_inputs = transitive_swift_dependency_inputs_list,
         transitive_swiftmodules = transitive_swiftmodules,
         user_compile_flags = copts,
         vfsoverlay_file = vfsoverlay_file,
@@ -579,6 +612,9 @@ def compile(
                 defines_set,
                 sets.make(swift_module.defines),
             )
+    transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
+        transitive_modules,
+    )
 
     # We need this when generating the VFS overlay file and also when
     # configuring inputs for the compile action, so it's best to precompute it
@@ -672,6 +708,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         source_files = srcs,
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
+        transitive_swift_dependency_inputs = transitive_swift_dependency_inputs_list,
         transitive_swiftmodules = transitive_swiftmodules,
         upcoming_features = upcoming_features,
         user_compile_flags = copts,

--- a/swift/internal/interface_synthesizing.bzl
+++ b/swift/internal/interface_synthesizing.bzl
@@ -17,6 +17,7 @@
 load("//swift:providers.bzl", "SwiftInfo")
 load(":action_names.bzl", "SWIFT_ACTION_SYNTHESIZE_INTERFACE")
 load(":actions.bzl", "run_toolchain_action")
+load(":compiling.bzl", "transitive_swift_dependency_inputs")
 load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(":utils.bzl", "merge_compilation_contexts")
 
@@ -74,6 +75,9 @@ def synthesize_interface(
         swift_module = module.swift
         if swift_module:
             transitive_swiftmodules.append(swift_module.swiftmodule)
+    transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
+        transitive_modules,
+    )
 
     prerequisites = struct(
         bin_dir = feature_configuration._bin_dir,
@@ -84,6 +88,7 @@ def synthesize_interface(
         output_file = output_file,
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
+        transitive_swift_dependency_inputs = transitive_swift_dependency_inputs_list,
         transitive_swiftmodules = transitive_swiftmodules,
     )
 

--- a/swift/internal/symbol_graph_extracting.bzl
+++ b/swift/internal/symbol_graph_extracting.bzl
@@ -17,6 +17,7 @@
 load("//swift:providers.bzl", "SwiftInfo")
 load(":action_names.bzl", "SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT")
 load(":actions.bzl", "run_toolchain_action")
+load(":compiling.bzl", "transitive_swift_dependency_inputs")
 load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
 load(":utils.bzl", "merge_compilation_contexts")
 
@@ -96,6 +97,9 @@ def extract_symbol_graph(
             transitive_swiftmodules.append(swift_module.swiftmodule)
             if module.name == module_name and swift_module.swiftdoc:
                 direct_swiftdocs.append(swift_module.swiftdoc)
+    transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
+        transitive_modules,
+    )
 
     prerequisites = struct(
         bin_dir = feature_configuration._bin_dir,
@@ -111,6 +115,7 @@ def extract_symbol_graph(
         output_dir = output_dir,
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
+        transitive_swift_dependency_inputs = transitive_swift_dependency_inputs_list,
         transitive_swiftmodules = transitive_swiftmodules,
     )
 

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -2071,7 +2071,7 @@ def _module_alias_map_fn(module):
         return None
 
 def _dependencies_swiftmodules_and_swiftdocs_configurator(prerequisites, args):
-    """Adds `.swiftmodule` and `.swiftdoc` files from the transitive modules to search paths and action inputs."""
+    """Adds Swift dependency search paths and `.swiftdoc` action inputs."""
     args.add_all(
         prerequisites.transitive_modules,
         format_each = "-I%s",
@@ -2080,12 +2080,12 @@ def _dependencies_swiftmodules_and_swiftdocs_configurator(prerequisites, args):
     )
 
     return ConfigResultInfo(
-        inputs = prerequisites.transitive_swiftmodules +
+        inputs = prerequisites.transitive_swift_dependency_inputs +
                  prerequisites.direct_swiftdocs,
     )
 
 def _dependencies_swiftmodules_configurator(prerequisites, args):
-    """Adds `.swiftmodule` files from deps to search paths and action inputs."""
+    """Adds Swift dependency search paths and action inputs."""
     args.add_all(
         prerequisites.transitive_modules,
         format_each = "-I%s",
@@ -2094,7 +2094,7 @@ def _dependencies_swiftmodules_configurator(prerequisites, args):
     )
 
     return ConfigResultInfo(
-        inputs = prerequisites.transitive_swiftmodules,
+        inputs = prerequisites.transitive_swift_dependency_inputs,
     )
 
 def _module_aliases_configurator(prerequisites, args):
@@ -2152,7 +2152,6 @@ def _plugin_search_paths_configurator(prerequisites, args):
 
 def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args, is_frontend = False):
     """Provides a single `.swiftmodule` search path using a VFS overlay."""
-    swiftmodules = prerequisites.transitive_swiftmodules
 
     # Bug: `swiftc` doesn't pass its `-vfsoverlay` arg to the frontend.
     # Workaround: Pass `-vfsoverlay` directly via `-Xfrontend`.
@@ -2165,7 +2164,9 @@ def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args, is_f
     )
 
     return ConfigResultInfo(
-        inputs = swiftmodules + [prerequisites.vfsoverlay_file],
+        inputs = prerequisites.transitive_swift_dependency_inputs + [
+            prerequisites.vfsoverlay_file,
+        ],
     )
 
 def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = False):
@@ -2186,7 +2187,7 @@ def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = F
             before_each = "-Xfrontend",
         )
     return ConfigResultInfo(
-        inputs = prerequisites.transitive_swiftmodules + [
+        inputs = prerequisites.transitive_swift_dependency_inputs + [
             prerequisites.explicit_swift_module_map_file,
         ],
     )

--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -16,6 +16,25 @@ swift_binary(
     deps = [":toy_module"],
 )
 
+swift_binary(
+    name = "transitive_client",
+    srcs = ["TransitiveClient.swift"],
+    tags = FIXTURE_TAGS,
+    deps = [":dependent_toy_module"],
+)
+
+swift_import(
+    name = "dependent_toy_module",
+    archives = [
+        "//test/fixtures/module_interface/library:toy_outputs/libDependentToyModule.a",
+    ],
+    module_name = "DependentToyModule",
+    swiftdoc = "//test/fixtures/module_interface/library:toy_outputs/DependentToyModule.swiftdoc",
+    swiftinterface = "//test/fixtures/module_interface/library:toy_outputs/DependentToyModule.swiftinterface",
+    tags = FIXTURE_TAGS,
+    deps = [":toy_module"],
+)
+
 swift_import(
     name = "toy_module",
     archives = [

--- a/test/fixtures/module_interface/TransitiveClient.swift
+++ b/test/fixtures/module_interface/TransitiveClient.swift
@@ -1,0 +1,24 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import DependentToyModule
+
+@main
+struct Main {
+  static func main() {
+    let value = DependentToyValue(number: 10)
+    print(value.value.stringValue)
+    print(value.value.squared())
+  }
+}

--- a/test/fixtures/module_interface/library/BUILD
+++ b/test/fixtures/module_interface/library/BUILD
@@ -25,6 +25,25 @@ licenses(["notice"])
 # that rule propagates its pre-built inputs in `DefaultInfo`.
 
 swift_library(
+    name = "dependent_toy_module_library",
+    srcs = ["DependentToyModule.swift"],
+    library_evolution = True,
+    module_name = "DependentToyModule",
+    tags = FIXTURE_TAGS,
+    deps = [":toy_module_library"],
+)
+
+swift_library_artifact_collector(
+    name = "dependent_toy_module_artifact_collector",
+    static_library = "toy_outputs/libDependentToyModule.a",
+    swiftdoc = "toy_outputs/DependentToyModule.swiftdoc",
+    swiftinterface = "toy_outputs/DependentToyModule.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target = ":dependent_toy_module_library",
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+swift_library(
     name = "toy_module_library",
     srcs = ["ToyModule.swift"],
     library_evolution = True,

--- a/test/fixtures/module_interface/library/DependentToyModule.swift
+++ b/test/fixtures/module_interface/library/DependentToyModule.swift
@@ -1,0 +1,26 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ToyModule
+
+/// A public wrapper around `ToyValue` used to exercise transitive interfaces.
+public struct DependentToyValue {
+  /// The wrapped value.
+  public let value: ToyValue
+
+  /// Creates a new wrapper around a toy value.
+  public init(number: Int) {
+    value = ToyValue(number: number)
+  }
+}

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -19,6 +19,11 @@ load(
     "//test/rules:action_command_line_test.bzl",
     "make_action_command_line_test_rule",
 )
+load(
+    "//test/rules:action_inputs_test.bzl",
+    "action_inputs_test",
+    "make_action_inputs_test_rule",
+)
 load("//test/rules:provider_test.bzl", "provider_test")
 
 explicit_swift_module_map_test = make_action_command_line_test_rule(
@@ -30,6 +35,22 @@ explicit_swift_module_map_test = make_action_command_line_test_rule(
 )
 
 vfsoverlay_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.vfsoverlay",
+        ],
+    },
+)
+
+explicit_swift_module_map_inputs_test = make_action_inputs_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_explicit_swift_module_map",
+        ],
+    },
+)
+
+vfsoverlay_inputs_test = make_action_inputs_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.vfsoverlay",
@@ -52,6 +73,14 @@ def module_interface_test_suite(name, tags = []):
         name = "{}_swift_binary_imports_swiftinterface".format(name),
         targets = [
             "//test/fixtures/module_interface:client",
+        ],
+        tags = all_tags,
+    )
+
+    build_test(
+        name = "{}_swift_binary_imports_transitive_swiftinterface".format(name),
+        targets = [
+            "//test/fixtures/module_interface:transitive_client",
         ],
         tags = all_tags,
     )
@@ -111,6 +140,52 @@ def module_interface_test_suite(name, tags = []):
         ],
         mnemonic = "SwiftCompileModuleInterface",
         target_under_test = "//test/fixtures/module_interface:toy_module",
+    )
+
+    # Test that dependency swiftinterface files are included as action inputs
+    action_inputs_test(
+        name = "{}_dependencies_included_as_inputs".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "ToyModule.swiftinterface",
+        ],
+        target_under_test = "//test/fixtures/module_interface:toy_module",
+    )
+
+    action_inputs_test(
+        name = "{}_transitive_dependencies_included_as_inputs".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "ToyModule.swiftinterface",
+            "DependentToyModule.swiftinterface",
+        ],
+        target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
+    )
+
+    explicit_swift_module_map_inputs_test(
+        name = "{}_explicit_swift_module_map_dependencies_included_as_inputs".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "ToyModule.swiftinterface",
+            "DependentToyModule.swiftinterface",
+            "dependent_toy_module.swift-explicit-module-map.json",
+        ],
+        target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
+    )
+
+    vfsoverlay_inputs_test(
+        name = "{}_vfsoverlay_dependencies_included_as_inputs".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "ToyModule.swiftinterface",
+            "DependentToyModule.swiftinterface",
+            "dependent_toy_module.vfsoverlay.yaml",
+        ],
+        target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
     )
 
     native.test_suite(

--- a/test/rules/action_inputs_test.bzl
+++ b/test/rules/action_inputs_test.bzl
@@ -1,0 +1,120 @@
+"""Rules for testing action inputs contain expected files."""
+
+load("@bazel_skylib//lib:collections.bzl", "collections")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "unittest")
+
+def _matches_expected_input(expected_input, input_path):
+    if "/" in expected_input:
+        return expected_input == input_path
+    return expected_input == input_path.rsplit("/", 1)[-1]
+
+def _action_inputs_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+
+    actions = analysistest.target_actions(env)
+    mnemonic = ctx.attr.mnemonic
+    matching_actions = [
+        action
+        for action in actions
+        if action.mnemonic == mnemonic
+    ]
+    if not matching_actions:
+        actual_mnemonics = collections.uniq(
+            [action.mnemonic for action in actions],
+        )
+        unittest.fail(
+            env,
+            ("Target '{}' registered no actions with the mnemonic '{}' " +
+             "(it had {}).").format(
+                str(target_under_test.label),
+                mnemonic,
+                actual_mnemonics,
+            ),
+        )
+        return analysistest.end(env)
+    if len(matching_actions) != 1:
+        unittest.fail(
+            env,
+            ("Expected exactly one action with the mnemonic '{}', " +
+             "but found {}.").format(
+                mnemonic,
+                len(matching_actions),
+            ),
+        )
+        return analysistest.end(env)
+
+    action = matching_actions[0]
+    message_prefix = "In {} action for target '{}', ".format(
+        mnemonic,
+        str(target_under_test.label),
+    )
+
+    input_paths = [input.short_path for input in action.inputs.to_list()]
+
+    for expected_input in ctx.attr.expected_inputs:
+        found = False
+        for path in input_paths:
+            if _matches_expected_input(expected_input, path):
+                found = True
+                break
+        if not found:
+            unittest.fail(
+                env,
+                "{}expected inputs to contain '{}' as a filename or path, but it did not. Inputs: {}".format(
+                    message_prefix,
+                    expected_input,
+                    input_paths,
+                ),
+            )
+
+    for not_expected_input in ctx.attr.not_expected_inputs:
+        found = False
+        for path in input_paths:
+            if _matches_expected_input(not_expected_input, path):
+                found = True
+                break
+        if found:
+            unittest.fail(
+                env,
+                "{}expected inputs to not contain '{}' as a filename or path, but it did. Inputs: {}".format(
+                    message_prefix,
+                    not_expected_input,
+                    input_paths,
+                ),
+            )
+
+    return analysistest.end(env)
+
+def make_action_inputs_test_rule(config_settings = {}):
+    """A `action_inputs_test`-like rule with custom configs.
+
+    Args:
+        config_settings: A dictionary of configuration settings and their values
+            that should be applied during tests.
+
+    Returns:
+        A rule returned by `analysistest.make` that has the `action_inputs_test`
+        interface and the given config settings.
+    """
+    return analysistest.make(
+        _action_inputs_test_impl,
+        attrs = {
+            "mnemonic": attr.string(
+                mandatory = True,
+                doc = "The mnemonic of the action to test.",
+            ),
+            "expected_inputs": attr.string_list(
+                default = [],
+                doc = "List of filenames or short_paths that should be present in action inputs.",
+            ),
+            "not_expected_inputs": attr.string_list(
+                default = [],
+                doc = "List of filenames or short_paths that should not be present in action inputs.",
+            ),
+        },
+        config_settings = config_settings,
+    )
+
+# A default instantiation of the rule when no custom config settings are needed.
+action_inputs_test = make_action_inputs_test_rule()


### PR DESCRIPTION
Previously when building `swift_import` targets that depend on other `swift_import` targets with `.swiftinterface` files failed when using Bazel sandbox with error:

```
  cannot open file 'swift-syntax/arm64/SwiftSyntax.private.swiftinterface' (No such file or directory)
```

The `SWIFT_ACTION_COMPILE_MODULE_INTERFACE` action was missing transitive dependency files as inputs so I made sure that they are explicitly listed.

(cherry picked from commit 5c8ae583cb5ab6e83b3f92ea495c1583d02d248d)