### PR TITLE
Pass `--incompatible_enable_proto_toolchain_resolution` for BCR builds

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -23,6 +23,7 @@ tasks:
     shell_commands: *shell_commands
     build_flags:
     - "--action_env=PATH"
+    - "--incompatible_enable_proto_toolchain_resolution"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
     - "-@rules_swift//examples/xplatform/macros/..." # Has a dev dependency


### PR DESCRIPTION
https://buildkite.com/bazel/bcr-presubmit/builds/32291/steps/canvas?jid=019d7875-3706-406a-b84e-7c279f12cf40&tab=output#019d7875-3706-406a-b84e-7c279f12cf40