### PR TITLE
3.x: Stop testing bazel 7 on BCR and enable proto toolchain resolution

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -5,7 +5,6 @@ shell_commands: &shell_commands
 
 matrix:
   bazel:
-  - 7.x
   - 8.x
   # TODO: Re-enable once >10.0.0-pre.20251105.2 is available https://github.com/bazelbuild/bazel/issues/27749
   # - rolling

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -6,8 +6,7 @@ shell_commands: &shell_commands
 matrix:
   bazel:
   - 8.x
-  # TODO: Re-enable once >10.0.0-pre.20251105.2 is available https://github.com/bazelbuild/bazel/issues/27749
-  # - rolling
+  - rolling
   platform:
   - ubuntu2004
 tasks:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -6,6 +6,7 @@ shell_commands: &shell_commands
 matrix:
   bazel:
   - 8.x
+  - 9.x
   - rolling
   platform:
   - ubuntu2004

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -24,6 +24,7 @@ tasks:
     shell_commands: *shell_commands
     build_flags:
     - "--action_env=PATH"
+    - "--incompatible_enable_proto_toolchain_resolution"
     build_targets:
     - "@rules_swift//examples/xplatform/..."
     - "-@rules_swift//examples/xplatform/macros/..." # Has a dev dependency

--- a/test/fixtures/linking/BUILD
+++ b/test/fixtures/linking/BUILD
@@ -61,7 +61,7 @@ bzl_library(
     name = "fake_framework",
     srcs = ["fake_framework.bzl"],
     deps = [
-        "@bazel_tools//tools/cpp:toolchain_utils.bzl",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
         "@rules_cc//cc/common",
     ],
 )

--- a/test/fixtures/linking/fake_framework.bzl
+++ b/test/fixtures/linking/fake_framework.bzl
@@ -1,13 +1,12 @@
 """Simple rule to emulate apple_static_framework_import"""
 
 load(
-    "@bazel_tools//tools/cpp:toolchain_utils.bzl",
-    "use_cpp_toolchain",
+    "@rules_cc//cc:find_cc_toolchain.bzl",
+    "CC_TOOLCHAIN_TYPE",
+    "use_cc_toolchain",
 )
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-
-_CPP_TOOLCHAIN_TYPE = Label("@bazel_tools//tools/cpp:toolchain_type")
 
 def _impl(ctx):
     binary1 = ctx.actions.declare_file("framework1.framework/framework1")
@@ -16,7 +15,7 @@ def _impl(ctx):
     binary2 = ctx.actions.declare_file("framework2.framework/framework2")
     ctx.actions.write(binary2, "empty")
 
-    cc_toolchain = ctx.exec_groups["default"].toolchains[_CPP_TOOLCHAIN_TYPE].cc
+    cc_toolchain = ctx.exec_groups["default"].toolchains[CC_TOOLCHAIN_TYPE].cc
     feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
@@ -53,7 +52,7 @@ fake_framework = rule(
     implementation = _impl,
     attrs = {
         "_cc_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            default = Label("@rules_cc//cc:current_cc_toolchain"),
             doc = "The C++ toolchain to use.",
         ),
     },
@@ -62,7 +61,7 @@ fake_framework = rule(
         # ensures that the execution platform of this Swift toolchain does not
         # unnecessarily constrain the execution platform of the C++ toolchain.
         "default": exec_group(
-            toolchains = use_cpp_toolchain(),
+            toolchains = use_cc_toolchain(),
         ),
     },
     fragments = ["cpp"],


### PR DESCRIPTION
Unblocking 3.x releases.