### PR TITLE
Remove _cc_toolchain attr

### DIFF
--- a/swift/internal/binary_attrs.bzl
+++ b/swift/internal/binary_attrs.bzl
@@ -100,11 +100,6 @@ into the binary. Possible values are:
 """,
                 mandatory = False,
             ),
-            # Do not add references; temporary attribute for C++ toolchain
-            # Starlark migration.
-            "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-            ),
             # A late-bound attribute denoting the value of the `--custom_malloc`
             # command line flag (or None if the flag is not provided).
             "_custom_malloc": attr.label(

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -699,13 +699,6 @@ List of files to carry over as test data to swift executables and tests.
 A list of additional Swift compiler flags that should be passed to Swift compile actions.
 """,
             ),
-            "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-                doc = """\
-The C++ toolchain from which other tools needed by the Swift toolchain (such as
-`clang` and `ar`) will be retrieved.
-""",
-            ),
             "_copts": attr.label(
                 default = Label("//swift:copt"),
                 doc = """\

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -1069,13 +1069,6 @@ A list of additional Objective-C compiler flags that should be passed (preceded 
 to Swift compile actions *and* Swift explicit module precompile actions.
 """,
             ),
-            "_cc_toolchain": attr.label(
-                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
-                doc = """\
-The C++ toolchain from which linking flags and other tools needed by the Swift
-toolchain (such as `clang`) will be retrieved.
-""",
-            ),
             "_copts": attr.label(
                 default = Label("//swift:copt"),
                 doc = """\


### PR DESCRIPTION
Shouldn't be necessary with our uses of `use_cpp_toolchain`

Cherry picked from 319d37f06f9f1e2dc1debf572fa7a9d72cbad36e
