### PR TITLE
Fix new warning when building modules

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1314,6 +1314,18 @@ def compile_action_configs(
                 SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES,
             ],
         ),
+        # Swift 6.2+ warns building swiftmodule files without any -language-mode
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_DERIVE_FILES,
+            ],
+            configurators = [add_arg("-swift-version", "5")],
+            not_features = [
+                SWIFT_FEATURE_ENABLE_V6,
+                SWIFT_FEATURE__SUPPORTS_V6,
+            ],
+        ),
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,

--- a/test/compiler_arguments_tests.bzl
+++ b/test/compiler_arguments_tests.bzl
@@ -30,6 +30,15 @@ full_lto_test = make_action_command_line_test_rule(
     },
 )
 
+swiftcopt_swift_version_test = make_action_command_line_test_rule(
+    config_settings = {
+        str(Label("//swift:copt")): [
+            "-swift-version",
+            "4.2",
+        ],
+    },
+)
+
 def compiler_arguments_test_suite(name, tags = []):
     """Test suite for various command line flags passed to Swift compiles.
 
@@ -101,6 +110,44 @@ def compiler_arguments_test_suite(name, tags = []):
         mnemonic = "SwiftCompile",
         tags = all_tags,
         target_under_test = "//test/fixtures/compiler_arguments:bin",
+    )
+
+    action_command_line_test(
+        name = "{}_default_swift_version".format(name),
+        expected_argv = ["-swift-version 5"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/compiler_arguments:no_package_name",
+    )
+
+    split_test(
+        name = "{}_default_swift_version_in_derive_files".format(name),
+        expected_argv = ["-swift-version 5"],
+        mnemonic = "SwiftDeriveFiles",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/compiler_arguments:no_package_name",
+    )
+
+    action_command_line_test(
+        name = "{}_copts_overrides_default_swift_version".format(name),
+        expected_argv = [
+            "-swift-version 5",
+            "-swift-version 4.2",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/compiler_arguments:lib_with_swift_version_copt",
+    )
+
+    swiftcopt_swift_version_test(
+        name = "{}_swiftcopt_overrides_default_swift_version".format(name),
+        expected_argv = [
+            "-swift-version 5",
+            "-swift-version 4.2",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/compiler_arguments:no_package_name",
     )
 
     native.test_suite(

--- a/test/fixtures/compiler_arguments/BUILD
+++ b/test/fixtures/compiler_arguments/BUILD
@@ -43,3 +43,13 @@ swift_binary(
     srcs = ["empty.swift"],
     tags = FIXTURE_TAGS,
 )
+
+swift_library(
+    name = "lib_with_swift_version_copt",
+    srcs = ["empty.swift"],
+    copts = [
+        "-swift-version",
+        "4.2",
+    ],
+    tags = FIXTURE_TAGS,
+)


### PR DESCRIPTION
```
INFO: From Compiling Swift module //test/fixtures/module_interface/library:dependent_toy_module_library:
  <unknown>:0: warning: emitting module interface files requires '-language-mode'
```
