### PR TITLE
Partially fix swiftly usage

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -13,7 +13,6 @@ x_defaults:
   linux_environment: &linux_environment
     platform: ubuntu2204
     environment:
-      CC: clang
       SWIFT_VERSION: "6.0.3"
       SWIFT_HOME: "$HOME/swift-$SWIFT_VERSION"
       PATH: "$SWIFT_HOME/usr/bin:$PATH"

--- a/.bazelrc
+++ b/.bazelrc
@@ -31,10 +31,8 @@ build --worker_sandboxing
 
 build --enable_platform_specific_config
 
-# The CNIOBoringSSL library uses C++14 features like 'enable_if_t' macro support.
-# For more details on how to enable this in Bazel:
-# https://stackoverflow.com/questions/40260242/how-to-set-c-standard-version-when-build-with-bazel/43388168#43388168
-build:linux --cxxopt='-std=c++14'
+common:linux --repo_env=CC=clang
+build:linux --cxxopt='-std=c++17' --host_cxxopt='-std=c++17'
 
 # This C2K warning causes zlib to fail to compile.
 # There is an open issue about it on the zlib repository here:

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -199,6 +199,21 @@ def _normalized_linux_cpu(cpu):
         return "x86_64"
     return cpu
 
+def _resolve_toolchain_root(repository_ctx, swiftc_path):
+    """Returns the Swift toolchain root directory for `swiftc_path`.
+
+    Swiftly installs a symlink that is changed based on the active toolchain.
+    This resolves that symlink to the actual toolchain directory.
+    """
+    result = repository_ctx.execute([swiftc_path, "-print-target-info"])
+    if result.return_code != 0:
+        fail("Failed to run '{} -print-target-info': {}".format(
+            swiftc_path,
+            result.stderr,
+        ))
+    runtime_resource_path = json.decode(result.stdout)["paths"]["runtimeResourcePath"]
+    return repository_ctx.path(runtime_resource_path).dirname.dirname
+
 def _create_linux_toolchain(*, repository_ctx):
     """Creates BUILD targets for the Swift toolchain on Linux.
 
@@ -212,7 +227,7 @@ def _create_linux_toolchain(*, repository_ctx):
 toolchain.
 """
 
-    root = path_to_swiftc.dirname.dirname
+    root = _resolve_toolchain_root(repository_ctx, path_to_swiftc)
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
     version_file = _write_swift_version(repository_ctx, path_to_swiftc)
 


### PR DESCRIPTION
Previously our logic assumed things about the installation structure of
swift on linux that aren't true when installing with swiftly. Now we
fetch the real canonical path to the installation in any layout.

This doesn't work fully because of rules_cc issues fixed by https://github.com/bazelbuild/rules_cc/pull/706
