### PR TITLE
Add --check_direct_dependencies=off

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+common --check_direct_dependencies=off
+
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 


### PR DESCRIPTION
We mostly let our minimum versions appear in the MODULE.bazel so if
something is being pulled up by a dev dep this warning is just noise
