### PR TITLE
Cherry pick some swiftinterface compile fixes

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ module(
 
 bazel_dep(name = "bazel_features", version = "1.46.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "abseil-cpp", version = "20250814.1")
 bazel_dep(name = "apple_support", version = "1.24.2", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_shell", version = "0.3.0")

--- a/doc/api.md
+++ b/doc/api.md
@@ -275,18 +275,28 @@ Compiles a Swift module interface.
 | <a id="swift_common.compile_module_interface-swiftinterface_file"></a>swiftinterface_file |  The Swift module interface file to compile.   |  none |
 | <a id="swift_common.compile_module_interface-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers from dependencies of the target being compiled.   |  none |
 | <a id="swift_common.compile_module_interface-swift_toolchain"></a>swift_toolchain |  The `SwiftToolchainInfo` provider of the toolchain.   |  `None` |
-| <a id="swift_common.compile_module_interface-target_name"></a>target_name |  The name of the target for which the code is being compiled, which is used to determine unique file paths for the outputs.   |  none |
+| <a id="swift_common.compile_module_interface-target_name"></a>target_name |  The name of the target for which the interface is being compiled, which is used to determine unique file paths for the outputs.   |  none |
 | <a id="swift_common.compile_module_interface-toolchains"></a>toolchains |  The struct containing the Swift and C++ toolchain providers, as returned by `swift_common.find_all_toolchains()`.   |  `None` |
 | <a id="swift_common.compile_module_interface-toolchain_type"></a>toolchain_type |  The toolchain type of the `swift_toolchain` which is used for the proper selection of the execution platform inside `run_toolchain_action`.   |  `Label("@rules_swift//toolchains:toolchain_type")` |
 
 **RETURNS**
 
-A Swift module context (as returned by `create_swift_module_context`)
-  that contains the Swift (and potentially C/Objective-C) compilation
-  prerequisites of the compiled module. This should typically be
-  propagated by a `SwiftInfo` provider of the calling rule, and the
-  `CcCompilationContext` inside the Clang module substructure should be
-  propagated by the `CcInfo` provider of the calling rule.
+A `struct` with the following fields:
+
+  *   `module_context`: A Swift module context (as returned by
+      `create_swift_module_context`) that contains the Swift (and
+      potentially C/Objective-C) compilation prerequisites of the compiled
+      module. This should typically be propagated by a `SwiftInfo`
+      provider of the calling rule, and the `CcCompilationContext` inside
+      the Clang module substructure should be propagated by the `CcInfo`
+      provider of the calling rule.
+
+  *   `supplemental_outputs`: A `struct` representing supplemental,
+      optional outputs. Its fields are:
+
+      *   `indexstore_directory`: A directory-type `File` that represents
+          the indexstore output files created when the feature
+          `swift.index_while_building` is enabled.
 
 
 <a id="swift_common.configure_features"></a>

--- a/doc/api.md
+++ b/doc/api.md
@@ -251,10 +251,10 @@ A `struct` with the following fields:
 ## swift_common.compile_module_interface
 
 <pre>
-swift_common.compile_module_interface(*, <a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>, <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>,
-                                      <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>, <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>,
-                                      <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>, <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>,
-                                      <a href="#swift_common.compile_module_interface-toolchains">toolchains</a>, <a href="#swift_common.compile_module_interface-toolchain_type">toolchain_type</a>)
+swift_common.compile_module_interface(*, <a href="#swift_common.compile_module_interface-actions">actions</a>, <a href="#swift_common.compile_module_interface-additional_inputs">additional_inputs</a>, <a href="#swift_common.compile_module_interface-clang_module">clang_module</a>,
+                                      <a href="#swift_common.compile_module_interface-compilation_contexts">compilation_contexts</a>, <a href="#swift_common.compile_module_interface-copts">copts</a>, <a href="#swift_common.compile_module_interface-exec_group">exec_group</a>, <a href="#swift_common.compile_module_interface-feature_configuration">feature_configuration</a>,
+                                      <a href="#swift_common.compile_module_interface-is_framework">is_framework</a>, <a href="#swift_common.compile_module_interface-module_name">module_name</a>, <a href="#swift_common.compile_module_interface-swiftinterface_file">swiftinterface_file</a>, <a href="#swift_common.compile_module_interface-swift_infos">swift_infos</a>,
+                                      <a href="#swift_common.compile_module_interface-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.compile_module_interface-target_name">target_name</a>, <a href="#swift_common.compile_module_interface-toolchains">toolchains</a>, <a href="#swift_common.compile_module_interface-toolchain_type">toolchain_type</a>)
 </pre>
 
 Compiles a Swift module interface.
@@ -265,6 +265,7 @@ Compiles a Swift module interface.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="swift_common.compile_module_interface-actions"></a>actions |  The context's `actions` object.   |  none |
+| <a id="swift_common.compile_module_interface-additional_inputs"></a>additional_inputs |  A list of `File`s that should be available to the compile action in the sandbox but are not referenced on the command line. The typical use case is making a sibling `.private.swiftinterface` available alongside the public `.swiftinterface` so the compiler can resolve SPI references during the textual-interface build.   |  `[]` |
 | <a id="swift_common.compile_module_interface-clang_module"></a>clang_module |  An optional underlying Clang module (as returned by `create_clang_module_inputs`), if present for this Swift module.   |  `None` |
 | <a id="swift_common.compile_module_interface-compilation_contexts"></a>compilation_contexts |  A list of `CcCompilationContext`s that represent C/Objective-C requirements of the target being compiled, such as Swift-compatible preprocessor defines, header search paths, and so forth. These are typically retrieved from the `CcInfo` providers of a target's dependencies.   |  none |
 | <a id="swift_common.compile_module_interface-copts"></a>copts |  A list of compiler flags that apply to the target being built.   |  `[]` |

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -169,6 +169,7 @@ def create_compilation_context(defines, srcs, transitive_modules):
 def compile_module_interface(
         *,
         actions,
+        additional_inputs = [],
         clang_module = None,
         compilation_contexts,
         copts = [],
@@ -186,6 +187,11 @@ def compile_module_interface(
 
     Args:
         actions: The context's `actions` object.
+        additional_inputs: A list of `File`s that should be available to the
+            compile action in the sandbox but are not referenced on the command
+            line. The typical use case is making a sibling `.private.swiftinterface`
+            available alongside the public `.swiftinterface` so the compiler can
+            resolve SPI references during the textual-interface build.
         clang_module: An optional underlying Clang module (as returned by
             `create_clang_module_inputs`), if present for this Swift module.
         compilation_contexts: A list of `CcCompilationContext`s that represent
@@ -329,6 +335,7 @@ def compile_module_interface(
         indexstore_directory = None
 
     prerequisites = struct(
+        additional_inputs = additional_inputs,
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_compilation_context,
         explicit_swift_module_map_file = explicit_swift_module_map_file,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -206,7 +206,7 @@ def compile_module_interface(
         swift_infos: A list of `SwiftInfo` providers from dependencies of the
             target being compiled.
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
-        target_name: The name of the target for which the code is being
+        target_name: The name of the target for which the interface is being
             compiled, which is used to determine unique file paths for the
             outputs.
         toolchains: The struct containing the Swift and C++ toolchain providers,
@@ -216,19 +216,32 @@ def compile_module_interface(
             `run_toolchain_action`.
 
     Returns:
-        A Swift module context (as returned by `create_swift_module_context`)
-        that contains the Swift (and potentially C/Objective-C) compilation
-        prerequisites of the compiled module. This should typically be
-        propagated by a `SwiftInfo` provider of the calling rule, and the
-        `CcCompilationContext` inside the Clang module substructure should be
-        propagated by the `CcInfo` provider of the calling rule.
+        A `struct` with the following fields:
+
+        *   `module_context`: A Swift module context (as returned by
+            `create_swift_module_context`) that contains the Swift (and
+            potentially C/Objective-C) compilation prerequisites of the compiled
+            module. This should typically be propagated by a `SwiftInfo`
+            provider of the calling rule, and the `CcCompilationContext` inside
+            the Clang module substructure should be propagated by the `CcInfo`
+            provider of the calling rule.
+
+        *   `supplemental_outputs`: A `struct` representing supplemental,
+            optional outputs. Its fields are:
+
+            *   `indexstore_directory`: A directory-type `File` that represents
+                the indexstore output files created when the feature
+                `swift.index_while_building` is enabled.
     """
     toolchains = gather_toolchains(
         swift_toolchain = swift_toolchain,
         toolchains = toolchains,
     )
 
-    swiftmodule_file = actions.declare_file("{}.swiftmodule".format(module_name))
+    swiftmodule_file = actions.declare_file(
+        "{}_outs/{}.swiftmodule".format(target_name, module_name),
+    )
+    outputs = [swiftmodule_file]
 
     implicit_swift_infos, implicit_cc_infos = get_swift_implicit_deps(
         feature_configuration = feature_configuration,
@@ -304,11 +317,23 @@ def compile_module_interface(
     else:
         explicit_swift_module_map_file = None
 
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_INDEX_WHILE_BUILDING,
+    ):
+        indexstore_directory = actions.declare_directory(
+            "{}.swiftinterface.indexstore".format(target_name),
+        )
+        outputs.append(indexstore_directory)
+    else:
+        indexstore_directory = None
+
     prerequisites = struct(
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_compilation_context,
         explicit_swift_module_map_file = explicit_swift_module_map_file,
         genfiles_dir = feature_configuration._genfiles_dir,
+        indexstore_directory = indexstore_directory,
         is_swift = True,
         module_name = module_name,
         objc_include_paths_workaround = depset(),
@@ -328,7 +353,7 @@ def compile_module_interface(
         action_name = SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
         exec_group = exec_group,
         feature_configuration = feature_configuration,
-        outputs = [swiftmodule_file],
+        outputs = outputs,
         prerequisites = prerequisites,
         progress_message = "Compiling Swift module {} from textual interface".format(module_name),
         swift_toolchain = toolchains.swift,
@@ -347,13 +372,19 @@ def compile_module_interface(
             feature_name = SWIFT_FEATURE_SYSTEM_MODULE,
         ),
         swift = create_swift_module_inputs(
+            indexstore = indexstore_directory,
             swiftdoc = None,
             swiftinterface = swiftinterface_file,
             swiftmodule = swiftmodule_file,
         ),
     )
 
-    return module_context
+    return struct(
+        module_context = module_context,
+        supplemental_outputs = struct(
+            indexstore_directory = indexstore_directory,
+        ),
+    )
 
 def compile(
         *,

--- a/swift/swift_import.bzl
+++ b/swift/swift_import.bzl
@@ -98,7 +98,7 @@ def _swift_import_impl(ctx):
     swift_infos = get_providers(deps, SwiftInfo)
 
     if swiftinterface:
-        module_context = compile_module_interface(
+        compile_result = compile_module_interface(
             actions = ctx.actions,
             compilation_contexts = get_compilation_contexts(ctx.attr.deps),
             feature_configuration = feature_configuration,
@@ -108,6 +108,7 @@ def _swift_import_impl(ctx):
             target_name = ctx.attr.name,
             toolchains = toolchains,
         )
+        module_context = compile_result.module_context
         swift_outputs = [
             module_context.swift.swiftmodule,
         ] + compact([module_context.swift.swiftdoc])

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1492,6 +1492,7 @@ def compile_action_configs(
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DERIVE_FILES,
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1194,6 +1194,7 @@ def compile_action_configs(
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
             ],
             configurators = [_index_while_building_configurator],
             features = [SWIFT_FEATURE_INDEX_WHILE_BUILDING],
@@ -1201,6 +1202,7 @@ def compile_action_configs(
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
             ],
             configurators = [add_arg("-index-include-locals")],
             features = [
@@ -1300,6 +1302,15 @@ def compile_action_configs(
                 SWIFT_ACTION_DERIVE_FILES,
             ],
             configurators = [add_arg("-Xfrontend", "-disable-availability-checking")],
+            features = [
+                SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING,
+            ],
+        ),
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+            ],
+            configurators = [add_arg("-disable-availability-checking")],
             features = [
                 SWIFT_FEATURE_DISABLE_AVAILABILITY_CHECKING,
             ],
@@ -1456,12 +1467,22 @@ def compile_action_configs(
             ActionConfigInfo(
                 actions = [
                     SWIFT_ACTION_COMPILE,
-                    SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                     SWIFT_ACTION_DERIVE_FILES,
                     SWIFT_ACTION_DUMP_AST,
                     SWIFT_ACTION_PRECOMPILE_C_MODULE,
                 ],
                 configurators = [_source_files_configurator],
+            ),
+            # When compiling a module interface, add the `.swiftinterface` file
+            # to the action inputs but don't add its path to the command line
+            # because we use a worker-specific flag
+            # for that
+            # (`-Xwrapped-swift=-explicit-compile-module-from-interface=<path>`).
+            ActionConfigInfo(
+                actions = [
+                    SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                ],
+                configurators = [_source_files_as_action_inputs_only_configurator],
             ),
         ],
     )
@@ -2226,6 +2247,15 @@ def _global_index_store_configurator(prerequisites, args):
 def _source_files_configurator(prerequisites, args):
     """Adds source files to the command line and required inputs."""
     args.add_all(prerequisites.source_files)
+    return _source_files_as_action_inputs_only_configurator(prerequisites, args)
+
+def _source_files_as_action_inputs_only_configurator(prerequisites, _args):
+    """Adds source files to the required inputs but not the command line.
+
+    This configurator assumes that the source files are already provided to the
+    command line through some other means (for example, through a
+    worker-specific flag).
+    """
 
     # Only add source files to the input file set if they are not strings (for
     # example, the module map of a system framework will be passed in as a file

--- a/swift/toolchains/config/compile_module_interface_config.bzl
+++ b/swift/toolchains/config/compile_module_interface_config.bzl
@@ -22,23 +22,16 @@ load(":action_config.bzl", "ActionConfigInfo", "add_arg")
 
 def compile_module_interface_action_configs():
     return [
-        # Library evolution is implied since we've already produced a
-        # .swiftinterface file. So we want to unconditionally enable the flag
-        # for this action.
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
-            configurators = [add_arg("-enable-library-evolution")],
-        ),
         ActionConfigInfo(
             actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
             configurators = [
-                _emit_module_path_from_module_interface_configurator,
-            ],
-        ),
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
-            configurators = [
+                # Library evolution is implied since we've already produced a
+                # .swiftinterface file. So we want to unconditionally enable
+                # the flag for this action.
+                add_arg("-enable-library-evolution"),
                 add_arg("-compile-module-from-interface"),
+                _emit_explicit_module_interface_build_configurator,
+                _emit_module_path_from_module_interface_configurator,
             ],
         ),
     ]
@@ -46,3 +39,12 @@ def compile_module_interface_action_configs():
 def _emit_module_path_from_module_interface_configurator(prerequisites, args):
     """Adds the `.swiftmodule` output path to the command line."""
     args.add("-o", prerequisites.swiftmodule_file)
+
+def _emit_explicit_module_interface_build_configurator(prerequisites, args):
+    """Adds flags to perform an explicit interface build to the command line."""
+
+    args.add("-explicit-interface-module-build")
+    args.add(
+        prerequisites.source_files[0],
+        format = "-Xwrapped-swift=-explicit-compile-module-from-interface=%s",
+    )

--- a/test/fixtures/module_interface/BUILD
+++ b/test/fixtures/module_interface/BUILD
@@ -45,3 +45,14 @@ swift_import(
     swiftinterface = "//test/fixtures/module_interface/library:toy_outputs/ToyModule.swiftinterface",
     tags = FIXTURE_TAGS,
 )
+
+swift_import(
+    name = "toy_module_duplicate",
+    archives = [
+        "//test/fixtures/module_interface/library:toy_outputs/libToyModule.a",
+    ],
+    module_name = "ToyModule",
+    swiftdoc = "//test/fixtures/module_interface/library:toy_outputs/ToyModule.swiftdoc",
+    swiftinterface = "//test/fixtures/module_interface/library:toy_outputs/ToyModule.swiftinterface",
+    tags = FIXTURE_TAGS,
+)

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -26,6 +26,22 @@ load(
 )
 load("//test/rules:provider_test.bzl", "provider_test")
 
+explicit_interface_indexstore_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.index_while_building",
+        ],
+    },
+)
+
+explicit_interface_indexstore_inputs_test = make_action_inputs_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.index_while_building",
+        ],
+    },
+)
+
 explicit_swift_module_map_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
@@ -81,6 +97,15 @@ def module_interface_test_suite(name, tags = []):
         name = "{}_swift_binary_imports_transitive_swiftinterface".format(name),
         targets = [
             "//test/fixtures/module_interface:transitive_client",
+        ],
+        tags = all_tags,
+    )
+
+    build_test(
+        name = "{}_swift_imports_with_same_module_name_do_not_conflict".format(name),
+        targets = [
+            "//test/fixtures/module_interface:toy_module",
+            "//test/fixtures/module_interface:toy_module_duplicate",
         ],
         tags = all_tags,
     )
@@ -162,6 +187,28 @@ def module_interface_test_suite(name, tags = []):
             "DependentToyModule.swiftinterface",
         ],
         target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
+    )
+
+    explicit_interface_indexstore_command_line_test(
+        name = "{}_explicit_interface_indexstore_command_line_test".format(name),
+        tags = all_tags,
+        expected_argv = [
+            "-index-store-path $(BIN_DIR)/test/fixtures/module_interface/toy_module.swiftinterface.indexstore",
+            "-explicit-interface-module-build",
+            "-Xwrapped-swift=-explicit-compile-module-from-interface=$(BIN_DIR)/test/fixtures/module_interface/library/toy_outputs/ToyModule.swiftinterface",
+        ],
+        mnemonic = "SwiftCompileModuleInterface",
+        target_under_test = "//test/fixtures/module_interface:toy_module",
+    )
+
+    explicit_interface_indexstore_inputs_test(
+        name = "{}_explicit_interface_indexstore_inputs_test".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompileModuleInterface",
+        expected_inputs = [
+            "ToyModule.swiftinterface",
+        ],
+        target_under_test = "//test/fixtures/module_interface:toy_module",
     )
 
     explicit_swift_module_map_inputs_test(

--- a/tools/common/BUILD
+++ b/tools/common/BUILD
@@ -41,6 +41,29 @@ cc_library(
 )
 
 cc_library(
+    name = "file_system",
+    srcs = ["file_system.cc"],
+    hdrs = ["file_system.h"],
+    copts = selects.with_or({
+        ("//tools:clang-cl", "//tools:msvc"): [
+            "/std:c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    }),
+    deps = [
+        "@abseil-cpp//absl/strings",
+    ],
+)
+
+cc_library(
+    name = "target_triple",
+    hdrs = ["target_triple.h"],
+    deps = ["@abseil-cpp//absl/strings"],
+)
+
+cc_library(
     name = "temp_file",
     hdrs = ["temp_file.h"],
     copts = selects.with_or({

--- a/tools/common/file_system.cc
+++ b/tools/common/file_system.cc
@@ -1,0 +1,29 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/common/file_system.h"
+
+#include <sys/stat.h>
+
+#include <string>
+
+namespace bazel_rules_swift {
+
+bool PathExists(absl::string_view path) {
+  struct stat stats;
+  std::string null_terminated_path{path};
+  return stat(null_terminated_path.c_str(), &stats) == 0;
+}
+
+}  // namespace bazel_rules_swift

--- a/tools/common/file_system.h
+++ b/tools/common/file_system.h
@@ -1,0 +1,27 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_
+
+#include "absl/strings/string_view.h"
+
+namespace bazel_rules_swift {
+
+// Returns true if the given path exists.
+bool PathExists(absl::string_view path);
+
+}  // namespace bazel_rules_swift
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_FILE_SYSTEM_H_

--- a/tools/common/target_triple.h
+++ b/tools/common/target_triple.h
@@ -1,0 +1,97 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TARGET_TRIPLE_H
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TARGET_TRIPLE_H
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/string_view.h"
+
+namespace bazel_rules_swift {
+
+// Represents a target triple as used by LLVM/Swift and provides operations to
+// query and modify it.
+class TargetTriple {
+ public:
+  // Creates a new target triple from the given components.
+  TargetTriple(absl::string_view arch, absl::string_view vendor,
+               absl::string_view os, absl::string_view environment)
+      : arch_(arch),
+        vendor_(vendor),
+        os_(os),
+        environment_(environment) {}
+
+  // Parses the given target triple string into its component parts.
+  static std::optional<TargetTriple> Parse(absl::string_view target_triple) {
+    std::vector<absl::string_view> components =
+        absl::StrSplit(target_triple, '-');
+    if (components.size() < 3) {
+      return std::nullopt;
+    }
+    return TargetTriple(components[0], components[1], components[2],
+                        components.size() > 3 ? components[3] : "");
+  }
+
+  // Returns the architecture component of the target triple.
+  std::string Arch() const { return arch_; }
+
+  // Returns the vendor component of the target triple.
+  std::string Vendor() const { return vendor_; }
+
+  // Returns the OS component of the target triple.
+  std::string OS() const { return os_; }
+
+  // Returns the environment component of the target triple.
+  std::string Environment() const { return environment_; }
+
+  // Returns this target triple as a string.
+  std::string TripleString() const {
+    std::string result = absl::StrJoin({arch_, vendor_, os_}, "-");
+    if (!environment_.empty()) {
+      absl::StrAppend(&result, "-", environment_);
+    }
+    return result;
+  }
+
+  // Returns a copy of this target triple with the version number removed from
+  // the OS component (if any).
+  TargetTriple WithoutOSVersion() const {
+    std::pair<absl::string_view, absl::string_view> os_and_version =
+    absl::StrSplit(os_, absl::MaxSplits(absl::ByAnyChar("0123456789"), 1));
+    return TargetTriple(arch_, vendor_, os_and_version.first, environment_);
+  }
+
+  // Returns a copy of this target triple, replacing its architecture with the
+  // given value.
+  TargetTriple WithArch(absl::string_view arch) const {
+    return TargetTriple(arch, vendor_, os_, environment_);
+  }
+
+ private:
+  std::string arch_;
+  std::string vendor_;
+  std::string os_;
+  std::string environment_;
+};
+
+}  // namespace bazel_rules_swift
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_COMMON_TARGET_TRIPLE_H

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -80,8 +80,11 @@ cc_library(
     }),
     deps = [
         "//tools/common:bazel_substitutions",
+        "//tools/common:file_system",
         "//tools/common:process",
+        "//tools/common:target_triple",
         "//tools/common:temp_file",
+        "@abseil-cpp//absl/strings",
         "@com_github_nlohmann_json//:json",
     ],
 )

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -16,9 +16,17 @@
 
 #include <filesystem>
 #include <fstream>
+#include <optional>
+#include <utility>
 
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "absl/strings/strip.h"
+#include "absl/strings/substitute.h"
 #include "tools/common/bazel_substitutions.h"
+#include "tools/common/file_system.h"
 #include "tools/common/process.h"
+#include "tools/common/target_triple.h"
 #include "tools/common/temp_file.h"
 #include "tools/worker/output_file_map.h"
 
@@ -28,6 +36,9 @@ bool ArgumentEnablesWMO(const std::string &arg) {
 }
 
 namespace {
+
+using bazel_rules_swift::PathExists;
+using bazel_rules_swift::TargetTriple;
 
 // Creates a temporary file and writes the given arguments to it, one per line.
 static std::unique_ptr<TempFile> WriteResponseFile(
@@ -92,6 +103,67 @@ static std::string Unescape(const std::string &arg) {
   return result;
 }
 
+// Consumes and returns a single argument from the given command line (skipping
+// any leading whitespace and also handling quoted/escaped arguments), advancing
+// the view to the end of the argument in a similar fashion to
+// `absl::ConsumePrefix()`.
+static std::optional<std::string> ConsumeArg(absl::string_view *line) {
+  size_t whitespace_count = 0;
+  size_t length = line->size();
+  while (whitespace_count < length && (*line)[whitespace_count] == ' ') {
+    whitespace_count++;
+  }
+  if (whitespace_count > 0) {
+    line->remove_prefix(whitespace_count);
+  }
+
+  if (line->empty()) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  length = line->size();
+  size_t i = 0;
+  for (i = 0; i < length; ++i) {
+    char ch = (*line)[i];
+
+    if (ch == ' ') {
+      break;
+    }
+
+    // If it's a backslash, consume it and append the character that follows.
+    if (ch == '\\' && i + 1 < length) {
+      ++i;
+      result.push_back((*line)[i]);
+      continue;
+    }
+
+    // If it's a quote, process everything up to the matching quote, unescaping
+    // backslashed characters as needed.
+    if (ch == '"' || ch == '\'') {
+      char quote = ch;
+      ++i;
+      while (i != length && (*line)[i] != quote) {
+        if ((*line)[i] == '\\' && i + 1 < length) {
+          ++i;
+        }
+        result.push_back((*line)[i]);
+        ++i;
+      }
+      if (i == length) {
+        break;
+      }
+      continue;
+    }
+
+    // It's a regular character.
+    result.push_back(ch);
+  }
+
+  line->remove_prefix(i);
+  return result;
+}
+
 // If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
 // function returns true. Otherwise, `str` is left unmodified and the function
 // returns `false`.
@@ -101,6 +173,94 @@ static bool StripPrefix(const std::string &prefix, std::string &str) {
   }
   str.erase(0, prefix.size());
   return true;
+}
+
+// Infers the path to the `.swiftinterface` file inside a `.swiftmodule`
+// directory based on the given target triple.
+//
+// This roughly mirrors the logic in the Swift frontend's
+// `forEachTargetModuleBasename` function at
+// https://github.com/swiftlang/swift/blob/d36b06747a54689a09ca6771b04798fc42b3e701/lib/Serialization/SerializedModuleLoader.cpp#L55.
+std::optional<std::string> InferInterfacePath(
+    absl::string_view module_path, absl::string_view target_triple_string) {
+  std::optional<TargetTriple> parsed_triple =
+      TargetTriple::Parse(target_triple_string);
+  if (!parsed_triple.has_value()) {
+    return std::nullopt;
+  }
+
+  // The target triple passed to us by the build rules has already been
+  // normalized (e.g., `macos` instead of `macosx`), so we don't have to do as
+  // much work here as the frontend normally would.
+  TargetTriple normalized_triple = parsed_triple->WithoutOSVersion();
+
+  // First, try the triple we were given.
+  std::string attempt = absl::Substitute("$0/$1.swiftinterface", module_path,
+                                         normalized_triple.TripleString());
+  if (PathExists(attempt)) {
+    return attempt;
+  }
+
+  // Next, if the target triple is `arm64`, we can also load an `arm64e`
+  // interface, so try that.
+  if (normalized_triple.Arch() == "arm64") {
+    TargetTriple arm64e_triple = normalized_triple.WithArch("arm64e");
+    attempt = absl::Substitute("$0/$1.swiftinterface", module_path,
+                               arm64e_triple.TripleString());
+    if (PathExists(attempt)) {
+      return attempt;
+    }
+  }
+
+  return std::nullopt;
+}
+
+// Extracts flags from the given `.swiftinterface` file and passes them to the
+// given consumer.
+void ExtractFlagsFromInterfaceFile(
+    absl::string_view module_or_interface_path, absl::string_view target_triple,
+    std::function<void(absl::string_view)> consumer) {
+  std::string interface_path;
+  if (absl::EndsWith(module_or_interface_path, ".swiftinterface")) {
+    interface_path = std::string(module_or_interface_path);
+  } else {
+    std::optional<std::string> inferred_path =
+        InferInterfacePath(module_or_interface_path, target_triple);
+    if (!inferred_path.has_value()) {
+      return;
+    }
+    interface_path = *inferred_path;
+  }
+
+  // Add the path to the interface file as a source file argument, then extract
+  // the flags from it and add them as well.
+  consumer(interface_path);
+
+  std::ifstream interface_file{std::string(interface_path)};
+  std::string line;
+  while (std::getline(interface_file, line)) {
+    absl::string_view line_view = line;
+    if (absl::ConsumePrefix(&line_view, "// swift-module-flags: ")) {
+      bool skip_next = false;
+      while (std::optional<std::string> flag = ConsumeArg(&line_view)) {
+        if (skip_next) {
+          skip_next = false;
+        } else if (*flag == "-target") {
+          // We have to skip the target triple in the interface file because it
+          // might be slightly different from the one the rest of our
+          // dependencies were compiled with. For example, if we are targeting
+          // `arm64-apple-macos`, that is the architecture that any Clang
+          // module dependencies will have used. If the module uses
+          // `arm64e-apple-macos` instead, then it will not be compatible with
+          // those Clang modules.
+          skip_next = true;
+        } else {
+          consumer(*flag);
+        }
+      }
+      return;
+    }
+  }
 }
 
 }  // namespace
@@ -364,6 +524,11 @@ bool SwiftRunner::ProcessArgument(
         changed = true;
       } else if (StripPrefix("-global-index-store-import-path=", new_arg)) {
         changed = true;
+      } else if (StripPrefix(
+                     "-explicit-compile-module-from-interface=", new_arg)) {
+        module_or_interface_path_ = new_arg;
+        bazel_placeholder_substitutions_.Apply(module_or_interface_path_);
+        changed = true;
       } else {
         // TODO(allevato): Report that an unknown wrapper arg was found and give
         // the caller a way to exit gracefully.
@@ -390,6 +555,11 @@ bool SwiftRunner::ProcessArgument(
         ++itr;
         new_arg = output_file_map_path_;
         changed = true;
+      } else if (arg == "-target") {
+        consumer("-target");
+        ++itr;
+        new_arg = *itr;
+        target_triple_ = new_arg;
       } else if (is_dump_ast_ && ArgumentEnablesWMO(arg)) {
         // WMO is invalid for -dump-ast,
         // so omit the argument that enables WMO
@@ -429,6 +599,9 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
         file_prefix_pwd_is_dot_ = true;
       } else if (arg == "-emit-swiftsourceinfo") {
         emit_swift_source_info_ = true;
+      } else if (StripPrefix(
+                     "-explicit-compile-module-from-interface=", arg)) {
+        module_or_interface_path_ = arg;
       }
     } else {
       if (arg == "-output-file-map") {
@@ -448,6 +621,11 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
         arg = *it;
         std::filesystem::path module_path(arg);
         swift_source_info_path_ = module_path.replace_extension(".swiftsourceinfo").string();
+        out_args.push_back(arg);
+      } else if (arg == "-target") {
+        ++it;
+        arg = *it;
+        target_triple_ = arg;
         out_args.push_back(arg);
       }
     }
@@ -481,6 +659,14 @@ std::vector<std::string> SwiftRunner::ProcessArguments(
       args_destination.push_back(arg);
     });
     ++it;
+  }
+
+  if (!module_or_interface_path_.empty()) {
+    ExtractFlagsFromInterfaceFile(
+        module_or_interface_path_, target_triple_,
+        [&](absl::string_view arg) {
+          args_destination.push_back(std::string(arg));
+        });
   }
 
   if (force_response_file_) {

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -171,6 +171,14 @@ class SwiftRunner {
   // The index store path argument passed to the runner
   std::string index_store_path_;
 
+  // The target triple of the current compilation.
+  std::string target_triple_;
+
+  // The path to either the `.swiftinterface` file to compile or to a
+  // `.swiftmodule` directory in which the worker will infer the interface file
+  // to compile.
+  std::string module_or_interface_path_;
+
   // The path of the global index store  when using
   // swift.use_global_index_store. When set, this is passed to `swiftc` as the
   // `-index-store-path`. After running `swiftc` `index-import` copies relevant


### PR DESCRIPTION
This takes a slightly different approach in the worker. In the past we
decided we didn't want to take the abseil dep, so we avoided directly
taking changes that used it. We've since decided that with bzlmod we're
ok with having that dep. So this takes the upstream abseil functions
directly, adding the deps as needed, which will reduce the conflicts in
cherry picks specific to those functions too. This doesn't overhaul the
entire worker to use it, but this will make later ones easier.

This fixes a few different bugs, but most importantly to me right now:

- multiple swiftinterface->swiftmodule actions in the same BUILD file
  conflicted based on module names, now they are in target name specific
  subdirectories
- the `-target` from a swiftinterface fought with the actual version we
  were trying to build for, which doesn't work with explicit modules, we
  now overwrite the target with our own

Cherry picks:

- 4c4184942dc091c1b43b0243848876d3c5b90c07
- 81c5b92823c03238cb9ad6f1b360227be4cb2691
- 3793c3a81596e2878427cc5e297cc3f92ac575ec
