### PR TITLE
Fix missing bzl_library dep

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -249,6 +249,7 @@ bzl_library(
         "//swift:__subpackages__",
     ],
     deps = [
+        "@bazel_features//:features",
         "@bazel_skylib//lib:paths",
         "@rules_cc//cc/common",
     ],


### PR DESCRIPTION
I'm going to try to figure out how to get CI to catch this
