### PR TITLE
Extract swift version on linux

### DIFF
--- a/swift/internal/extensions/BUILD.bazel.tpl
+++ b/swift/internal/extensions/BUILD.bazel.tpl
@@ -168,6 +168,7 @@ swift_toolchain(
         "-swift.file_prefix_map",
     ],
     os = "none",
+    parsed_version = "{swift_version}",
     swift_tools = "tools",
     version_file = ".swift-version",
 )
@@ -188,6 +189,7 @@ swift_toolchain(
         "@platforms//os:linux": "linux",
         "@platforms//os:macos": "macos",
     }),
+    parsed_version = "{swift_version}",
     runtime = glob([
         "usr/lib/swift/**/*.dylib", # On MacOS
         "usr/lib/swift/**/*.so", # On Linux

--- a/swift/internal/extensions/standalone_toolchain.bzl
+++ b/swift/internal/extensions/standalone_toolchain.bzl
@@ -102,6 +102,7 @@ def _standalone_toolchain_impl(repository_ctx):
         substitutions = {
             "{exec_os}": repository_ctx.os.name,
             "{exec_arch}": repository_ctx.os.arch,
+            "{swift_version}": repository_ctx.attr.swift_version,
         },
     )
 

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -141,10 +141,11 @@ def _write_swift_version(repository_ctx, swiftc_path):
         parsed = (
             contents.splitlines()[0]
                 .split("Swift version")[-1]
+                .strip()
                 .split(" ")[0]
                 .split("-")[0]
                 .strip()
-        )
+        ) or "0.0"
 
     filename = "swift_version"
     repository_ctx.file(filename, contents, executable = False)
@@ -327,7 +328,7 @@ Swift toolchain.
     ]
     disabled_features = []
 
-    version_file = _write_swift_version(repository_ctx, path_to_swiftc)
+    version_file, parsed_version = _write_swift_version(repository_ctx, path_to_swiftc)
     xctest_version = repository_ctx.execute([
         _get_python_bin(repository_ctx),
         "-c",
@@ -347,6 +348,7 @@ swift_toolchain(
   features = [{features}],
   os = "windows",
   root = "{root}",
+  parsed_version = "{parsed_version}",
   version_file = "{version_file}",
   env = {env},
   sdkroot = "{sdkroot}",
@@ -357,6 +359,7 @@ swift_toolchain(
         features = ", ".join(['"{}"'.format(feature) for feature in enabled_features] + ['"-{}"'.format(feature) for feature in disabled_features]),
         root = root,
         env = env,
+        parsed_version = parsed_version,
         sdkroot = repository_ctx.os.environ["SDKROOT"].replace("\\", "/"),
         xctest_version = xctest_version.stdout.rstrip(),
         version_file = version_file,

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -132,12 +132,23 @@ def _write_swift_version(repository_ctx, swiftc_path):
     """
     result = repository_ctx.execute([swiftc_path, "-version"])
     contents = "unknown"
+    parsed = "0.0"
     if result.return_code == 0:
         contents = result.stdout.strip()
 
+        # Swift version 6.3.1 (swift-6.3.1-RELEASE) -> 6.3.1
+        # Swift version 6.4-dev -> 6.4
+        parsed = (
+            contents.splitlines()[0]
+                .split("Swift version")[-1]
+                .split(" ")[0]
+                .split("-")[0]
+                .strip()
+        )
+
     filename = "swift_version"
     repository_ctx.file(filename, contents, executable = False)
-    return filename
+    return filename, parsed
 
 def _compute_feature_values(repository_ctx, swiftc_path):
     """Computes a list of supported/unsupported features by running checks.
@@ -229,7 +240,7 @@ toolchain.
 
     root = _resolve_toolchain_root(repository_ctx, path_to_swiftc)
     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
-    version_file = _write_swift_version(repository_ctx, path_to_swiftc)
+    version_file, parsed_version = _write_swift_version(repository_ctx, path_to_swiftc)
 
     # TODO: This should be removed so that private headers can be used with
     # explicit modules, but the build targets for CgRPC need to be cleaned up
@@ -245,6 +256,7 @@ swift_toolchain(
     features = [{feature_list}],
     os = "linux",
     root = "{root}",
+    parsed_version = "{parsed_version}",
     version_file = "{version_file}",
 )
 """.format(
@@ -254,6 +266,7 @@ swift_toolchain(
             for feature in feature_values
         ]),
         root = root,
+        parsed_version = parsed_version,
         version_file = version_file,
     )
 

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -689,6 +689,9 @@ List of files to carry over as test data to swift executables and tests.
 """,
                 allow_files = True,
             ),
+            "parsed_version": attr.string(
+                mandatory = True,
+            ),
             "version_file": attr.label(
                 mandatory = True,
                 allow_single_file = True,

--- a/test/fixtures/toolchains/BUILD
+++ b/test/fixtures/toolchains/BUILD
@@ -7,6 +7,7 @@ swift_toolchain(
     name = "_toolchain_macos_arm64_with_sdkroot",
     arch = "arm64",
     os = "macos",
+    parsed_version = "6.3",
     root = ".",
     sdkroot = "testpath",
     version_file = ".swift_version",


### PR DESCRIPTION
This way we can do version comparisons like what we do on macOS with
xcode versions
