### PR TITLE
Remove -disable-implicit-swift-modules

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -879,13 +879,14 @@ def compile_action_configs(
             ],
             features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
         ),
-        ActionConfigInfo(
-            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
-            configurators = [
-                add_arg("-disable-implicit-swift-modules"),
-            ],
-            features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
-        ),
+        # TODO: Pass through system modules and pass this to all actions
+        # ActionConfigInfo(
+        #     actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+        #     configurators = [
+        #         add_arg("-disable-implicit-swift-modules"),
+        #     ],
+        #     features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
+        # ),
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,


### PR DESCRIPTION
This never worked but today we don't use this action. We will use it
soon with explicit modules support. We probably want to support this in
the future but that requires us explicitly threading through swiftmodule
files from the SDK, vs letting swift find them automatically.
