### PR TITLE
Disable warnings from creating system PCMs

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -850,6 +850,10 @@ def compile_action_configs(
                 add_arg("-Xcc", "-emit-module"),
                 add_arg("-Xcc", "-Xclang"),
                 add_arg("-Xcc", "-fsystem-module"),
+                # The clang importer emits ClangDeclarationImport diagnostics
+                # against `NS_SWIFT_NAME` annotations in the SDK that we cannot
+                # fix.
+                add_arg("-suppress-warnings"),
             ],
             features = [SWIFT_FEATURE_SYSTEM_MODULE],
         ),


### PR DESCRIPTION
This compile can emit warnings, often due to bad annotations in objc
headers from the sdk. In this case I think we'd prefer to remove the
noise since there's nothing you can do.
