### PR TITLE
Pass additional_swiftc_copts to PCM compiles

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1437,14 +1437,12 @@ def compile_action_configs(
     if additional_swiftc_copts:
         action_configs.append(
             ActionConfigInfo(
-                # TODO(allevato): Determine if there are any uses of
-                # `-Xcc`-prefixed flags that need to be added to explicit module
-                # actions, or if we should advise against/forbid that.
                 actions = [
                     SWIFT_ACTION_COMPILE,
                     SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                     SWIFT_ACTION_DERIVE_FILES,
                     SWIFT_ACTION_DUMP_AST,
+                    SWIFT_ACTION_PRECOMPILE_C_MODULE,
                 ],
                 configurators = [
                     lambda _, args: args.add_all(


### PR DESCRIPTION
As far as I can tell this is required for -Xcc flags specifically,
otherwise you get PCMs that mismatch with your other compiles and
therefore aren't importable.
