### PR TITLE
Embed PCM paths in swiftmodules for explicit modules

### DIFF
--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -436,3 +436,7 @@ SWIFT_FEATURE_ENABLE_CPP23_INTEROP = "swift.enable_cpp23_interop"
 #   automatically include it at compile time, and provide it to the linker at link time
 # * alwayslink on swift_library() target will now default to False, as it is not required in embedded mode
 SWIFT_FEATURE_ENABLE_EMBEDDED = "swift.enable_embedded"
+
+# Before swift 6.3 using macros lead to absolute paths in swiftmodule files
+# even with -prefix-serialized-debugging-options
+SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE = "swift._supports_hermetic_swiftmodule"

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -93,6 +93,7 @@ load(
     "SWIFT_FEATURE__COVERAGE_PREFIX_MAP_ABSOLUTE_SOURCES_NON_HERMETIC",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
     "SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR",
+    "SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE",
     "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
     "SWIFT_FEATURE__SUPPORTS_V6",
     "SWIFT_FEATURE__WMO_IN_SWIFTCOPTS",
@@ -417,6 +418,17 @@ def compile_action_configs(
             not_features = [
                 [SWIFT_FEATURE_OPT],
                 [SWIFT_FEATURE_CACHEABLE_SWIFTMODULES],
+            ],
+        ),
+        ActionConfigInfo(
+            actions = all_compile_action_names(),
+            configurators = [
+                add_arg("-Xfrontend", "-serialize-debugging-options"),
+                add_arg("-Xfrontend", "-prefix-serialized-debugging-options"),
+            ],
+            features = [
+                SWIFT_FEATURE_USE_C_MODULES,
+                SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE,
             ],
         ),
 

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -53,6 +53,7 @@ load(
     "SWIFT_FEATURE_USE_AUTOLINK_EXTRACT",
     "SWIFT_FEATURE_USE_GLOBAL_INDEX_STORE",
     "SWIFT_FEATURE_USE_MODULE_WRAP",
+    "SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE",
 )
 load(
     "//swift/internal:features.bzl",
@@ -524,6 +525,9 @@ def _swift_toolchain_impl(ctx):
         # `InternalImportsByDefault`.
         "swift.experimental.AccessLevelOnImport",
     ])
+
+    if apple_common.dotted_version(ctx.attr.parsed_version) >= apple_common.dotted_version("6.3"):
+        requested_features.append(SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE)
 
     requested_features.extend(ctx.features)
 

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -58,6 +58,7 @@ load(
     "SWIFT_FEATURE_MODULE_MAP_HOME_IS_CWD",
     "SWIFT_FEATURE_REMAP_XCODE_PATH",
     "SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR",
+    "SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE",
     "SWIFT_FEATURE__SUPPORTS_UPCOMING_FEATURES",
     "SWIFT_FEATURE__SUPPORTS_V6",
 )
@@ -830,6 +831,9 @@ def _xcode_swift_toolchain_impl(ctx):
             # where two modules contain the same header.
             SWIFT_FEATURE_MODULE_HOME_IS_CWD,
         ])
+
+    if _is_xcode_at_least_version(xcode_config, "26.4"):
+        requested_features.append(SWIFT_FEATURE__SUPPORTS_HERMETIC_SWIFTMODULE)
 
     # Xcode toolchains always support DEVELOPER_DIR
     requested_features.append(SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR)


### PR DESCRIPTION
When using explicit modules swift needs to embed the PCM paths you
depend on in the swiftmodule for lldb to be able to find them. Until
Swift 6.3 (the current latest) these options included absolute paths to
swift compiler plugins. We use version checking to not automatically
enable this until you're on those versions (meaning you cannot debug
these in lldb).
