### PR TITLE
Disable clang warning about relocated PCMs

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -713,6 +713,8 @@ def compile_action_configs(
             configurators = [
                 add_arg("-Xcc", "-Xclang"),
                 add_arg("-Xcc", "-fmodule-file-home-is-cwd"),
+                add_arg("-Xcc", "-Xclang"),
+                add_arg("-Xcc", "-fno-modules-check-relocated"),
             ],
             features = [[
                 SWIFT_FEATURE_EMIT_C_MODULE,


### PR DESCRIPTION
In order to create reproducible PCMs for explicit modules we create them
through a symlink. The consumers then can potentially think they've been
moved. This disables the warning that produces.
