### PR TITLE
Pass --target through -Xcc

### DIFF
--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -218,6 +218,19 @@ def _all_action_configs(os, arch, target_triple, sdkroot, xctest_version, additi
             ],
             configurators = [
                 add_arg("-target", target_triples.str(target_triple)),
+            ],
+        ),
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                SWIFT_ACTION_DERIVE_FILES,
+                SWIFT_ACTION_DUMP_AST,
+                SWIFT_ACTION_PRECOMPILE_C_MODULE,
+                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
+                SWIFT_ACTION_SYNTHESIZE_INTERFACE,
+            ],
+            configurators = [
                 # https://github.com/swiftlang/llvm-project/issues/12826
                 add_arg("-Xcc", "--target={}".format(target_triples.str(target_triple))),
             ],

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -218,6 +218,8 @@ def _all_action_configs(os, arch, target_triple, sdkroot, xctest_version, additi
             ],
             configurators = [
                 add_arg("-target", target_triples.str(target_triple)),
+                # https://github.com/swiftlang/llvm-project/issues/12826
+                add_arg("-Xcc", "--target={}".format(target_triples.str(target_triple))),
             ],
         ),
     ]

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -448,6 +448,8 @@ def _all_action_configs(
             ],
             configurators = [
                 add_arg("-target", target_triples.str(target_triple)),
+                # https://github.com/swiftlang/llvm-project/issues/12826
+                add_arg("-Xcc", "--target={}".format(target_triples.str(target_triple))),
                 add_arg("-sdk", apple_toolchain.sdk_dir()),
             ],
         ),


### PR DESCRIPTION
Currently it seems like this is required to get the correct target in
the swiftmodule that lldb ends up parsing. Without this lldb attempts to
load PCMs at the wrong version and fails.
