### PR TITLE
Make swift_clang_module_aspect grab some copts

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -612,7 +612,7 @@ check it.
 swift_common.precompile_clang_module(*, <a href="#swift_common.precompile_clang_module-actions">actions</a>, <a href="#swift_common.precompile_clang_module-cc_compilation_context">cc_compilation_context</a>, <a href="#swift_common.precompile_clang_module-exec_group">exec_group</a>,
                                      <a href="#swift_common.precompile_clang_module-feature_configuration">feature_configuration</a>, <a href="#swift_common.precompile_clang_module-module_map_file">module_map_file</a>, <a href="#swift_common.precompile_clang_module-module_name">module_name</a>,
                                      <a href="#swift_common.precompile_clang_module-swift_toolchain">swift_toolchain</a>, <a href="#swift_common.precompile_clang_module-target_name">target_name</a>, <a href="#swift_common.precompile_clang_module-toolchains">toolchains</a>, <a href="#swift_common.precompile_clang_module-toolchain_type">toolchain_type</a>,
-                                     <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>)
+                                     <a href="#swift_common.precompile_clang_module-swift_infos">swift_infos</a>, <a href="#swift_common.precompile_clang_module-user_compile_flags">user_compile_flags</a>)
 </pre>
 
 Precompiles an explicit Clang module that is compatible with Swift.
@@ -633,6 +633,7 @@ Precompiles an explicit Clang module that is compatible with Swift.
 | <a id="swift_common.precompile_clang_module-toolchains"></a>toolchains |  The struct containing the Swift and C++ toolchain providers, as returned by `swift_common.find_all_toolchains()`.   |  `None` |
 | <a id="swift_common.precompile_clang_module-toolchain_type"></a>toolchain_type |  The toolchain type of the Swift toolchain.   |  `Label("@rules_swift//toolchains:toolchain_type")` |
 | <a id="swift_common.precompile_clang_module-swift_infos"></a>swift_infos |  A list of `SwiftInfo` providers representing dependencies required to compile this module.   |  `[]` |
+| <a id="swift_common.precompile_clang_module-user_compile_flags"></a>user_compile_flags |  Additional Clang flags to pass to the precompile action. Each flag is forwarded to the underlying clang invocation via `-Xcc`.   |  `[]` |
 
 **RETURNS**
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -848,6 +848,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             swift_toolchain = toolchains.swift,
             target_name = target_name,
             toolchain_type = toolchain_type,
+            user_compile_flags = [],
         )
         if pcm_outputs:
             precompiled_module = pcm_outputs.pcm_file
@@ -942,7 +943,8 @@ def precompile_clang_module(
         target_name,
         toolchains = None,
         toolchain_type = SWIFT_TOOLCHAIN_TYPE,
-        swift_infos = []):
+        swift_infos = [],
+        user_compile_flags = []):
     """Precompiles an explicit Clang module that is compatible with Swift.
 
     Args:
@@ -973,6 +975,9 @@ def precompile_clang_module(
         toolchain_type: The toolchain type of the Swift toolchain.
         swift_infos: A list of `SwiftInfo` providers representing dependencies
             required to compile this module.
+        user_compile_flags: Additional Clang flags to pass to the precompile
+            action. Each flag is forwarded to the underlying clang invocation
+            via `-Xcc`.
 
     Returns:
         A struct containing the following fields:
@@ -1002,6 +1007,7 @@ def precompile_clang_module(
         target_name = target_name,
         toolchains = toolchains,
         toolchain_type = toolchain_type,
+        user_compile_flags = user_compile_flags,
     )
 
 def _precompile_clang_module(
@@ -1017,7 +1023,8 @@ def _precompile_clang_module(
         swift_toolchain = None,
         target_name,
         toolchains = None,
-        toolchain_type):
+        toolchain_type,
+        user_compile_flags):
     """Precompiles an explicit Clang module that is compatible with Swift.
 
     Args:
@@ -1050,6 +1057,9 @@ def _precompile_clang_module(
         toolchains: The struct containing the Swift and C++ toolchain providers,
             as returned by `swift_common.find_all_toolchains()`.
         toolchain_type: The toolchain type of the Swift toolchain.
+        user_compile_flags: Additional Clang flags to pass to the precompile
+            action. Each flag is forwarded to the underlying clang invocation
+            via `-Xcc`.
 
     Returns:
         A struct containing the following fields:
@@ -1152,6 +1162,7 @@ def _precompile_clang_module(
         source_files = [module_map_file],
         target_label = feature_configuration._label,
         transitive_modules = transitive_modules,
+        user_compile_flags = user_compile_flags,
     )
 
     run_toolchain_action(

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -413,6 +413,16 @@ def _handle_module(
 
     output_groups = {}
 
+    # Private -D flags might be needed to compile the PCM
+    # TODO: Only grab local_defines once that has existed for long enough
+    local_defines = [
+        copt
+        for copt in getattr(attr, "copts", [])
+        if copt.startswith("-D") and "$(" not in copt
+    ]
+    for define in getattr(attr, "local_defines", []):
+        local_defines.append("-D" + define)
+
     pcm_outputs = precompile_clang_module(
         actions = aspect_ctx.actions,
         cc_compilation_context = compilation_context_to_compile,
@@ -423,6 +433,7 @@ def _handle_module(
         toolchains = toolchains,
         target_name = target.label.name,
         toolchain_type = toolchain_type,
+        user_compile_flags = local_defines,
     )
     precompiled_module = getattr(pcm_outputs, "pcm_file", None)
     pcm_indexstore = getattr(pcm_outputs, "indexstore_directory", None)

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1433,6 +1433,12 @@ def compile_action_configs(
             configurators = [_user_compile_flags_configurator],
         ),
     )
+    action_configs.append(
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_PRECOMPILE_C_MODULE],
+            configurators = [_precompile_user_compile_flags_configurator],
+        ),
+    )
     if additional_objc_copts:
         action_configs.append(
             ActionConfigInfo(
@@ -2314,6 +2320,18 @@ def _user_compile_flags_configurator(prerequisites, args):
     args.add_all(
         prerequisites.user_compile_flags,
         map_each = _fail_if_flag_is_banned,
+    )
+
+def _precompile_user_compile_flags_configurator(prerequisites, args):
+    """Forwards the underlying clang library's copts to the precompile action.
+
+    Each flag is wrapped in `-Xcc` so that swiftc passes it through to clang
+    when emitting the `.pcm`. This lets flags like `-DSWIFT_PACKAGE` reach
+    the precompile, since they don't propagate via `CcInfo`.
+    """
+    args.add_all(
+        prerequisites.user_compile_flags,
+        before_each = "-Xcc",
     )
 
 def _make_wmo_thread_count_configurator(should_check_flags):

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":additional_linker_inputs_tests.bzl", "additional_linker_inputs_test_suite")
+load(":aspect_tests.bzl", "aspect_tests")
 load(":ast_file_tests.bzl", "ast_file_test_suite")
 load(":bzl_test.bzl", "bzl_test")
 load(":cc_library_tests.bzl", "cc_library_test_suite")
@@ -33,6 +34,8 @@ load(":xctest_runner_tests.bzl", "xctest_runner_test_suite")
 licenses(["notice"])
 
 additional_linker_inputs_test_suite(name = "additional_linker_inputs")
+
+aspect_tests(name = "aspect_tests")
 
 ast_file_test_suite(name = "ast_file")
 

--- a/test/aspect_tests.bzl
+++ b/test/aspect_tests.bzl
@@ -1,0 +1,25 @@
+"""Tests for `swift_clang_module_aspect`"""
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+def aspect_tests(name, tags = []):
+    """Tests for `swift_clang_module_aspect`
+
+    Args:
+        name: The base name to be used for targets created by this macro.
+        tags: Additional tags to apply to each test.
+    """
+    all_tags = [name] + tags
+
+    build_test(
+        name = "{}_build_test".format(name),
+        tags = all_tags,
+        targets = [
+            "//test/fixtures/precompile_user_compile_flags:user_explicit_modules",
+        ],
+    )
+
+    native.test_suite(
+        name = name,
+        tags = all_tags,
+    )

--- a/test/fixtures/precompile_user_compile_flags/BUILD
+++ b/test/fixtures/precompile_user_compile_flags/BUILD
@@ -45,4 +45,6 @@ force_features_binary(
         "swift.use_c_modules",
         "swift.emit_c_module",
     ],
+    # TODO: Remove when we support explicit modules on Linux
+    target_compatible_with = ["@platforms//os:macos"],
 )

--- a/test/fixtures/precompile_user_compile_flags/BUILD
+++ b/test/fixtures/precompile_user_compile_flags/BUILD
@@ -41,10 +41,10 @@ force_features_binary(
     name = "user_explicit_modules",
     binary = ":user",
     tags = FIXTURE_TAGS,
+    # TODO: Remove when we support explicit modules on Linux
+    target_compatible_with = ["@platforms//os:macos"],
     transitive_features = [
         "swift.use_c_modules",
         "swift.emit_c_module",
     ],
-    # TODO: Remove when we support explicit modules on Linux
-    target_compatible_with = ["@platforms//os:macos"],
 )

--- a/test/fixtures/precompile_user_compile_flags/BUILD
+++ b/test/fixtures/precompile_user_compile_flags/BUILD
@@ -1,0 +1,48 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//swift:swift_binary.bzl", "swift_binary")
+load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
+load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+load("//test/fixtures/precompiled_modules:force_features.bzl", "force_features_binary")
+
+package(default_visibility = ["//test:__subpackages__"])
+
+licenses(["notice"])
+
+swift_interop_hint(
+    name = "Defines_hint",
+    module_name = "Defines",
+    tags = FIXTURE_TAGS,
+)
+
+cc_library(
+    name = "Defines",
+    srcs = [
+        "Defines.c",
+        "Defines.h",
+    ],
+    hdrs = ["Defines.h"],
+    aspect_hints = [":Defines_hint"],
+    copts = [
+        "-DFIXTURE_FROM_COPTS=1",
+        "-include$(location :Defines.h)",
+    ],
+    local_defines = ["FIXTURE_FROM_LOCAL_DEFINES=1"],
+    tags = FIXTURE_TAGS,
+)
+
+swift_binary(
+    name = "user",
+    srcs = ["main.swift"],
+    tags = FIXTURE_TAGS,
+    deps = [":Defines"],
+)
+
+force_features_binary(
+    name = "user_explicit_modules",
+    binary = ":user",
+    tags = FIXTURE_TAGS,
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+    ],
+)

--- a/test/fixtures/precompile_user_compile_flags/BUILD
+++ b/test/fixtures/precompile_user_compile_flags/BUILD
@@ -1,8 +1,8 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//swift:swift_binary.bzl", "swift_binary")
 load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
+load("//test:transitions.bzl", "force_features_binary")
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
-load("//test/fixtures/precompiled_modules:force_features.bzl", "force_features_binary")
 
 package(default_visibility = ["//test:__subpackages__"])
 

--- a/test/fixtures/precompile_user_compile_flags/Defines.c
+++ b/test/fixtures/precompile_user_compile_flags/Defines.c
@@ -1,0 +1,5 @@
+#include "Defines.h"
+
+int defines_fixture_value(void) {
+    return 0;
+}

--- a/test/fixtures/precompile_user_compile_flags/Defines.h
+++ b/test/fixtures/precompile_user_compile_flags/Defines.h
@@ -1,0 +1,15 @@
+#ifndef DEFINES_FIXTURE_H
+#define DEFINES_FIXTURE_H
+
+// If the defines are missing, creating the PCM will fail
+#if !defined(FIXTURE_FROM_COPTS)
+#error "FIXTURE_FROM_COPTS was not defined when compiling the module"
+#endif
+
+#if !defined(FIXTURE_FROM_LOCAL_DEFINES)
+#error "FIXTURE_FROM_LOCAL_DEFINES was not defined when compiling the module"
+#endif
+
+int defines_fixture_value(void);
+
+#endif

--- a/test/fixtures/precompile_user_compile_flags/main.swift
+++ b/test/fixtures/precompile_user_compile_flags/main.swift
@@ -1,0 +1,3 @@
+import Defines
+
+print(defines_fixture_value())


### PR DESCRIPTION
If the underlying cc_library / objc_library target has `-D` flags that
aren't in `defines` (and therefore propagated up), they still might be
necessary if they're used in `#if` conditions in private headers that
are exercised during the pcm compile. We only grab `-D` flags, and
ideally in the future we can use only `local_defines` for this.
