### PR TITLE
Update triple for PCM compiles

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -470,7 +470,6 @@ def _all_action_configs(
                 SWIFT_ACTION_DERIVE_FILES,
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -482,6 +481,7 @@ def _all_action_configs(
             # Actions that run directly with -frontend so -Xfrontend is invalid
             actions = [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [
                 add_arg("-clang-target", sdk_version_triple),

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -433,6 +433,14 @@ def _all_action_configs(
     Returns:
         The action configurations for the Swift toolchain.
     """
+    sdk_version_triple = target_triples.str(target_triples.make(
+        cpu = target_triple.cpu,
+        vendor = target_triple.vendor,
+        os = target_triples.unversioned_os(target_triple) + str(xcode_config.sdk_version_for_platform(
+            target_triples.bazel_apple_platform(target_triple),
+        )),
+        environment = target_triple.environment,
+    ))
 
     # Basic compilation flags (target triple and toolchain search paths).
     action_configs = [
@@ -449,12 +457,37 @@ def _all_action_configs(
             ],
             configurators = [
                 add_arg("-target", target_triples.str(target_triple)),
-                # https://github.com/swiftlang/llvm-project/issues/12826
-                add_arg("-Xcc", "--target={}".format(target_triples.str(target_triple))),
                 add_arg("-sdk", apple_toolchain.sdk_dir()),
             ],
         ),
     ]
+
+    # https://github.com/swiftlang/llvm-project/issues/12826
+    action_configs.extend([
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE,
+                SWIFT_ACTION_DERIVE_FILES,
+                SWIFT_ACTION_DUMP_AST,
+                SWIFT_ACTION_PRECOMPILE_C_MODULE,
+                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
+                SWIFT_ACTION_SYNTHESIZE_INTERFACE,
+            ],
+            configurators = [
+                add_arg("-Xfrontend", "-clang-target"),
+                add_arg("-Xfrontend", sdk_version_triple),
+            ],
+        ),
+        ActionConfigInfo(
+            # Actions that run directly with -frontend so -Xfrontend is invalid
+            actions = [
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+            ],
+            configurators = [
+                add_arg("-clang-target", sdk_version_triple),
+            ],
+        ),
+    ])
 
     action_configs.extend([
         # Xcode path remapping


### PR DESCRIPTION
Turns out what Xcode does for Swift PCM dependencies is it uses the
version of the SDK as the target triple. This doesn't override the
actual deployment target but is passed through separately to the
compiler.

Importantly this sidesteps minimum OS version transition issues because
this version never changes throughout a single build.

Xcode currently uses your actual deployment target for Objective-C
target PCMs, but we don't support that yet so we can ignore that for
now.
