### PR TITLE
Add swift_verify_test rule

### DIFF
--- a/test/rules/swift_verify_test.bzl
+++ b/test/rules/swift_verify_test.bzl
@@ -30,7 +30,7 @@ def _swift_verify_test_impl(ctx):
             output_groups = provider
             break
 
-    test_executable = ctx.actions.declare_file(ctx.label.name)
+    test_executable = ctx.actions.declare_file(ctx.label.name + "_verify_test.sh")
     ctx.actions.write(
         content = "#!/bin/bash\nexit 0\n",
         is_executable = True,

--- a/test/rules/swift_verify_test.bzl
+++ b/test/rules/swift_verify_test.bzl
@@ -1,0 +1,61 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for running swiftc -frontend -verify for asserting diagnostics."""
+
+load("//swift:swift_test.bzl", "swift_test")
+
+_VERIFY_COPTS = [
+    "-wmo",  # Disable incremental
+    "-Xfrontend",
+    "-verify",
+]
+
+def _swift_verify_test_impl(ctx):
+    parent_providers = ctx.super()
+    output_groups = None
+    for provider in parent_providers:
+        if type(provider) == "OutputGroupInfo":
+            output_groups = provider
+            break
+
+    test_executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(
+        content = "#!/bin/bash\nexit 0\n",
+        is_executable = True,
+        output = test_executable,
+    )
+
+    return [
+        DefaultInfo(
+            executable = test_executable,
+            runfiles = ctx.runfiles(
+                # NOTE: Some files from the compile must be propagated or the
+                # compile action won't happen.
+                transitive_files = output_groups.const_values,
+            ),
+        ),
+    ]
+
+def _swift_verify_test_initializer(name, copts = [], **_kwargs):
+    return {
+        "copts": (copts or []) + _VERIFY_COPTS,
+        "discover_tests": False,
+    }
+
+swift_verify_test = rule(
+    implementation = _swift_verify_test_impl,
+    initializer = _swift_verify_test_initializer,
+    parent = swift_test,
+)

--- a/test/verify/BUILD
+++ b/test/verify/BUILD
@@ -1,0 +1,6 @@
+load("//test/rules:swift_verify_test.bzl", "swift_verify_test")
+
+swift_verify_test(
+    name = "unavailable_error",
+    srcs = ["unavailable_error.swift"],
+)

--- a/test/verify/unavailable_error.swift
+++ b/test/verify/unavailable_error.swift
@@ -1,0 +1,4 @@
+@available(*, unavailable)
+struct NeverAvailable {} // expected-note {{'NeverAvailable' has been explicitly marked unavailable here}}
+
+let neverAvailable = NeverAvailable() // expected-error {{'NeverAvailable' is unavailable}}

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -48,6 +48,57 @@ bool copy_file(const std::filesystem::path &from,
 #endif
 }
 
+static bool TouchFile(const std::filesystem::path &path,
+                      std::ostringstream &output) {
+  std::error_code ec;
+  if (!path.parent_path().empty()) {
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+      output << "swift_worker: Could not create directory "
+             << path.parent_path() << " (" << ec.message() << ")\n";
+      return false;
+    }
+  }
+
+  std::ofstream stream(path);
+  if (!stream) {
+    output << "swift_worker: Could not create " << path << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+static bool CreateVerifyOutputs(const std::string &output_file_map_path,
+                                const std::string &emit_module_path,
+                                std::ostringstream &output) {
+  if (!output_file_map_path.empty()) {
+    OutputFileMap output_file_map;
+    output_file_map.ReadFromPath(output_file_map_path, "", "");
+    for (const auto &expected_output_pair :
+         output_file_map.incremental_outputs()) {
+      if (!TouchFile(expected_output_pair.first, output)) {
+        return false;
+      }
+    }
+  }
+
+  if (!emit_module_path.empty()) {
+    if (!TouchFile(emit_module_path, output)) {
+      return false;
+    }
+
+    std::string swiftdoc_path = std::filesystem::path(emit_module_path)
+                                    .replace_extension(".swiftdoc")
+                                    .string();
+    if (!TouchFile(swiftdoc_path, output)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static void FinalizeWorkRequest(
     const bazel_rules_swift::worker_protocol::WorkRequest &request,
     bazel_rules_swift::worker_protocol::WorkResponse &response, int exit_code,
@@ -86,6 +137,7 @@ void WorkProcessor::ProcessWorkRequest(
   std::string emit_objc_header_path;
   bool is_wmo = false;
   bool is_dump_ast = false;
+  bool is_verify = false;
   bool emit_swift_source_info = false;
 
   std::string prev_arg;
@@ -100,6 +152,8 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (arg == "-dump-ast") {
       is_dump_ast = true;
+    } else if (arg == "-verify") {
+      is_verify = true;
     } else if (prev_arg == "-output-file-map") {
       // Peel off the `-output-file-map` argument, so we can rewrite it if
       // necessary later.
@@ -253,6 +307,12 @@ void WorkProcessor::ProcessWorkRequest(
   int exit_code = swift_runner.Run(&stderr_stream, /*stdout_to_stderr=*/true);
   if (exit_code != 0) {
     FinalizeWorkRequest(request, response, exit_code, stderr_stream);
+    return;
+  }
+
+  if (is_verify && !CreateVerifyOutputs(output_file_map_path, emit_module_path,
+                                        stderr_stream)) {
+    FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
     return;
   }
 


### PR DESCRIPTION
This is currently only used in our tests, it runs `swiftc -frontend
-verify` which is a mode that checks the current file being compiled and
asserts things about its diagnostics. It's not really public API but it
is heavily used in the compiler tests so it feels pretty safe. This lets
us write tests against things that shouldn't compile given some
configuration.
