### PR TITLE
Add explicit module app extension test

### DIFF
--- a/test/fixtures/precompiled_modules/ApplicationExtensionLib.swift
+++ b/test/fixtures/precompiled_modules/ApplicationExtensionLib.swift
@@ -1,0 +1,10 @@
+import ExtensionUnavailableObjC
+import Foundation
+
+@available(macOSApplicationExtension, unavailable)
+private func foo() { // expected-note {{'foo()' has been explicitly marked unavailable here}}
+    print("This is a private function in the application extension library.")
+}
+
+let applicationExtensionCheck: Void = foo() // expected-error {{'foo()' is unavailable in application extensions for macOS}}
+let objcApplicationExtensionCheck: String = ExtensionUnavailableAPI.extensionUnavailableMessage() // expected-error {{is unavailable in application extensions for macOS: message}}

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -13,6 +13,7 @@ load(
     "transition_test",
 )
 load("//test/fixtures:common.bzl", "FIXTURE_TAGS")
+load("//test/rules:swift_verify_test.bzl", "swift_verify_test")
 load(":cross_platform.bzl", "cross_platform_targets")
 
 package(default_visibility = ["//test:__subpackages__"])
@@ -277,6 +278,52 @@ transition_binary(
     name = "mixed_language_explicit_bin_transitioned",
     tags = FIXTURE_TAGS,
     target = ":mixed_language_explicit_bin",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+    ],
+)
+
+swift_interop_hint(
+    name = "ExtensionUnavailableObjC_hint",
+    module_name = "ExtensionUnavailableObjC",
+    tags = FIXTURE_TAGS,
+)
+
+objc_library(
+    name = "ExtensionUnavailableObjC",
+    srcs = ["ExtensionUnavailableObjC.m"],
+    hdrs = ["ExtensionUnavailableObjC.h"],
+    aspect_hints = [":ExtensionUnavailableObjC_hint"],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = ["@system_sdk//:Foundation"],
+)
+
+swift_verify_test(
+    name = "application_extension_unavailable",
+    srcs = ["ApplicationExtensionLib.swift"],
+    copts = [
+        "-application-extension",
+        "-Xfrontend",
+        "-verify-ignore-unrelated",
+        "-Xcc",
+        "-fno-application-extension",
+    ],
+    module_name = "ApplicationExtensionLib",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":ExtensionUnavailableObjC",
+        "@system_sdk//:Foundation",
+    ],
+)
+
+transition_test(
+    name = "application_extension_unavailable_transitioned",
+    tags = FIXTURE_TAGS,
+    target = ":application_extension_unavailable",
     transitive_features = [
         "swift.use_c_modules",
         "swift.emit_c_module",

--- a/test/fixtures/precompiled_modules/ExtensionUnavailableObjC.h
+++ b/test/fixtures/precompiled_modules/ExtensionUnavailableObjC.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ExtensionUnavailableAPI : NSObject
++ (NSString *)extensionUnavailableMessage NS_EXTENSION_UNAVAILABLE("message");
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/fixtures/precompiled_modules/ExtensionUnavailableObjC.m
+++ b/test/fixtures/precompiled_modules/ExtensionUnavailableObjC.m
@@ -1,0 +1,9 @@
+#import "test/fixtures/precompiled_modules/ExtensionUnavailableObjC.h"
+
+@implementation ExtensionUnavailableAPI
+
++ (NSString *)extensionUnavailableMessage {
+    return @"extension unavailable Objective-C API";
+}
+
+@end

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -117,6 +117,7 @@ def precompiled_modules_test_suite(name, tags = []):
     build_test(
         name = "{}_build_test".format(name),
         targets = [
+            "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",
             "//test/fixtures/precompiled_modules:lower_version_bin_transitioned",

--- a/test/rules/swift_verify_test.bzl
+++ b/test/rules/swift_verify_test.bzl
@@ -30,7 +30,7 @@ def _swift_verify_test_impl(ctx):
             output_groups = provider
             break
 
-    test_executable = ctx.actions.declare_file(ctx.label.name)
+    test_executable = ctx.actions.declare_file(ctx.label.name + "_verify_test.sh")
     ctx.actions.write(
         content = "#!/bin/bash\nexit 0\n",
         is_executable = True,

--- a/test/rules/swift_verify_test.bzl
+++ b/test/rules/swift_verify_test.bzl
@@ -1,0 +1,61 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rule for running swiftc -frontend -verify for asserting diagnostics."""
+
+load("//swift:swift_test.bzl", "swift_test")
+
+_VERIFY_COPTS = [
+    "-wmo",  # Disable incremental
+    "-Xfrontend",
+    "-verify",
+]
+
+def _swift_verify_test_impl(ctx):
+    parent_providers = ctx.super()
+    output_groups = None
+    for provider in parent_providers:
+        if type(provider) == "OutputGroupInfo":
+            output_groups = provider
+            break
+
+    test_executable = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(
+        content = "#!/bin/bash\nexit 0\n",
+        is_executable = True,
+        output = test_executable,
+    )
+
+    return [
+        DefaultInfo(
+            executable = test_executable,
+            runfiles = ctx.runfiles(
+                # NOTE: Some files from the compile must be propagated or the
+                # compile action won't happen.
+                transitive_files = output_groups.const_values,
+            ),
+        ),
+    ]
+
+def _swift_verify_test_initializer(name, copts = [], **_kwargs):
+    return {
+        "copts": (copts or []) + _VERIFY_COPTS,
+        "discover_tests": False,
+    }
+
+swift_verify_test = rule(
+    implementation = _swift_verify_test_impl,
+    initializer = _swift_verify_test_initializer,
+    parent = swift_test,
+)

--- a/test/verify/BUILD
+++ b/test/verify/BUILD
@@ -1,0 +1,6 @@
+load("//test/rules:swift_verify_test.bzl", "swift_verify_test")
+
+swift_verify_test(
+    name = "unavailable_error",
+    srcs = ["unavailable_error.swift"],
+)

--- a/test/verify/unavailable_error.swift
+++ b/test/verify/unavailable_error.swift
@@ -1,0 +1,4 @@
+@available(*, unavailable)
+struct NeverAvailable {} // expected-note {{'NeverAvailable' has been explicitly marked unavailable here}}
+
+let neverAvailable = NeverAvailable() // expected-error {{'NeverAvailable' is unavailable}}

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -48,6 +48,57 @@ bool copy_file(const std::filesystem::path &from,
 #endif
 }
 
+static bool TouchFile(const std::filesystem::path &path,
+                      std::ostringstream &output) {
+  std::error_code ec;
+  if (!path.parent_path().empty()) {
+    std::filesystem::create_directories(path.parent_path(), ec);
+    if (ec) {
+      output << "swift_worker: Could not create directory "
+             << path.parent_path() << " (" << ec.message() << ")\n";
+      return false;
+    }
+  }
+
+  std::ofstream stream(path);
+  if (!stream) {
+    output << "swift_worker: Could not create " << path << "\n";
+    return false;
+  }
+
+  return true;
+}
+
+static bool CreateVerifyOutputs(const std::string &output_file_map_path,
+                                const std::string &emit_module_path,
+                                std::ostringstream &output) {
+  if (!output_file_map_path.empty()) {
+    OutputFileMap output_file_map;
+    output_file_map.ReadFromPath(output_file_map_path, "", "");
+    for (const auto &expected_output_pair :
+         output_file_map.incremental_outputs()) {
+      if (!TouchFile(expected_output_pair.first, output)) {
+        return false;
+      }
+    }
+  }
+
+  if (!emit_module_path.empty()) {
+    if (!TouchFile(emit_module_path, output)) {
+      return false;
+    }
+
+    std::string swiftdoc_path = std::filesystem::path(emit_module_path)
+                                    .replace_extension(".swiftdoc")
+                                    .string();
+    if (!TouchFile(swiftdoc_path, output)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 static void FinalizeWorkRequest(
     const bazel_rules_swift::worker_protocol::WorkRequest &request,
     bazel_rules_swift::worker_protocol::WorkResponse &response, int exit_code,
@@ -86,6 +137,7 @@ void WorkProcessor::ProcessWorkRequest(
   std::string emit_objc_header_path;
   bool is_wmo = false;
   bool is_dump_ast = false;
+  bool is_verify = false;
   bool emit_swift_source_info = false;
 
   std::string prev_arg;
@@ -100,6 +152,8 @@ void WorkProcessor::ProcessWorkRequest(
       arg.clear();
     } else if (arg == "-dump-ast") {
       is_dump_ast = true;
+    } else if (arg == "-verify") {
+      is_verify = true;
     } else if (prev_arg == "-output-file-map") {
       // Peel off the `-output-file-map` argument, so we can rewrite it if
       // necessary later.
@@ -253,6 +307,12 @@ void WorkProcessor::ProcessWorkRequest(
   int exit_code = swift_runner.Run(&stderr_stream, /*stdout_to_stderr=*/true);
   if (exit_code != 0) {
     FinalizeWorkRequest(request, response, exit_code, stderr_stream);
+    return;
+  }
+
+  if (is_verify && !CreateVerifyOutputs(output_file_map_path, emit_module_path,
+                                        stderr_stream)) {
+    FinalizeWorkRequest(request, response, EXIT_FAILURE, stderr_stream);
     return;
   }
 


### PR DESCRIPTION
We have to apply a weird workaround for app extensions, this makes sure
we still get stopped from using API that we shouldn't be
