### PR TITLE
drop bazel 7 support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,9 +6,6 @@ common --incompatible_allow_tags_propagation
 common --flag_alias=swiftcopt=//swift:copt
 common --flag_alias=host_swiftcopt=//swift:exec_copt
 
-# Fail if a glob doesn't match anything (https://github.com/bazelbuild/bazel/issues/8195)
-build --incompatible_disallow_empty_glob
-
 build --host_macos_minimum_os=14.0
 build --macos_minimum_os=14.0
 
@@ -16,16 +13,8 @@ build --macos_minimum_os=14.0
 # dependencies cause us to use a newer version
 build --check_direct_dependencies=off
 
-# This is needed for Bazel 6 compatibility.
-# It's enabled (and can't be disabled) in Bazel 7.
-# TODO: Remove this once we drop Bazel 6 support.
-# See also: https://github.com/bazelbuild/bazel/issues/14327
-build --experimental_enable_aspect_hints
-
 # Make sure no warnings slip into the C++ tools we vendor
 build --features treat_warnings_as_errors
-# TODO: Remove when we update protobuf
-build --copt=-Wno-deprecated-declarations --host_copt=-Wno-deprecated-declarations
 
 # The default strategy is worker, which has sandboxing disabled by default,
 # which can hide issues with non-hermetic bugs.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@
 module(
     name = "rules_swift",
     version = "0",
-    bazel_compatibility = [">=7.0.0"],
+    bazel_compatibility = [">=8.0.0"],
     compatibility_level = 3,
     repo_name = "build_bazel_rules_swift",
 )

--- a/README.md
+++ b/README.md
@@ -123,9 +123,11 @@ as best as we can since the 1.0.0 release.
 
 | Bazel release | Minimum supported rules version | Final supported rules version|
 |:-------------------:|:-------------------:|:-------------------------:|
-| 8.x (most recent rolling) | 0.27.0 | current |
-| 7.x | 0.27.0 | current |
-| 6.x | 0.27.0 | 2.2.0 |
+| 10.x (most recent rolling) | 3.5.0 | current |
+| 9.x | 3.5.0 | current |
+| 8.x | 1.14.0 | current |
+| 7.x | 1.8.0 | 3.6.1 |
+| 6.x | 0.27.0 | 2.8.2 |
 | 5.x | 0.25.0 | 1.14.0 |
 | 4.x | 0.19.0 | 0.24.0 |
 | 3.x | 0.14.0 | 0.18.0 |

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -319,11 +319,6 @@ swift_interop_hint(<a href="#swift_interop_hint-name">name</a>, <a href="#swift_
 Defines an aspect hint that associates non-Swift BUILD targets with additional
 information required for them to be imported by Swift.
 
-> [!NOTE]
-> Bazel 6 users must set the `--experimental_enable_aspect_hints` flag to utilize
-> this rule. In addition, downstream consumers of rules that utilize this rule
-> must also set the flag. The flag is enabled by default in Bazel 7.
-
 Some build rules, such as `objc_library`, support interoperability with Swift
 simply by depending on them; a module map is generated automatically. This is
 for convenience, because the common case is that most `objc_library` targets

--- a/swift/internal/actions.bzl
+++ b/swift/internal/actions.bzl
@@ -18,10 +18,6 @@ load("@bazel_skylib//lib:types.bzl", "types")
 load("//swift/toolchains/config:action_config.bzl", "ConfigResultInfo")
 load(":features.bzl", "are_all_features_enabled", "gather_toolchains")
 
-# This is a proxy for being on bazel 7.x which has
-# --incompatible_merge_fixed_and_default_shell_env enabled by default
-USE_DEFAULT_SHELL_ENV = not hasattr(apple_common, "apple_crosstool_transition")
-
 def _apply_action_configs(
         action_name,
         args,
@@ -248,6 +244,6 @@ def run_toolchain_action(
             tools,
             transitive = action_inputs.additional_tools,
         ),
-        use_default_shell_env = USE_DEFAULT_SHELL_ENV,
+        use_default_shell_env = True,
         **kwargs
     )

--- a/swift/internal/module_maps.bzl
+++ b/swift/internal/module_maps.bzl
@@ -16,9 +16,6 @@
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
 
-# TODO(#723): Remove these disables once https://github.com/bazelbuild/buildtools/issues/926 is fixed
-# buildifier: disable=return-value
-# buildifier: disable=function-docstring-return
 def write_module_map(
         actions,
         module_map_file,

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -693,8 +693,7 @@ def _find_swift_interop_info(target, aspect_ctx):
     # We don't break this loop early when we find a matching hint, because we
     # want to give an error message if there are two aspect hints that provide
     # `SwiftInteropInfo` (or if both the rule and an aspect hint do).
-    # TODO: remove usage of `getattr` and use `aspect_ctx.rule.attr.aspect_hints` directly when we drop Bazel 6.
-    for hint in getattr(aspect_ctx.rule.attr, "aspect_hints", []):
+    for hint in aspect_ctx.rule.attr.aspect_hints:
         if SwiftInteropInfo in hint:
             if interop_target:
                 if interop_from_rule:

--- a/swift/swift_interop_hint.bzl
+++ b/swift/swift_interop_hint.bzl
@@ -81,11 +81,6 @@ generate.
 Defines an aspect hint that associates non-Swift BUILD targets with additional
 information required for them to be imported by Swift.
 
-> [!NOTE]
-> Bazel 6 users must set the `--experimental_enable_aspect_hints` flag to utilize
-> this rule. In addition, downstream consumers of rules that utilize this rule
-> must also set the flag. The flag is enabled by default in Bazel 7.
-
 Some build rules, such as `objc_library`, support interoperability with Swift
 simply by depending on them; a module map is generated automatically. This is
 for convenience, because the common case is that most `objc_library` targets

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -528,11 +528,7 @@ def _swift_toolchain_impl(ctx):
             additional_rpaths,
         )
 
-    # TODO: Remove once we drop bazel 7.x support
-    if not bazel_features.cc.swift_fragment_removed:
-        swiftcopts = list(ctx.fragments.swift.copts())
-    else:
-        swiftcopts = []
+    swiftcopts = []
 
     if is_exec_config(ctx):
         swiftcopts.extend(ctx.attr._exec_copts[BuildSettingInfo].value)

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -792,11 +792,7 @@ def _xcode_swift_toolchain_impl(ctx):
 
     xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
 
-    # TODO: Remove once we drop bazel 7.x support
-    if not bazel_features.cc.swift_fragment_removed:
-        swiftcopts = list(ctx.fragments.swift.copts())
-    else:
-        swiftcopts = []
+    swiftcopts = []
 
     if is_exec_config(ctx):
         swiftcopts.extend(ctx.attr._exec_copts[BuildSettingInfo].value)


### PR DESCRIPTION
In service of an N-1 + rolling support policy, plus cleaning up some small amount of cruft. Better to do this before we continue pushing breaking changes in 4.x, since we haven't been testing 7.x in CI in a while.
