### PR TITLE
Add verify test for add_default_precompiled_modules

### DIFF
--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -302,6 +302,29 @@ objc_library(
 )
 
 swift_verify_test(
+    name = "foundation_requires_explicit_dep",
+    srcs = ["foundation_requires_explicit_dep.swift"],
+    module_name = "FoundationRequiresExplicitDep",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = select({
+        "@build_bazel_apple_support//configs:apple": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = ["@system_sdk//:CoreFoundation"],
+)
+
+transition_test(
+    name = "foundation_requires_explicit_dep_transitioned",
+    tags = FIXTURE_TAGS,
+    target = ":foundation_requires_explicit_dep",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+    ],
+)
+
+swift_verify_test(
     name = "application_extension_unavailable",
     srcs = ["ApplicationExtensionLib.swift"],
     copts = [

--- a/test/fixtures/precompiled_modules/foundation_requires_explicit_dep.swift
+++ b/test/fixtures/precompiled_modules/foundation_requires_explicit_dep.swift
@@ -1,0 +1,1 @@
+import Foundation // expected-error {{Foundation}}

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -118,6 +118,7 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_build_test".format(name),
         targets = [
             "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
+            "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",
             "//test/fixtures/precompiled_modules:lower_version_bin_transitioned",


### PR DESCRIPTION
This makes sure swift can't accidentally find this module
