### PR TITLE
Add more SwiftInfo to system_module_group

### DIFF
--- a/swift/internal/system_module_group.bzl
+++ b/swift/internal/system_module_group.bzl
@@ -16,21 +16,44 @@
 
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load("//swift:providers.bzl", "SwiftInfo")
+load("//swift:providers.bzl", "SwiftInfo", "create_swift_module_context")
 load(":system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
 load(":utils.bzl", "get_providers")
 
+def _inferred_module_name(ctx):
+    target_name = ctx.label.name
+    sdk_name = ctx.attr.sdk_name
+    if sdk_name:
+        prefix = sdk_name + "_"
+        if target_name.startswith(prefix):
+            return target_name[len(prefix):]
+    return target_name
+
 def _system_module_group_impl(ctx):
+    modules = []
+    if ctx.attr.creates_module:
+        modules.append(create_swift_module_context(
+            name = _inferred_module_name(ctx),
+            is_system = True,
+        ))
+
     return [
         DefaultInfo(),
         cc_common.merge_cc_infos(
             cc_infos = [d[CcInfo] for d in ctx.attr.modules if CcInfo in d],
         ),
-        SwiftInfo(swift_infos = get_providers(ctx.attr.modules, SwiftInfo)),
+        SwiftInfo(
+            modules = modules,
+            swift_infos = get_providers(ctx.attr.modules, SwiftInfo),
+        ),
     ]
 
 system_module_group = rule(
     attrs = sdk_min_os_transition_attrs() | {
+        "creates_module": attr.bool(
+            default = True,
+            doc = "Whether this group propagates a direct system module inferred from the target name.",
+        ),
         "modules": attr.label_list(providers = [[CcInfo, SwiftInfo]]),
     },
     cfg = sdk_min_os_transition,

--- a/tools/explicit_modules/extensions.bzl
+++ b/tools/explicit_modules/extensions.bzl
@@ -172,7 +172,10 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-system_module_group(name = "all_modules")
+system_module_group(
+    name = "all_modules",
+    creates_module = False,
+)
 """
 
 def _system_sdk_stub_repo_impl(rctx):

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -107,7 +107,10 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-system_module_group(name = "_empty_all_modules")
+system_module_group(
+    name = "_empty_all_modules",
+    creates_module = False,
+)
 """
 
 
@@ -210,6 +213,7 @@ def _render_all_modules_group(
     out.write("\n")
     out.write("system_module_group(\n")
     out.write(f'    name = "{sdk}_all_modules",\n')
+    out.write("    creates_module = False,\n")
     out.write("    modules = [\n")
     _write_labels(out, {f"{sdk}_{name}" for name in all_module_names})
     out.write("    ],\n")


### PR DESCRIPTION
This will be used with cross module imports, so we need to return the
real module name that exists.
