### PR TITLE
Add cross import overlay handling

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -197,7 +197,7 @@ using `swift_compiler_plugin`.
 
 <pre>
 swift_cross_import_overlay(<a href="#swift_cross_import_overlay-name">name</a>, <a href="#swift_cross_import_overlay-deps">deps</a>, <a href="#swift_cross_import_overlay-bystanding_module">bystanding_module</a>, <a href="#swift_cross_import_overlay-bystanding_module_name">bystanding_module_name</a>, <a href="#swift_cross_import_overlay-declaring_module">declaring_module</a>,
-                           <a href="#swift_cross_import_overlay-declaring_module_name">declaring_module_name</a>)
+                           <a href="#swift_cross_import_overlay-declaring_module_name">declaring_module_name</a>, <a href="#swift_cross_import_overlay-swiftoverlay">swiftoverlay</a>)
 </pre>
 
 Declares a cross-import overlay that will be automatically added as a dependency
@@ -233,6 +233,7 @@ the future, this rule is not recommended for other widespread use.
 | <a id="swift_cross_import_overlay-bystanding_module_name"></a>bystanding_module_name |  The name of the bystanding module from the target specified by the `bystanding_module` attribute. This is inferred if `bystanding_module` only exports a single direct module; this name must be specified if `bystanding_module` exports more than one.   | String | optional |  `""`  |
 | <a id="swift_cross_import_overlay-declaring_module"></a>declaring_module |  A label for the target representing the first of the two modules (the other being `bystanding_module`) that must be imported for the cross-import overlay modules to be imported. This is the module that contains the `.swiftcrossimport` overlay definition that connects it to the bystander and to the overlay modules.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="swift_cross_import_overlay-declaring_module_name"></a>declaring_module_name |  The name of the declaring module from the target specified by the `declaring_module` attribute. This is inferred if `declaring_module` only exports a single direct module; this name must be specified if `declaring_module` exports more than one.   | String | optional |  `""`  |
+| <a id="swift_cross_import_overlay-swiftoverlay"></a>swiftoverlay |  The path to the SDK `.swiftoverlay` file that declares this cross-import.   | String | required |  |
 
 
 <a id="swift_feature_allowlist"></a>
@@ -1113,5 +1114,4 @@ Once that is the case, this macro will be deprecated.
 | <a id="mixed_language_library-weak_sdk_frameworks"></a>weak_sdk_frameworks |  A list of SDK frameworks to weakly link with. For instance, "MediaAccessibility". In difference to regularly linked SDK frameworks, symbols from weakly linked frameworks do not cause an error if they are not present at runtime.   |  `[]` |
 | <a id="mixed_language_library-deps"></a>deps |  A list of targets that are dependencies of the target being built.   |  `[]` |
 | <a id="mixed_language_library-kwargs"></a>kwargs |  Additional arguments to pass to the underlying clang and swift library targets.   |  none |
-
 

--- a/doc/rules.md
+++ b/doc/rules.md
@@ -1115,3 +1115,4 @@ Once that is the case, this macro will be deprecated.
 | <a id="mixed_language_library-deps"></a>deps |  A list of targets that are dependencies of the target being built.   |  `[]` |
 | <a id="mixed_language_library-kwargs"></a>kwargs |  Additional arguments to pass to the underlying clang and swift library targets.   |  none |
 
+

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -249,6 +249,7 @@ bzl_library(
         "//swift:__subpackages__",
     ],
     deps = [
+        ":providers",
         "@bazel_features//:features",
         "@bazel_skylib//lib:paths",
         "@rules_cc//cc/common",

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -57,6 +57,7 @@ load(
     "SWIFT_FEATURE_SPLIT_DERIVED_FILES_GENERATION",
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_THIN_LTO",
+    "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
     "SWIFT_FEATURE_VFSOVERLAY",
     "SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS",
@@ -568,10 +569,21 @@ def compile(
     # TODO(allevato): It would potentially clean things up if we included the
     # toolchain's implicit dependencies here as well. Do this and make sure it
     # doesn't break anything unexpected.
-    swift_infos_to_propagate = swift_infos + _cross_imported_swift_infos(
-        swift_toolchain = toolchains.swift,
-        user_swift_infos = swift_infos + private_swift_infos + implicit_swift_infos,
-    )
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_USE_C_MODULES,
+    ):
+        cross_imported_overlays = _cross_imported_overlays(
+            swift_toolchain = toolchains.swift,
+            user_swift_infos = swift_infos + private_swift_infos + implicit_swift_infos,
+        )
+    else:
+        cross_imported_overlays = []
+    swift_infos_to_propagate = swift_infos + [
+        swift_info
+        for overlay in cross_imported_overlays
+        for swift_info in overlay.swift_infos
+    ]
     all_swift_infos = (
         swift_infos_to_propagate + private_swift_infos + implicit_swift_infos
     )
@@ -748,6 +760,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         cc_compilation_context = merged_cc_info.compilation_context,
         const_gather_protocols_file = const_gather_protocols_file,
         cc_linking_context = merged_cc_info.linking_context,
+        cross_import_overlays = cross_imported_overlays,
         defines = sets.to_list(defines_set),
         developer_dirs = toolchains.swift.developer_dirs,
         experimental_features = experimental_features,
@@ -1262,8 +1275,11 @@ def _create_cc_compilation_context(
         transitive_compilation_contexts = compilation_contexts,
     )
 
-def _cross_imported_swift_infos(*, swift_toolchain, user_swift_infos):
-    """Returns `SwiftInfo` providers for any cross-imported modules.
+def _cross_imported_overlays(
+        *,
+        swift_toolchain,
+        user_swift_infos):
+    """Returns cross-import overlays needed for a compilation.
 
     Args:
         swift_toolchain: The `SwiftToolchainInfo` provider of the toolchain.
@@ -1274,8 +1290,8 @@ def _cross_imported_swift_infos(*, swift_toolchain, user_swift_infos):
             compilation prerequisites, if any.
 
     Returns:
-        A list of `SwiftInfo` providers representing cross-import overlays
-        needed for compilation.
+        A list of `SwiftCrossImportOverlayInfo` providers needed for
+        compilation.
     """
 
     # Build a "set" containing the module names of direct dependencies so that
@@ -1288,13 +1304,13 @@ def _cross_imported_swift_infos(*, swift_toolchain, user_swift_infos):
     # For each cross-import overlay registered with the toolchain, add its
     # `SwiftInfo` providers to the list if both its declaring and bystanding
     # modules were imported.
-    overlay_swift_infos = []
+    overlays = []
     for overlay in swift_toolchain.cross_import_overlays:
         if (overlay.declaring_module in direct_module_names and
             overlay.bystanding_module in direct_module_names):
-            overlay_swift_infos.extend(overlay.swift_infos)
+            overlays.append(overlay)
 
-    return overlay_swift_infos
+    return overlays
 
 def _declare_compile_outputs(
         *,

--- a/swift/internal/providers.bzl
+++ b/swift/internal/providers.bzl
@@ -43,6 +43,18 @@ A list of `SwiftInfo` providers that describe the cross-import overlay modules
 that should be injected into the dependencies of a compilation when both the
 `declaring_module` and `bystanding_module` are imported.
 """,
+        "swiftoverlay_file": """\
+The path to the SDK `.swiftoverlay` file that declares this cross-import.
+""",
+    },
+)
+
+SwiftCrossImportOverlaysInfo = provider(
+    doc = "A collection of cross-import overlay module definitions.",
+    fields = {
+        "overlays": """\
+A list of `SwiftCrossImportOverlayInfo` providers.
+""",
     },
 )
 

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -289,8 +289,9 @@ xcode_swift_toolchain(
 
 xcode_swift_toolchain(
     name = "xcode-toolchain",
+    cross_import_overlays = ["@system_sdk//:all_cross_import_overlays"],
     features = [{feature_list}],
-    system_modules = "@system_sdk//:all_modules"
+    system_modules = "@system_sdk//:all_modules",
 )
 """.format(
         feature_list = ", ".join([

--- a/swift/internal/utils.bzl
+++ b/swift/internal/utils.bzl
@@ -27,6 +27,11 @@ load(
     "SWIFT_FEATURE_USE_C_MODULES",
 )
 load(":features.bzl", "is_feature_enabled")
+load(
+    ":providers.bzl",
+    "SwiftCrossImportOverlayInfo",
+    "SwiftCrossImportOverlaysInfo",
+)
 
 def collect_implicit_deps_providers(targets, additional_cc_infos = []):
     """Returns a struct with important providers from a list of implicit deps.
@@ -59,6 +64,24 @@ def collect_implicit_deps_providers(targets, additional_cc_infos = []):
         cc_infos = cc_infos + additional_cc_infos,
         swift_infos = swift_infos,
     )
+
+def collect_cross_import_overlays(targets):
+    """Returns cross-import overlay providers from targets or groups.
+
+    Args:
+        targets: A list of targets that provide `SwiftCrossImportOverlayInfo` or
+            `SwiftCrossImportOverlaysInfo`.
+
+    Returns:
+        A list of `SwiftCrossImportOverlayInfo` providers.
+    """
+    overlays = []
+    for target in targets:
+        if SwiftCrossImportOverlayInfo in target:
+            overlays.append(target[SwiftCrossImportOverlayInfo])
+        if SwiftCrossImportOverlaysInfo in target:
+            overlays.extend(target[SwiftCrossImportOverlaysInfo].overlays)
+    return overlays
 
 def compact(sequence):
     """Returns a copy of the sequence with any `None` items removed.

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -46,6 +46,11 @@ load(
 )
 load(":swift_common.bzl", _swift_common = "swift_common")
 load(
+    ":swift_cross_import_overlay.bzl",
+    _swift_cross_import_overlay = "swift_cross_import_overlay",
+    _swift_cross_import_overlay_group = "swift_cross_import_overlay_group",
+)
+load(
     ":swift_extract_symbol_graph.bzl",
     _swift_extract_symbol_graph = "swift_extract_symbol_graph",
 )
@@ -83,12 +88,10 @@ SwiftToolchainInfo = _SwiftToolchainInfo
 swift_common = _swift_common
 
 # Re-export rules.
-system_clang_module = _system_clang_module
-system_module_group = _system_module_group
-system_swiftinterface = _system_swiftinterface
 swift_binary = _swift_binary
 swift_compiler_plugin = _swift_compiler_plugin
-universal_swift_compiler_plugin = _universal_swift_compiler_plugin
+swift_cross_import_overlay = _swift_cross_import_overlay
+swift_cross_import_overlay_group = _swift_cross_import_overlay_group
 swift_extract_symbol_graph = _swift_extract_symbol_graph
 swift_feature_allowlist = _swift_feature_allowlist
 swift_import = _swift_import
@@ -97,6 +100,10 @@ swift_library = _swift_library
 swift_library_group = _swift_library_group
 swift_package_configuration = _swift_package_configuration
 swift_test = _swift_test
+system_clang_module = _system_clang_module
+system_module_group = _system_module_group
+system_swiftinterface = _system_swiftinterface
+universal_swift_compiler_plugin = _universal_swift_compiler_plugin
 
 # Re-export public aspects.
 swift_clang_module_aspect = _swift_clang_module_aspect

--- a/swift/swift_cross_import_overlay.bzl
+++ b/swift/swift_cross_import_overlay.bzl
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implementation of the `swift_cross_import_overlay` rule."""
+"""Implementation of cross-import overlay rules."""
 
-load("//swift/internal:providers.bzl", "SwiftCrossImportOverlayInfo")
+load(
+    "//swift/internal:providers.bzl",
+    "SwiftCrossImportOverlayInfo",
+    "SwiftCrossImportOverlaysInfo",
+)
 load(":providers.bzl", "SwiftInfo")
 
 def _get_sole_module_name(swift_info, attr):
@@ -38,6 +42,7 @@ def _swift_cross_import_overlay_impl(ctx):
             bystanding_module = bystanding_module,
             declaring_module = declaring_module,
             swift_infos = [dep[SwiftInfo] for dep in ctx.attr.deps],
+            swiftoverlay_file = ctx.attr.swiftoverlay,
         ),
     ]
 
@@ -92,6 +97,10 @@ dependencies when a target depends on both `declaring_module` and
             mandatory = True,
             providers = [[SwiftInfo]],
         ),
+        "swiftoverlay": attr.string(
+            doc = "The path to the SDK `.swiftoverlay` file that declares this cross-import.",
+            mandatory = True,
+        ),
     },
     doc = """\
 Declares a cross-import overlay that will be automatically added as a dependency
@@ -117,4 +126,24 @@ a public feature of the compiler and its design and implementation may change in
 the future, this rule is not recommended for other widespread use.
 """,
     implementation = _swift_cross_import_overlay_impl,
+)
+
+def _swift_cross_import_overlay_group_impl(ctx):
+    return [
+        SwiftCrossImportOverlaysInfo(
+            overlays = [
+                target[SwiftCrossImportOverlayInfo]
+                for target in ctx.attr.overlays
+            ],
+        ),
+    ]
+
+swift_cross_import_overlay_group = rule(
+    attrs = {
+        "overlays": attr.label_list(
+            allow_empty = True,
+            providers = [[SwiftCrossImportOverlayInfo]],
+        ),
+    },
+    implementation = _swift_cross_import_overlay_group_impl,
 )

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -931,6 +931,11 @@ def compile_action_configs(
         ),
         ActionConfigInfo(
             actions = all_compile_action_names(),
+            configurators = [_cross_import_overlays_configurator],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ),
+        ActionConfigInfo(
+            actions = all_compile_action_names(),
             configurators = [_module_aliases_configurator],
         ),
         ActionConfigInfo(
@@ -2151,6 +2156,15 @@ def _plugin_search_paths_configurator(prerequisites, args):
             "-plugin-path",
             "__BAZEL_SWIFT_TOOLCHAIN_PATH__/usr/lib/swift/host/plugins/testing",
         )
+
+def _cross_import_overlays_configurator(prerequisites, args):
+    """Adds cross-import overlay declarations to the command line."""
+    if prerequisites.cross_import_overlays:
+        args.add("-Xfrontend", "-disable-cross-import-overlay-search")
+    for overlay in prerequisites.cross_import_overlays:
+        args.add("-Xfrontend", "-swift-module-cross-import")
+        args.add("-Xfrontend", overlay.declaring_module)
+        args.add("-Xfrontend", overlay.swiftoverlay_file)
 
 def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args, is_frontend = False):
     """Provides a single `.swiftmodule` search path using a VFS overlay."""

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -64,11 +64,13 @@ load(
 load(
     "//swift/internal:providers.bzl",
     "SwiftCrossImportOverlayInfo",
+    "SwiftCrossImportOverlaysInfo",
     "SwiftModuleAliasesInfo",
 )
 load("//swift/internal:target_triples.bzl", "target_triples")
 load(
     "//swift/internal:utils.bzl",
+    "collect_cross_import_overlays",
     "collect_implicit_deps_providers",
     "get_swift_executable_for_toolchain",
     "is_exec_config",
@@ -605,10 +607,7 @@ def _swift_toolchain_impl(ctx):
         clang_implicit_deps_providers = (
             collect_implicit_deps_providers([])
         ),
-        cross_import_overlays = [
-            target[SwiftCrossImportOverlayInfo]
-            for target in ctx.attr.cross_import_overlays
-        ],
+        cross_import_overlays = collect_cross_import_overlays(ctx.attr.cross_import_overlays),
         debug_outputs_provider = None,
         developer_dirs = [],
         entry_point_linkopts_provider = _entry_point_linkopts_provider,
@@ -675,12 +674,16 @@ architecture-specific content, such as "x86_64" in "lib/swift/linux/x86_64".
             "cross_import_overlays": attr.label_list(
                 allow_empty = True,
                 doc = """\
-A list of `swift_cross_import_overlay` targets that will be automatically
-injected into the dependencies of Swift compilations if their declaring module
-and bystanding module are both already declared as dependencies.
+A list of `swift_cross_import_overlay` or `swift_cross_import_overlay_group`
+targets that will be automatically injected into the dependencies of Swift
+compilations if their declaring module and bystanding module are both already
+declared as dependencies.
 """,
                 mandatory = False,
-                providers = [[SwiftCrossImportOverlayInfo]],
+                providers = [
+                    [SwiftCrossImportOverlayInfo],
+                    [SwiftCrossImportOverlaysInfo],
+                ],
             ),
             "feature_allowlists": attr.label_list(
                 doc = """\

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -71,11 +71,13 @@ load(
 load(
     "//swift/internal:providers.bzl",
     "SwiftCrossImportOverlayInfo",
+    "SwiftCrossImportOverlaysInfo",
     "SwiftModuleAliasesInfo",
 )
 load("//swift/internal:target_triples.bzl", "target_triples")
 load(
     "//swift/internal:utils.bzl",
+    "collect_cross_import_overlays",
     "collect_implicit_deps_providers",
     "compact",
     "get_swift_executable_for_toolchain",
@@ -945,10 +947,7 @@ def _xcode_swift_toolchain_impl(ctx):
         clang_implicit_deps_providers = collect_implicit_deps_providers(
             ctx.attr.clang_implicit_deps,
         ),
-        cross_import_overlays = [
-            target[SwiftCrossImportOverlayInfo]
-            for target in ctx.attr.cross_import_overlays
-        ],
+        cross_import_overlays = collect_cross_import_overlays(ctx.attr.cross_import_overlays),
         developer_dirs = swift_toolchain_developer_paths,
         entry_point_linkopts_provider = _entry_point_linkopts_provider,
         feature_allowlists = [
@@ -1027,12 +1026,16 @@ implicit dependencies.
             "cross_import_overlays": attr.label_list(
                 allow_empty = True,
                 doc = """\
-A list of `swift_cross_import_overlay` targets that will be automatically
-injected into the dependencies of Swift compilations if their declaring module
-and bystanding module are both already declared as dependencies.
+A list of `swift_cross_import_overlay` or `swift_cross_import_overlay_group`
+targets that will be automatically injected into the dependencies of Swift
+compilations if their declaring module and bystanding module are both already
+declared as dependencies.
 """,
                 mandatory = False,
-                providers = [[SwiftCrossImportOverlayInfo]],
+                providers = [
+                    [SwiftCrossImportOverlayInfo],
+                    [SwiftCrossImportOverlaysInfo],
+                ],
             ),
             "default_enabled_features": attr.string_list(
                 doc = """\

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -427,6 +427,37 @@ transition_binary(
     ],
 )
 
+swift_binary(
+    name = "cross_import_overlay",
+    srcs = [
+        # NOTE: The current API requires a cross import overlay, but we might
+        # need to find another one in the future if this one moves.
+        "cross_import_overlay.swift",
+        "main.swift",
+    ],
+    copts = ["-suppress-warnings"],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = select({
+        "@build_bazel_apple_support//configs:apple": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        "@system_sdk//:MapKit",
+        "@system_sdk//:SwiftUI",
+    ],
+)
+
+transition_binary(
+    name = "cross_import_overlay_transitioned",
+    tags = FIXTURE_TAGS,
+    target = ":cross_import_overlay",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+    ],
+)
+
 bzl_library(
     name = "cross_platform",
     srcs = ["cross_platform.bzl"],

--- a/test/fixtures/precompiled_modules/cross_import_overlay.swift
+++ b/test/fixtures/precompiled_modules/cross_import_overlay.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import MapKit
+
+var hola: some View {
+    Map(
+        coordinateRegion: .constant(MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            latitudinalMeters: 200,
+            longitudinalMeters: 200
+        )),
+    annotationItems: [
+        Pin(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0))
+    ]
+    ) { pin in
+        MapMarker(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0), tint: .green)
+    }
+}
+
+struct Pin: Identifiable {
+    let id = "1"
+    let coordinate: CLLocationCoordinate2D
+}
+
+

--- a/test/fixtures/precompiled_modules/cross_platform.bzl
+++ b/test/fixtures/precompiled_modules/cross_platform.bzl
@@ -4,6 +4,7 @@ load("//test:transitions.bzl", "transition_binary")
 
 _BINARIES = [
     "c_module_imports",
+    "cross_import_overlay",
     "mixed_language_bin",
     "mixed_language_explicit_bin",
     "objc_interop_implicit_bin",

--- a/tools/explicit_modules/extensions.bzl
+++ b/tools/explicit_modules/extensions.bzl
@@ -167,10 +167,13 @@ def _sdk_extension_impl(module_ctx):
 _STUB_BUILD_FILE = """\
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_cross_import_overlay_group",
     "system_module_group",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+swift_cross_import_overlay_group(name = "all_cross_import_overlays")
 
 system_module_group(
     name = "all_modules",

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -100,12 +100,16 @@ _TARGETS_PER_SDK = {
 _HEADER = """\
 load(
     "@build_bazel_rules_swift//swift:swift.bzl",
+    "swift_cross_import_overlay",
+    "swift_cross_import_overlay_group",
     "system_clang_module",
     "system_module_group",
     "system_swiftinterface",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+swift_cross_import_overlay_group(name = "_empty_cross_import_overlays")
 
 system_module_group(
     name = "_empty_all_modules",
@@ -219,6 +223,55 @@ def _render_all_modules_group(
     out.write("    ],\n")
     _write_transition_attrs(out, sdk=sdk, sdk_version=sdk_version)
     out.write(")\n")
+
+
+def _render_cross_import_overlay_targets(
+    overlays: list["_CrossImportOverlay"],
+    sdk: str,
+    out: TextIO,
+) -> None:
+    for overlay in overlays:
+        out.write("\n")
+        out.write("swift_cross_import_overlay(\n")
+        out.write(f'    name = "{overlay.target_name}",\n')
+        out.write(
+            f'    bystanding_module = ":{_canonical_name(overlay.bystanding_module, sdk, "alias")}",\n'
+        )
+        out.write(
+            f'    declaring_module = ":{_canonical_name(overlay.declaring_module, sdk, "alias")}",\n'
+        )
+        out.write("    deps = [\n")
+        _write_labels(
+            out,
+            {
+                _canonical_name(module, sdk, "alias")
+                for module in overlay.overlay_modules
+            },
+        )
+        out.write("    ],\n")
+        out.write(f'    swiftoverlay = "{overlay.swiftoverlay_path}",\n')
+        out.write(")\n")
+
+    out.write("\n")
+    out.write("swift_cross_import_overlay_group(\n")
+    out.write(f'    name = "{sdk}_all_cross_import_overlays",\n')
+    out.write("    overlays = [\n")
+    _write_labels(out, {overlay.target_name for overlay in overlays})
+    out.write("    ],\n")
+    out.write(")\n")
+
+
+@dataclass(order=True, frozen=True)
+class _CrossImportOverlay:
+    declaring_module: str
+    bystanding_module: str
+    overlay_modules: tuple[str, ...]
+    swiftoverlay_path: str
+    sdk: str = field(compare=False)
+
+    @property
+    def target_name(self) -> str:
+        return f"{self.sdk}_{self.declaring_module}_{self.bystanding_module}_cross_import_overlay"
 
 
 @dataclass(order=True)
@@ -399,6 +452,101 @@ def _parse_output(
         module.set_deps(cpu, deps)
 
 
+def _strip_yaml_comment(line: str) -> str:
+    return line.split("#", 1)[0].strip()
+
+
+def _parse_yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _get_overlay_deps(path: Path) -> tuple[str, ...]:
+    version = None
+    modules = []
+    in_modules = False
+    pending_module = False
+
+    for raw_line in path.read_text().splitlines():
+        line = _strip_yaml_comment(raw_line)
+        if not line or line == "---":
+            continue
+
+        if line.startswith("version:"):
+            version = _parse_yaml_scalar(line.partition(":")[2])
+            continue
+
+        if line == "modules:":
+            in_modules = True
+            continue
+
+        if not in_modules:
+            raise ValueError(f"{path}: unexpected line before modules: {raw_line}")
+
+        if line == "-":
+            pending_module = True
+            continue
+
+        if line.startswith("- "):
+            entry = line[2:].strip()
+            if not entry.startswith("name:"):
+                raise ValueError(f"{path}: expected module name entry: {raw_line}")
+            modules.append(_parse_yaml_scalar(entry.partition(":")[2]))
+            pending_module = False
+            continue
+
+        if pending_module and line.startswith("name:"):
+            modules.append(_parse_yaml_scalar(line.partition(":")[2]))
+            pending_module = False
+            continue
+
+        raise ValueError(f"{path}: unexpected modules entry: {raw_line}")
+
+    if version != "1":
+        raise ValueError(f"{path}: expected version: 1, got {version!r}")
+    if not modules:
+        raise ValueError(f"{path}: expected at least one overlay module")
+    return tuple(modules)
+
+
+def _discover_cross_import_overlays(
+    *,
+    cross_import_dirs: set[Path],
+    developer_dir: str,
+    sdk: str,
+    sdk_path: str,
+    all_modules: set[str],
+) -> list[_CrossImportOverlay]:
+    overlays = []
+    for cross_import_dir in cross_import_dirs:
+        for overlay_file in cross_import_dir.glob("*.swiftoverlay"):
+            # The SDK can contain overlays referencing modules they don't ship.
+            # For example there are some overlays in the macOS SDK that depend
+            # on UIKit
+            if (
+                cross_import_dir.stem not in all_modules
+                or overlay_file.stem not in all_modules
+            ):
+                continue
+
+            overlays.append(
+                _CrossImportOverlay(
+                    declaring_module=cross_import_dir.stem,
+                    bystanding_module=overlay_file.stem,
+                    overlay_modules=_get_overlay_deps(overlay_file),
+                    sdk=sdk,
+                    swiftoverlay_path=_normalize_system_path(
+                        overlay_file.as_posix(),
+                        developer_dir=developer_dir,
+                        sdkroot=sdk_path,
+                    ),
+                )
+            )
+    return sorted(overlays)
+
+
 def _get_deployment_target(sdk: str, sdk_path: Path) -> str:
     settings = sdk_path / "SDKSettings.json"
     with open(settings) as f:
@@ -481,11 +629,16 @@ def _discover_all_modules(
     ]
 
     modules: set[str] = set()
+    cross_import_dirs: set[Path] = set()
     for directory in set(
         framework_search_paths + library_search_paths + swift_search_paths
     ):
         for x in directory.iterdir():
             if x.stem in excluded_modules:
+                continue
+            if x.suffix == ".swiftcrossimport":
+                modules.add(x.stem)
+                cross_import_dirs.add(x)
                 continue
             if not x.is_dir():
                 if x.suffix == ".modulemap":
@@ -497,15 +650,26 @@ def _discover_all_modules(
             if x.suffix == ".swiftmodule":
                 modules.add(x.stem)
             elif x.suffix == ".framework":
-                if (x / "Modules/module.modulemap").exists() or (
-                    x / "Modules" / (x.stem + ".swiftmodule")
+                modules_dir = x / "Modules"
+                if (modules_dir / "module.modulemap").exists() or (
+                    modules_dir / (x.stem + ".swiftmodule")
                 ).exists():
                     modules.add(x.stem)
+                    cross_import_dir = modules_dir / f"{x.stem}.swiftcrossimport"
+                    if cross_import_dir.is_dir():
+                        cross_import_dirs.add(cross_import_dir)
             elif (x / "module.modulemap").exists():
                 modules.add(x.stem)  # /usr/include/CommonCrypto/module.modulemap
 
     deployment_target = _get_deployment_target(sdk, sdk_path)
     cpu_targets = _TARGETS_PER_SDK[sdk.lower()]
+    cross_import_overlays = _discover_cross_import_overlays(
+        cross_import_dirs=cross_import_dirs,
+        developer_dir=developer_dir.as_posix(),
+        sdk=sdk,
+        sdk_path=sdk_path.as_posix(),
+        all_modules=modules,
+    )
 
     with ThreadPoolExecutor(max_workers=len(cpu_targets)) as pool:
         scan_futures = {
@@ -544,6 +708,7 @@ def _discover_all_modules(
     buf = io.StringIO()
     for module in all_modules:
         module.render_target(buf)
+    _render_cross_import_overlay_targets(cross_import_overlays, sdk, buf)
     _render_clang_module_groups(
         all_modules,
         clang_names - swift_names,
@@ -702,6 +867,17 @@ def _main() -> None:
         if all_modules_by_sdk.get(sdk):
             buf.write(f'        ":{sdk}_sdk": ":{sdk}_all_modules",\n')
     buf.write('        "@platforms//os:none": ":_empty_all_modules",\n')
+    buf.write("    }),\n")
+    buf.write(")\n")
+
+    buf.write("\n")
+    buf.write("alias(\n")
+    buf.write('    name = "all_cross_import_overlays",\n')
+    buf.write("    actual = select({\n")
+    for sdk in sdk_names:
+        if all_modules_by_sdk.get(sdk):
+            buf.write(f'        ":{sdk}_sdk": ":{sdk}_all_cross_import_overlays",\n')
+    buf.write('        "@platforms//os:none": ":_empty_cross_import_overlays",\n')
     buf.write("    }),\n")
     buf.write(")\n")
 

--- a/tools/explicit_modules/xcode_explicit_module_hub_repo.bzl
+++ b/tools/explicit_modules/xcode_explicit_module_hub_repo.bzl
@@ -58,7 +58,10 @@ def _xcode_explicit_module_hub_repo_impl(rctx):
     manifest = json.decode(rctx.read(rctx.attr.default_manifest))
     rctx.watch(rctx.attr.default_manifest)
 
-    root_module_names = {"all_modules": True}
+    root_module_names = {
+        "all_cross_import_overlays": True,
+        "all_modules": True,
+    }
     for name in manifest:
         root_module_names[name] = True
 


### PR DESCRIPTION
With the way we pass explicit modules to the compiler, the driver
doesn't automatically discover cross module imports anymore. This is ok
because we need to pass the precompiled deps of those modules anyways.
We now scan for those modules and add them to our generated build files,
then wire them up to be passed to the frontend.
