### PR TITLE
Add example failing test with canImport

### DIFF
--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -354,6 +354,25 @@ transition_test(
     ],
 )
 
+swift_library(
+    name = "can_import_undeclared_sdk_module",
+    srcs = ["can_import_undeclared_sdk_module.swift"],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = ["@system_sdk//:Foundation"],
+)
+
+transition_binary(
+    name = "can_import_undeclared_sdk_module_transitioned",
+    tags = FIXTURE_TAGS,
+    target = ":can_import_undeclared_sdk_module",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+    ],
+)
+
 cross_platform_targets(tags = FIXTURE_TAGS)
 
 swift_import(

--- a/test/fixtures/precompiled_modules/can_import_undeclared_sdk_module.swift
+++ b/test/fixtures/precompiled_modules/can_import_undeclared_sdk_module.swift
@@ -1,0 +1,8 @@
+#if canImport(SwiftUI)
+// #error("should this be false if the dep is missing?")
+import SwiftUI
+#endif
+
+public struct CanImportUndeclaredSDKModule {
+    public init() {}
+}

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -118,6 +118,7 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_build_test".format(name),
         targets = [
             "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
+            "//test/fixtures/precompiled_modules:can_import_undeclared_sdk_module_transitioned",
             "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",


### PR DESCRIPTION
Currently `canImport` for modules that aren't in your deps returns
`true`, but then things fail because underlying clang modules aren't in
the dep tree.
