### PR TITLE
Add error for objc pcm with explicit modules

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -35,6 +35,7 @@ load(
 )
 load(
     "//swift/internal:feature_names.bzl",
+    "SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES",
     "SWIFT_FEATURE_CACHEABLE_SWIFTMODULES",
     "SWIFT_FEATURE_CHECKED_EXCLUSIVITY",
     "SWIFT_FEATURE_CODEVIEW_DEBUG_INFO",
@@ -834,6 +835,17 @@ def compile_action_configs(
             configurators = [_c_layering_check_configurator],
             features = [SWIFT_FEATURE_LAYERING_CHECK],
             not_features = [SWIFT_FEATURE_SYSTEM_MODULE],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_PRECOMPILE_C_MODULE],
+            configurators = [
+                add_arg("-Xcc", "-Werror=non-modular-include-in-module"),
+            ],
+            features = [SWIFT_FEATURE_EMIT_C_MODULE],
+            not_features = [
+                [SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES],
+                [SWIFT_FEATURE_SYSTEM_MODULE],
+            ],
         ),
         ActionConfigInfo(
             actions = [SWIFT_ACTION_PRECOMPILE_C_MODULE],

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -14,6 +14,10 @@
 
 """Tests for `swift_library.generated_header`."""
 
+load(
+    "//test/rules:action_command_line_test.bzl",
+    "make_action_command_line_test_rule",
+)
 load("//test/rules:analysis_failure_test.bzl", "analysis_failure_test")
 load(
     "//test/rules:provider_test.bzl",
@@ -24,6 +28,26 @@ load(
 private_deps_with_target_name_test = make_provider_test_rule(
     config_settings = {
         "//command_line_option:features": ["swift.add_target_name_to_output"],
+    },
+)
+
+_default_precompiled_modules_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_c_modules",
+            "swift.emit_c_module",
+            "swift.add_default_precompiled_modules",
+        ],
+    },
+)
+
+_explicit_precompiled_modules_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_c_modules",
+            "swift.emit_c_module",
+            "-swift.add_default_precompiled_modules",
+        ],
     },
 )
 
@@ -58,6 +82,26 @@ def generated_header_test_suite(name, tags = []):
         ],
         field = "files",
         provider = "DefaultInfo",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/generated_header:auto_header",
+    )
+
+    _explicit_precompiled_modules_test(
+        name = "{}_generated_header_pcm_errors_on_non_modular_includes".format(name),
+        expected_argv = [
+            "-Xcc -Werror=non-modular-include-in-module",
+        ],
+        mnemonic = "SwiftPrecompileCModule",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/generated_header:auto_header",
+    )
+
+    _default_precompiled_modules_test(
+        name = "{}_generated_header_pcm_allows_default_precompiled_modules".format(name),
+        mnemonic = "SwiftPrecompileCModule",
+        not_expected_argv = [
+            "-Xcc -Werror=non-modular-include-in-module",
+        ],
         tags = all_tags,
         target_under_test = "//test/fixtures/generated_header:auto_header",
     )

--- a/test/generated_header_tests.bzl
+++ b/test/generated_header_tests.bzl
@@ -94,6 +94,7 @@ def generated_header_test_suite(name, tags = []):
         mnemonic = "SwiftPrecompileCModule",
         tags = all_tags,
         target_under_test = "//test/fixtures/generated_header:auto_header",
+        target_compatible_with = ["@platforms//os:macos"],
     )
 
     _default_precompiled_modules_test(
@@ -104,6 +105,7 @@ def generated_header_test_suite(name, tags = []):
         ],
         tags = all_tags,
         target_under_test = "//test/fixtures/generated_header:auto_header",
+        target_compatible_with = ["@platforms//os:macos"],
     )
 
     # Verify that no generated header is created if the target doesn't request


### PR DESCRIPTION
If you disable `swift.add_default_precompiled_modules`, you must add the
system deps to any objc_library targets you depend on or you end up with
conflicting "instances" of objc types. This upgrades a warning that
helps catch this case.
