### PR TITLE
Remove absolute path to Xcode from rpaths

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -277,12 +277,9 @@ def _swift_linkopts_cc_info(
         target_triple = target_triple,
         xcode_config = xcode_config,
     )
-    developer_dir_rpath_roots = _DEVELOPER_DIR_SYMLINKS + [
-        "__BAZEL_XCODE_DEVELOPER_DIR__",
-    ]
     rpaths = ["/usr/lib/swift"] + [
         paths.join(developer_dir_symlink, compatibility_dir)
-        for developer_dir_symlink in developer_dir_rpath_roots
+        for developer_dir_symlink in _DEVELOPER_DIR_SYMLINKS
         for compatibility_dir in swift_compatibility_lib_dirs
     ]
     linkopts += [
@@ -328,17 +325,11 @@ def _test_linking_context(target_triple, toolchain_label):
         binaries.
     """
 
-    # xcode-select creates the following symlink(s) to the developer directory
-    # (we list both because the behavior changed between versions of macOS).
-    # We also include Bazel's developer directory placeholder for local test
-    # actions. These let the required libraries be found if Xcode is installed
-    # in a different location on the machine that runs the tests than the
-    # machine used to link them.
-    developer_dir_rpath_roots = _DEVELOPER_DIR_SYMLINKS + [
-        "__BAZEL_XCODE_DEVELOPER_DIR__",
-    ]
+    # We use these as the rpaths for linking tests so that the required
+    # libraries are found if Xcode is installed in a different location on the
+    # machine that runs the tests than the machine used to link them.
     linkopts = []
-    for developer_dir in developer_dir_rpath_roots:
+    for developer_dir in _DEVELOPER_DIR_SYMLINKS:
         platform_developer_framework_dir = _platform_developer_framework_dir(
             developer_dir,
             target_triple,

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -328,9 +328,6 @@ def features_test_suite(name, tags = []):
         name = "{}_swift_test_rpath_roots_link_test".format(name),
         tags = all_tags,
         expected_argv = [
-            "-Wl,-rpath,__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/usr/lib",
-            "-Wl,-rpath,__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks",
-            "-Wl,-rpath,__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks",
             "-Wl,-rpath,/private/var/select/developer_dir/Platforms/MacOSX.platform/Developer/usr/lib",
             "-Wl,-rpath,/private/var/select/developer_dir/Platforms/MacOSX.platform/Developer/Library/Frameworks",
             "-Wl,-rpath,/private/var/select/developer_dir/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks",


### PR DESCRIPTION
Based on the discussion in
https://github.com/bazelbuild/rules_swift/issues/1629 the symlinks that
we use to find Xcode via rpaths weren't available on the machine,
possibly right after an update, but I think we need to treat that as a
bad environment instead since this otherwise makes the binaries non
hermetic.

This reverts e40028884604d06faa9e9276ba05ce712f32d788
