### PR TITLE
Handle cross import overlays from transitive deps

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1296,18 +1296,20 @@ def _cross_imported_overlays(
 
     # Build a "set" containing the module names of direct dependencies so that
     # we can do quicker hash-based lookups below.
-    direct_module_names = {}
+    module_names = {}
     for swift_info in user_swift_infos:
-        for module_context in swift_info.direct_modules:
-            direct_module_names[module_context.name] = True
+        # TODO: Ideally this would only be the direct dependencies, but unless
+        # you enforce layering_check it's easy to rely on this
+        for module_context in swift_info.transitive_modules.to_list():
+            module_names[module_context.name] = True
 
     # For each cross-import overlay registered with the toolchain, add its
     # `SwiftInfo` providers to the list if both its declaring and bystanding
     # modules were imported.
     overlays = []
     for overlay in swift_toolchain.cross_import_overlays:
-        if (overlay.declaring_module in direct_module_names and
-            overlay.bystanding_module in direct_module_names):
+        if (overlay.declaring_module in module_names and
+            overlay.bystanding_module in module_names):
             overlays.append(overlay)
 
     return overlays

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -458,6 +458,45 @@ transition_binary(
     ],
 )
 
+swift_library(
+    name = "pollute_appkit_dep",
+    srcs = ["empty.swift"],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = ["@system_sdk//:AppKit"],  # This dep becomes available to consumers who don't enable swift.layering_check
+)
+
+swift_test(
+    name = "cross_import_overlay_dep_pollution",
+    srcs = [
+        # NOTE: The current API requires a cross import overlay, but we might
+        # need to find another one in the future if this one moves.
+        "cross_import_overlay_pollution.swift",
+        "main.swift",
+    ],
+    discover_tests = False,
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":pollute_appkit_dep",
+        "@system_sdk//:Testing", # Testing + AppKit currently have a cross import overlay which must be imported
+    ],
+)
+
+transition_test(
+    name = "cross_import_overlay_dep_pollution_transitioned",
+    testonly = True,
+    minimum_os = "26.0",
+    tags = FIXTURE_TAGS,
+    target = ":cross_import_overlay_dep_pollution",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+        "swift.use_explicit_swift_module_map",
+    ],
+)
+
 bzl_library(
     name = "cross_platform",
     srcs = ["cross_platform.bzl"],

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -497,6 +497,20 @@ transition_test(
     ],
 )
 
+transition_test(
+    name = "cross_import_overlay_dep_pollution_default_precompiled_modules_transitioned",
+    testonly = True,
+    minimum_os = "26.0",
+    tags = FIXTURE_TAGS,
+    target = ":cross_import_overlay_dep_pollution",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "swift.add_default_precompiled_modules",
+        "swift.use_explicit_swift_module_map",
+    ],
+)
+
 bzl_library(
     name = "cross_platform",
     srcs = ["cross_platform.bzl"],

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -429,12 +429,7 @@ transition_binary(
 
 swift_binary(
     name = "cross_import_overlay",
-    srcs = [
-        # NOTE: The current API requires a cross import overlay, but we might
-        # need to find another one in the future if this one moves.
-        "cross_import_overlay.swift",
-        "main.swift",
-    ],
+    srcs = ["main.swift"],
     copts = ["-suppress-warnings"],
     tags = FIXTURE_TAGS,
     target_compatible_with = select({
@@ -468,12 +463,7 @@ swift_library(
 
 swift_test(
     name = "cross_import_overlay_dep_pollution",
-    srcs = [
-        # NOTE: The current API requires a cross import overlay, but we might
-        # need to find another one in the future if this one moves.
-        "cross_import_overlay_pollution.swift",
-        "main.swift",
-    ],
+    srcs = ["main.swift"],
     discover_tests = False,
     tags = FIXTURE_TAGS,
     target_compatible_with = ["@platforms//os:macos"],

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -479,7 +479,7 @@ swift_test(
     target_compatible_with = ["@platforms//os:macos"],
     deps = [
         ":pollute_appkit_dep",
-        "@system_sdk//:Testing", # Testing + AppKit currently have a cross import overlay which must be imported
+        "@system_sdk//:Testing",  # Testing + AppKit currently have a cross import overlay which must be imported
     ],
 )
 

--- a/test/fixtures/precompiled_modules/cross_import_overlay.swift
+++ b/test/fixtures/precompiled_modules/cross_import_overlay.swift
@@ -20,5 +20,3 @@ struct Pin: Identifiable {
     let id = "1"
     let coordinate: CLLocationCoordinate2D
 }
-
-

--- a/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
+++ b/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
@@ -1,9 +1,0 @@
-import AppKit
-import Testing
-
-private func foo() {
-  let image = NSImage(data: Data())!
-  // This currently relies on a protocol conformance for NSImage that exists in _Testing_AppKit which is
-  // imported implicitly through a cross import overlay
-  Attachment.record(image, named: "foo", as: .png)
-}

--- a/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
+++ b/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
@@ -1,0 +1,9 @@
+import AppKit
+import Testing
+
+private func foo() {
+  let image = NSImage(data: Data())!
+  // This currently relies on a protocol conformance for NSImage that exists in _Testing_AppKit which is
+  // imported implicitly through a cross import overlay
+  Attachment.record(image, named: "foo", as: .png)
+}

--- a/test/fixtures/precompiled_modules/empty.swift
+++ b/test/fixtures/precompiled_modules/empty.swift
@@ -1,0 +1,1 @@
+// empty file

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -121,7 +121,7 @@ def precompiled_modules_test_suite(name, tags = []):
         target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
         expected_argv = [
             "-Xfrontend -disable-cross-import-overlay-search",
-            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend",  # Any cross module import is ok, different Xcode version have different ones
         ],
     )
 
@@ -132,7 +132,7 @@ def precompiled_modules_test_suite(name, tags = []):
         target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
         expected_argv = [
             "-Xfrontend -disable-cross-import-overlay-search",
-            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend",  # Any cross module import is ok, different Xcode version have different ones
         ],
     )
 
@@ -140,8 +140,6 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_build_test".format(name),
         targets = [
             "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
-            "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution_default_precompiled_modules_transitioned",
-            "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution_transitioned",
             "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -114,6 +114,21 @@ def precompiled_modules_test_suite(name, tags = []):
         ],
     )
 
+    _precompiled_modules_test(
+        name = "{}_cross_import_overlay_dep_pollution_test".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompile",
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
+        expected_argv = [
+            "-Xfrontend -disable-cross-import-overlay-search",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+        ],
+    )
+
     build_test(
         name = "{}_build_test".format(name),
         targets = [

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -118,10 +118,6 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_cross_import_overlay_dep_pollution_no_default_precompiled_modules_test".format(name),
         tags = all_tags,
         mnemonic = "SwiftCompile",
-        target_compatible_with = select({
-            "//test:apple_build_tests_enabled": [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        }),
         target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
         expected_argv = [
             "-Xfrontend -disable-cross-import-overlay-search",
@@ -133,10 +129,6 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_cross_import_overlay_dep_pollution_default_precompiled_modules_test".format(name),
         tags = all_tags,
         mnemonic = "SwiftCompile",
-        target_compatible_with = select({
-            "//test:apple_build_tests_enabled": [],
-            "//conditions:default": ["@platforms//:incompatible"],
-        }),
         target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
         expected_argv = [
             "-Xfrontend -disable-cross-import-overlay-search",

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -114,8 +114,23 @@ def precompiled_modules_test_suite(name, tags = []):
         ],
     )
 
+    _explicit_precompiled_modules_test(
+        name = "{}_cross_import_overlay_dep_pollution_no_default_precompiled_modules_test".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompile",
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution",
+        expected_argv = [
+            "-Xfrontend -disable-cross-import-overlay-search",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+        ],
+    )
+
     _precompiled_modules_test(
-        name = "{}_cross_import_overlay_dep_pollution_test".format(name),
+        name = "{}_cross_import_overlay_dep_pollution_default_precompiled_modules_test".format(name),
         tags = all_tags,
         mnemonic = "SwiftCompile",
         target_compatible_with = select({
@@ -133,6 +148,8 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_build_test".format(name),
         targets = [
             "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
+            "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution_default_precompiled_modules_transitioned",
+            "//test/fixtures/precompiled_modules:cross_import_overlay_dep_pollution_transitioned",
             "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",


### PR DESCRIPTION
Unless you enforce layering_check for targets, you could rely on cross
import overlays from any of your transitive deps.

This is very not ideal, but otherwise this results in subtle failures.
