### PR TITLE
Fix linking cross module overlays without use_explicit_swift_module_map

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -119,6 +119,54 @@ def transitive_swift_dependency_inputs(transitive_modules):
 
     return inputs
 
+def _explicit_swift_module_map_info(
+        *,
+        actions,
+        feature_configuration,
+        target_name,
+        transitive_modules,
+        vfsoverlay_file):
+    """Returns the explicit Swift module map file and matching Swift inputs."""
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+    ):
+        if vfsoverlay_file:
+            fail("Cannot use both `swift.vfsoverlay` and `swift.use_explicit_swift_module_map` features at the same time.")
+
+        module_contexts = transitive_modules
+        filename = "{}.swift-explicit-module-map.json".format(target_name)
+        inputs = []
+    elif is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_USE_C_MODULES,
+    ):
+        # Keep non-system Swift deps on search paths, but include system
+        # modules to make sure everything loads them with the same behavior
+        module_contexts = [
+            module
+            for module in transitive_modules
+            if module.is_system
+        ]
+        if not module_contexts:
+            return struct(file = None, inputs = [])
+
+        filename = "{}.swift-system-explicit-module-map.json".format(target_name)
+        inputs = transitive_swift_dependency_inputs(module_contexts)
+    else:
+        return struct(file = None, inputs = [])
+
+    explicit_swift_module_map_file = actions.declare_file(filename)
+    write_explicit_swift_module_map_file(
+        actions = actions,
+        explicit_swift_module_map_file = explicit_swift_module_map_file,
+        module_contexts = module_contexts,
+    )
+    return struct(
+        file = explicit_swift_module_map_file,
+        inputs = inputs,
+    )
+
 def create_compilation_context(defines, srcs, transitive_modules):
     """Cretes a compilation context for a Swift target.
 
@@ -306,23 +354,13 @@ def compile_module_interface(
     else:
         vfsoverlay_file = None
 
-    if is_feature_enabled(
+    explicit_swift_module_map_info = _explicit_swift_module_map_info(
+        actions = actions,
         feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
-    ):
-        if vfsoverlay_file:
-            fail("Cannot use both `swift.vfsoverlay` and `swift.use_explicit_swift_module_map` features at the same time.")
-
-        explicit_swift_module_map_file = actions.declare_file(
-            "{}.swift-explicit-module-map.json".format(target_name),
-        )
-        write_explicit_swift_module_map_file(
-            actions = actions,
-            explicit_swift_module_map_file = explicit_swift_module_map_file,
-            module_contexts = transitive_modules,
-        )
-    else:
-        explicit_swift_module_map_file = None
+        target_name = target_name,
+        transitive_modules = transitive_modules,
+        vfsoverlay_file = vfsoverlay_file,
+    )
 
     if is_feature_enabled(
         feature_configuration = feature_configuration,
@@ -339,7 +377,8 @@ def compile_module_interface(
         additional_inputs = additional_inputs,
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_compilation_context,
-        explicit_swift_module_map_file = explicit_swift_module_map_file,
+        explicit_swift_module_map_file = explicit_swift_module_map_info.file,
+        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs or transitive_swift_dependency_inputs_list,
         genfiles_dir = feature_configuration._genfiles_dir,
         indexstore_directory = indexstore_directory,
         is_swift = True,
@@ -701,25 +740,13 @@ def compile(
     else:
         vfsoverlay_file = None
 
-    if is_feature_enabled(
+    explicit_swift_module_map_info = _explicit_swift_module_map_info(
+        actions = actions,
         feature_configuration = feature_configuration,
-        feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
-    ):
-        if vfsoverlay_file:
-            fail("Cannot use both `swift.vfsoverlay` and `swift.use_explicit_swift_module_map` features at the same time.")
-
-        # Generate the JSON file that contains the manifest of Swift
-        # dependencies.
-        explicit_swift_module_map_file = actions.declare_file(
-            "{}.swift-explicit-module-map.json".format(target_name),
-        )
-        write_explicit_swift_module_map_file(
-            actions = actions,
-            explicit_swift_module_map_file = explicit_swift_module_map_file,
-            module_contexts = transitive_modules,
-        )
-    else:
-        explicit_swift_module_map_file = None
+        target_name = target_name,
+        transitive_modules = transitive_modules,
+        vfsoverlay_file = vfsoverlay_file,
+    )
 
     # As of the time of this writing (Xcode 15.0), macros are the only kind of
     # plugins that are available. Since macros do source-level transformations,
@@ -764,7 +791,8 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         defines = sets.to_list(defines_set),
         developer_dirs = toolchains.swift.developer_dirs,
         experimental_features = experimental_features,
-        explicit_swift_module_map_file = explicit_swift_module_map_file,
+        explicit_swift_module_map_file = explicit_swift_module_map_info.file,
+        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs,
         genfiles_dir = feature_configuration._genfiles_dir,
         include_dev_srch_paths = include_dev_srch_paths_value,
         is_swift = True,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -136,7 +136,6 @@ def _explicit_swift_module_map_info(
 
         module_contexts = transitive_modules
         filename = "{}.swift-explicit-module-map.json".format(target_name)
-        inputs = []
     elif is_feature_enabled(
         feature_configuration = feature_configuration,
         feature_name = SWIFT_FEATURE_USE_C_MODULES,
@@ -152,7 +151,6 @@ def _explicit_swift_module_map_info(
             return struct(file = None, inputs = [])
 
         filename = "{}.swift-system-explicit-module-map.json".format(target_name)
-        inputs = transitive_swift_dependency_inputs(module_contexts)
     else:
         return struct(file = None, inputs = [])
 
@@ -164,7 +162,7 @@ def _explicit_swift_module_map_info(
     )
     return struct(
         file = explicit_swift_module_map_file,
-        inputs = inputs,
+        inputs = transitive_swift_dependency_inputs(module_contexts),
     )
 
 def create_compilation_context(defines, srcs, transitive_modules):
@@ -378,7 +376,7 @@ def compile_module_interface(
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_compilation_context,
         explicit_swift_module_map_file = explicit_swift_module_map_info.file,
-        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs or transitive_swift_dependency_inputs_list,
+        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs,
         genfiles_dir = feature_configuration._genfiles_dir,
         indexstore_directory = indexstore_directory,
         is_swift = True,

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -902,6 +902,28 @@ def compile_action_configs(
             ],
             features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
         ),
+        ActionConfigInfo(
+            actions = all_compile_action_names() + [
+                SWIFT_ACTION_DUMP_AST,
+            ],
+            configurators = [
+                _explicit_swift_module_map_configurator,
+            ],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],  # If this feature is enabled we still use this file just with more contents
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [
+                lambda prerequisites, args: _explicit_swift_module_map_configurator(
+                    prerequisites,
+                    args,
+                    is_frontend = True,
+                ),
+            ],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],  # If this feature is enabled we still use this file just with more contents
+        ),
         # TODO: Pass through system modules and pass this to all actions
         # ActionConfigInfo(
         #     actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
@@ -2199,6 +2221,9 @@ def _dependencies_swiftmodules_vfsoverlay_configurator(prerequisites, args, is_f
 
 def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = False):
     """Adds the explicit Swift module map file to the command line."""
+    if not prerequisites.explicit_swift_module_map_file:
+        return ConfigResultInfo()
+
     if is_frontend:
         args.add(
             prerequisites.explicit_swift_module_map_file,
@@ -2210,7 +2235,7 @@ def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = F
             format = "-Xwrapped-swift=-driver-explicit-swift-module-map-file=%s",
         )
     return ConfigResultInfo(
-        inputs = prerequisites.transitive_swift_dependency_inputs + [
+        inputs = prerequisites.explicit_swift_module_map_inputs + [
             prerequisites.explicit_swift_module_map_file,
         ],
     )

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -5,6 +5,10 @@ load(
     "//test/rules:action_command_line_test.bzl",
     "make_action_command_line_test_rule",
 )
+load(
+    "//test/rules:action_inputs_test.bzl",
+    "make_action_inputs_test_rule",
+)
 
 default_test = make_action_command_line_test_rule()
 
@@ -84,6 +88,14 @@ vfsoverlay_with_target_name_test = make_action_command_line_test_rule(
 )
 
 explicit_swift_module_map_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.use_explicit_swift_module_map",
+        ],
+    },
+)
+
+explicit_swift_module_map_inputs_test = make_action_inputs_test_rule(
     config_settings = {
         "//command_line_option:features": [
             "swift.use_explicit_swift_module_map",
@@ -248,6 +260,17 @@ def features_test_suite(name, tags = []):
             "-I$(BIN_DIR)/test/fixtures/basic",
             "-I/__build_bazel_rules_swift/swiftmodules",
             "-Xfrontend -vfsoverlay$(BIN_DIR)/test/fixtures/basic/second.vfsoverlay.yaml",
+        ],
+        mnemonic = "SwiftCompile",
+        target_under_test = "//test/fixtures/basic:second",
+    )
+
+    explicit_swift_module_map_inputs_test(
+        name = "{}_explicit_swift_module_map_inputs_test".format(name),
+        tags = all_tags,
+        expected_inputs = [
+            "first.swiftmodule",
+            "second.swift-explicit-module-map.json",
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/basic:second",

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -427,6 +427,36 @@ transition_binary(
     ],
 )
 
+swift_test(
+    name = "linking_cross_import_overlay",
+    srcs = [
+        # NOTE: The current API requires a cross import overlay, but we might
+        # need to find another one in the future if this one moves.
+        "cross_import_overlay_pollution.swift",
+        "main.swift",
+    ],
+    discover_tests = False,
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        "@system_sdk//:AppKit",
+        "@system_sdk//:Testing",
+    ],
+)
+
+transition_test(
+    name = "linking_cross_import_overlay_transitioned",
+    testonly = True,
+    tags = FIXTURE_TAGS,
+    target = ":cross_import_overlay_dep_pollution",
+    transitive_features = [
+        "swift.use_c_modules",
+        "swift.emit_c_module",
+        "-swift.add_default_precompiled_modules",
+        # NOTE: Must not enable swift.use_explicit_swift_module_map which affects linking logic
+    ],
+)
+
 swift_binary(
     name = "cross_import_overlay",
     srcs = ["main.swift"],

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -5,6 +5,7 @@ load(
     "//test/fixtures/precompiled_modules:cross_platform.bzl",
     "CROSS_PLATFORM_TARGETS",
 )
+load("//test/hermetic_pcm:xcode_version_at_least.bzl", "xcode_version_at_least")
 load(
     "//test/rules:action_command_line_test.bzl",
     "make_action_command_line_test_rule",
@@ -38,6 +39,16 @@ def precompiled_modules_test_suite(name, tags = []):
         tags: Additional tags to apply to each test.
     """
     all_tags = [name] + tags
+
+    xcode_version_at_least(
+        name = "xcode_at_least_26_4",
+        minimum_version = "26.4",
+    )
+
+    native.config_setting(
+        name = "has_testing_appkit_overlay",
+        flag_values = {":xcode_at_least_26_4": "True"},
+    )
 
     _precompiled_modules_test(
         name = "{}_use_c_modules_flags_test".format(name),
@@ -144,8 +155,12 @@ def precompiled_modules_test_suite(name, tags = []):
         expected_argv = [
             "-Xwrapped-swift=-driver-explicit-swift-module-map-file=$(BIN_DIR)/test/fixtures/precompiled_modules/linking_cross_import_overlay.swift-system-explicit-module-map.json",
             "-Xfrontend -disable-cross-import-overlay-search",
-            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend",  # Any cross module import is ok, different Xcode version have different ones
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
         ],
+        target_compatible_with = select({
+            ":has_testing_appkit_overlay": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
     )
 
     build_test(

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -144,7 +144,7 @@ def precompiled_modules_test_suite(name, tags = []):
         expected_argv = [
             "-Xwrapped-swift=-driver-explicit-swift-module-map-file=$(BIN_DIR)/test/fixtures/precompiled_modules/linking_cross_import_overlay.swift-system-explicit-module-map.json",
             "-Xfrontend -disable-cross-import-overlay-search",
-            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend",  # Any cross module import is ok, different Xcode version have different ones
         ],
     )
 

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -136,6 +136,18 @@ def precompiled_modules_test_suite(name, tags = []):
         ],
     )
 
+    _explicit_precompiled_modules_test(
+        name = "{}_linking_cross_import_overlay_transitioned_test".format(name),
+        tags = all_tags,
+        mnemonic = "SwiftCompile",
+        target_under_test = "//test/fixtures/precompiled_modules:linking_cross_import_overlay",
+        expected_argv = [
+            "-Xwrapped-swift=-driver-explicit-swift-module-map-file=$(BIN_DIR)/test/fixtures/precompiled_modules/linking_cross_import_overlay.swift-system-explicit-module-map.json",
+            "-Xfrontend -disable-cross-import-overlay-search",
+            "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
+        ],
+    )
+
     build_test(
         name = "{}_build_test".format(name),
         targets = [
@@ -143,6 +155,7 @@ def precompiled_modules_test_suite(name, tags = []):
             "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",
+            "//test/fixtures/precompiled_modules:linking_cross_import_overlay_transitioned",
             "//test/fixtures/precompiled_modules:lower_version_bin_transitioned",
             "//test/fixtures/precompiled_modules:min_os_bin_transitioned",
             "//test/fixtures/precompiled_modules:objc_interop_bin_transitioned",


### PR DESCRIPTION
The isFramework field in the explicit swift module map also results in
having a `-framework Foo` linker entry in an object file. If the user
doesn't enable this feature, we still need to pass these modules in the
same file format with only system dependencies.

Currently using this file isn't compatible with indexing in Xcode, but
that shouldn't matter for system dependencies because in that case it
will have to fall back to implicit modules either way, so dropping this
argument should be inconsequential
