### PR TITLE
Apply SDK min-OS transition to system Swift interfaces

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -343,6 +343,7 @@ bzl_library(
         "//swift:swift_common",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
+        "//swift/internal:system_module_transition",
         "//swift/internal:toolchain_utils",
         "@rules_cc//cc/common",
     ],

--- a/swift/internal/system_swiftinterface.bzl
+++ b/swift/internal/system_swiftinterface.bzl
@@ -24,6 +24,7 @@ load(
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
 )
+load("@build_bazel_rules_swift//swift/internal:system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
 load("@build_bazel_rules_swift//swift/internal:toolchain_utils.bzl", "SWIFT_SDK_TOOLCHAIN_TYPE")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -95,7 +96,8 @@ def _system_swiftinterface_impl(ctx):
     ]
 
 system_swiftinterface = rule(
-    attrs = {
+    cfg = sdk_min_os_transition,
+    attrs = sdk_min_os_transition_attrs() | {
         "is_framework": attr.bool(
             default = False,
             doc = "Whether the compiled Swift interface represents a framework module.",

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("//mixed_language:mixed_language_library.bzl", "mixed_language_library")
+load("//swift:swift.bzl", "system_swiftinterface")
 load("//swift:swift_binary.bzl", "swift_binary")
 load("//swift:swift_compiler_plugin.bzl", "swift_compiler_plugin")
 load("//swift:swift_import.bzl", "swift_import")
@@ -362,6 +363,139 @@ swift_import(
     swiftinterface = "LowerVersionLib.swiftinterface",  # NOTE: The macOS version in this file _must_ not be the same one we use globally, that is the behavior we're testing
     tags = FIXTURE_TAGS,
     target_compatible_with = ["@platforms//os:macos"],
+)
+
+# Mirrors scan.py output for SDK textual interfaces. The analysis test only
+# inspects the registered argv, so this path is not read.
+system_swiftinterface(
+    name = "system_swiftinterface_with_sdk_min_os",
+    module_name = "Testing",
+    sdk_name = "MacOSX",
+    sdk_version = "26.4",
+    system_swiftinterface = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-macos.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_ios_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "iPhoneOS",
+    sdk_version = "26.4",
+    system_swiftinterface = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneOS.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-ios.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:ios"],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_ios_simulator_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "iPhoneSimulator",
+    sdk_version = "26.4",
+    system_swiftinterface = select({
+        "@platforms//cpu:arm64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-ios-simulator.swiftinterface",
+        "@platforms//cpu:x86_64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
+    }),
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:ios",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_tvos_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "AppleTVOS",
+    sdk_version = "26.4",
+    system_swiftinterface = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/AppleTVOS.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-tvos.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:tvos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_tvos_simulator_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "AppleTVSimulator",
+    sdk_version = "26.4",
+    system_swiftinterface = select({
+        "@platforms//cpu:arm64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/AppleTVSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-tvos-simulator.swiftinterface",
+        "@platforms//cpu:x86_64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/AppleTVSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/x86_64-apple-tvos-simulator.swiftinterface",
+    }),
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:tvos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_watchos_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "WatchOS",
+    sdk_version = "26.4",
+    system_swiftinterface = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchOS.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-watchos.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_watchos_simulator_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "WatchSimulator",
+    sdk_version = "26.4",
+    system_swiftinterface = select({
+        "@platforms//cpu:arm64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-watchos-simulator.swiftinterface",
+        "@platforms//cpu:x86_64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/x86_64-apple-watchos-simulator.swiftinterface",
+    }),
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:watchos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_visionos_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "XROS",
+    sdk_version = "26.4",
+    system_swiftinterface = "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/XROS.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-xros.swiftinterface",
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:visionos",
+        "@build_bazel_apple_support//constraints:device",
+    ],
+)
+
+system_swiftinterface(
+    name = "system_swiftinterface_visionos_simulator_with_sdk_min_os",
+    is_framework = True,
+    module_name = "Testing",
+    sdk_name = "XRSimulator",
+    sdk_version = "26.4",
+    system_swiftinterface = select({
+        "@platforms//cpu:arm64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/XRSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/arm64-apple-xros-simulator.swiftinterface",
+        "@platforms//cpu:x86_64": "__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/XRSimulator.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftmodule/x86_64-apple-xros-simulator.swiftinterface",
+    }),
+    tags = FIXTURE_TAGS,
+    target_compatible_with = [
+        "@platforms//os:visionos",
+        "@build_bazel_apple_support//constraints:simulator",
+    ],
 )
 
 swift_binary(

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -1,5 +1,6 @@
 """Tests for the default precompiled-modules injection."""
 
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "unittest")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//test/fixtures/precompiled_modules:cross_platform.bzl",
@@ -27,6 +28,164 @@ _explicit_precompiled_modules_test = make_action_command_line_test_rule(
             "swift.use_c_modules",
             "swift.emit_c_module",
             "-swift.add_default_precompiled_modules",
+        ],
+    },
+)
+
+def _system_swiftinterface_sdk_min_os_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    matching_actions = [
+        action
+        for action in actions
+        if action.mnemonic == "SwiftCompileModuleInterface"
+    ]
+
+    if len(matching_actions) != 1:
+        unittest.fail(
+            env,
+            "Expected exactly one SwiftCompileModuleInterface action, but found {}. Available actions: {}".format(
+                len(matching_actions),
+                [action.mnemonic for action in actions],
+            ),
+        )
+        return analysistest.end(env)
+
+    argv = matching_actions[0].argv
+    target_triple = None
+    for i in range(len(argv) - 1):
+        if argv[i] == "-target":
+            target_triple = argv[i + 1]
+            break
+
+    if not target_triple:
+        unittest.fail(
+            env,
+            "Expected SwiftCompileModuleInterface action to pass -target. Arguments were: {}".format(argv),
+        )
+        return analysistest.end(env)
+
+    if not target_triple.endswith(ctx.attr.expected_target_suffix):
+        unittest.fail(
+            env,
+            "Expected system Swift interface -target to use the SDK min OS, but got '{}'. Arguments were: {}".format(
+                target_triple,
+                argv,
+            ),
+        )
+
+    return analysistest.end(env)
+
+_system_swiftinterface_macos_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:macos_minimum_os": "14.0",
+    },
+)
+
+_system_swiftinterface_ios_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:ios_minimum_os": "12.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:ios_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_ios_simulator_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:ios_minimum_os": "12.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:ios_sim_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_tvos_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:tvos_minimum_os": "12.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:tvos_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_tvos_simulator_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:tvos_minimum_os": "12.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:tvos_sim_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_watchos_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:watchos_minimum_os": "9.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:watchos_device_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_watchos_simulator_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:watchos_minimum_os": "9.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:watchos_x86_64"),
+        ],
+    },
+)
+
+_system_swiftinterface_visionos_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:minimum_os_version": "1.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:visionos_arm64"),
+        ],
+    },
+)
+
+_system_swiftinterface_visionos_simulator_sdk_min_os_test = analysistest.make(
+    _system_swiftinterface_sdk_min_os_test_impl,
+    attrs = {
+        "expected_target_suffix": attr.string(mandatory = True),
+    },
+    config_settings = {
+        "//command_line_option:minimum_os_version": "1.0",
+        "//command_line_option:platforms": [
+            Label("@build_bazel_apple_support//platforms:visionos_sim_arm64"),
         ],
     },
 )
@@ -161,6 +320,105 @@ def precompiled_modules_test_suite(name, tags = []):
             ":has_testing_appkit_overlay": [],
             "//conditions:default": ["@platforms//:incompatible"],
         }),
+    )
+
+    _system_swiftinterface_macos_sdk_min_os_test(
+        name = "{}_system_swiftinterface_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-macos26.4",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_ios_sdk_min_os_test(
+        name = "{}_system_swiftinterface_ios_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-ios26.4",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_ios_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_ios_simulator_sdk_min_os_test(
+        name = "{}_system_swiftinterface_ios_simulator_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-ios26.4-simulator",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_ios_simulator_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_tvos_sdk_min_os_test(
+        name = "{}_system_swiftinterface_tvos_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-tvos26.4",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_tvos_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_tvos_simulator_sdk_min_os_test(
+        name = "{}_system_swiftinterface_tvos_simulator_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-tvos26.4-simulator",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_tvos_simulator_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_watchos_sdk_min_os_test(
+        name = "{}_system_swiftinterface_watchos_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-watchos26.4",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_watchos_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_watchos_simulator_sdk_min_os_test(
+        name = "{}_system_swiftinterface_watchos_simulator_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-watchos26.4-simulator",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_watchos_simulator_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_visionos_sdk_min_os_test(
+        name = "{}_system_swiftinterface_visionos_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-xros26.4",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_visionos_with_sdk_min_os",
+    )
+
+    _system_swiftinterface_visionos_simulator_sdk_min_os_test(
+        name = "{}_system_swiftinterface_visionos_simulator_uses_sdk_min_os_test".format(name),
+        expected_target_suffix = "-apple-xros26.4-simulator",
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/precompiled_modules:system_swiftinterface_visionos_simulator_with_sdk_min_os",
     )
 
     build_test(

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -376,6 +376,11 @@ class _Module:
                     out.write("    is_framework = True,\n")
                 out.write(f'    module_name = "{self.name}",\n')
                 self._render_deps(out)
+                _write_transition_attrs(
+                    out,
+                    sdk=self.sdk,
+                    sdk_version=self.sdk_version,
+                )
                 _write_string_attr(
                     out,
                     name="system_swiftinterface",


### PR DESCRIPTION
When explicit modules are enabled:

```
common --features=swift.emit_c_module
common --host_features=swift.emit_c_module
common --features=swift.use_c_modules
common --host_features=swift.use_c_modules
```

The following error shows up:

```
external/rules_swift++system_sdk+system_sdk_xcode_26_4_0_17E192/BUILD.bazel:31971:22: Compiling Swift module Testing from textual interface failed: (Exit 1): worker failed: error executing SwiftCompileModuleInterface command (from system_swiftinterface rule target @@rules_swift++system_sdk+system_sdk_xcode_26_4_0_17E192//:iPhoneSimulator_Testing) bazel-out/darwin_arm64-opt-exec/bin/external/rules_swift+/tools/worker/worker swiftc ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
.rules_swift_interface_sources/Testing.swiftmodule/arm64-apple-ios-simulator.swiftinterface:88:282: error: 'Actor' is only available in iOS 13.0 or newer
  86 | @_disfavoredOverload internal func __checkClosureCall<E>(throws errorType: E.Type, performing body: () throws -> some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Error
  87 | @usableFromInline
  88 | @_disfavoredOverload internal func __checkClosureCall<E>(throws errorType: E.Type, performing body: () async throws -> sending some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, isolation: isolated (any _Concurrency.Actor)? = #isolation, sourceLocation: Testing.SourceLocation) async -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Error
     |                                    |                                                                                                                                                                                                                                                     `- error: 'Actor' is only available in iOS 13.0 or newer
     |                                    `- note: add '@available' attribute to enclosing global function
  89 | @usableFromInline
  90 | @_disfavoredOverload internal func __checkClosureCall<E>(throws error: E, performing body: () throws -> some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Equatable, E : Swift.Error

.rules_swift_interface_sources/Testing.swiftmodule/arm64-apple-ios-simulator.swiftinterface:88:293: error: 'isolation()' is only available in iOS 13.0 or newer
  86 | @_disfavoredOverload internal func __checkClosureCall<E>(throws errorType: E.Type, performing body: () throws -> some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Error
  87 | @usableFromInline
  88 | @_disfavoredOverload internal func __checkClosureCall<E>(throws errorType: E.Type, performing body: () async throws -> sending some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, isolation: isolated (any _Concurrency.Actor)? = #isolation, sourceLocation: Testing.SourceLocation) async -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Error
     |                                    |                                                                                                                                                                                                                                                                `- error: 'isolation()' is only available in iOS 13.0 or newer
     |                                    `- note: add '@available' attribute to enclosing global function
  89 | @usableFromInline
  90 | @_disfavoredOverload internal func __checkClosureCall<E>(throws error: E, performing body: () throws -> some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Equatable, E : Swift.Error

.rules_swift_interface_sources/Testing.swiftmodule/arm64-apple-ios-simulator.swiftinterface:92:273: error: 'Actor' is only available in iOS 13.0 or newer
  90 | @_disfavoredOverload internal func __checkClosureCall<E>(throws error: E, performing body: () throws -> some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Equatable, E : Swift.Error
  91 | @usableFromInline
  92 | @_disfavoredOverload internal func __checkClosureCall<E>(throws error: E, performing body: () async throws -> sending some Any, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, isolation: isolated (any _Concurrency.Actor)? = #isolation, sourceLocation: Testing.SourceLocation) async -> Swift.Result<Swift.Void, any Swift.Error> where E : Swift.Equatable, E : Swift.Error
     |                                    |                                                                                                                                                                                                                                            `- error: 'Actor' is only available in iOS 13.0 or newer
     |                                    `- note: add '@available' attribute to enclosing global function
  93 | @usableFromInline
  94 | @_disfavoredOverload internal func __checkClosureCall<R>(performing body: () throws -> R, throws errorMatcher: (any Swift.Error) throws -> Swift.Bool, mismatchExplanation: ((any Swift.Error) -> Swift.String)? = nil, expression: Testing.__Expression, comments: @autoclosure () -> [Testing.Comment], isRequired: Swift.Bool, sourceLocation: Testing.SourceLocation) -> Swift.Result<Swift.Void, any Swift.Error>

.rules_swift_interface_sources/Testing.swiftmodule/arm64-apple-ios-simulator.swiftinterface:1:1: error: failed to build module 'Testing' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
   1 | // swift-interface-format-version: 1.0
     | `- error: failed to build module 'Testing' for importation due to the errors above; the textual interface may be broken by project issues or a compiler bug
   2 | // swift-compiler-version: Apple Swift version 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102)
   3 | // swift-module-flags: -target arm64-apple-ios13.0-simulator -enable-objc-interop -enable-library-evolution -swift-version 6 -O -enable-experimental-feature Lifetimes -enable-experimental-feature AccessLevelOnImport -enable-upcoming-feature InternalImportsByDefault -enable-upcoming-feature MemberImportVisibility -enable-upcoming-feature ExistentialAny -enable-upcoming-feature InferIsolatedConformances -enable-experimental-feature DebugDescriptionMacro -user-module-version 1743 -module-name Testing -package-name swift_testing
```

Applying min-os transition fixes it.