### PR TITLE
Surface prebuilt SDK swiftmodules via explicit module map

### DIFF
--- a/doc/providers.md
+++ b/doc/providers.md
@@ -406,7 +406,7 @@ A `struct` containing the given values provided as arguments.
 <pre>
 create_swift_module_inputs(*, <a href="#create_swift_module_inputs-ast_files">ast_files</a>, <a href="#create_swift_module_inputs-const_protocols_to_gather">const_protocols_to_gather</a>, <a href="#create_swift_module_inputs-defines">defines</a>, <a href="#create_swift_module_inputs-generated_header">generated_header</a>,
                            <a href="#create_swift_module_inputs-indexstore">indexstore</a>, <a href="#create_swift_module_inputs-original_module_name">original_module_name</a>, <a href="#create_swift_module_inputs-plugins">plugins</a>, <a href="#create_swift_module_inputs-private_swiftinterface">private_swiftinterface</a>,
-                           <a href="#create_swift_module_inputs-swiftdoc">swiftdoc</a>, <a href="#create_swift_module_inputs-swiftinterface">swiftinterface</a>, <a href="#create_swift_module_inputs-swiftmodule">swiftmodule</a>, <a href="#create_swift_module_inputs-swiftsourceinfo">swiftsourceinfo</a>)
+                           <a href="#create_swift_module_inputs-swiftdoc">swiftdoc</a>, <a href="#create_swift_module_inputs-swiftinterface">swiftinterface</a>, <a href="#create_swift_module_inputs-swiftmodule">swiftmodule</a>, <a href="#create_swift_module_inputs-swiftmodule_path">swiftmodule_path</a>, <a href="#create_swift_module_inputs-swiftsourceinfo">swiftsourceinfo</a>)
 </pre>
 
 Creates a value representing a Swift module use as a Swift dependency.
@@ -426,7 +426,8 @@ Creates a value representing a Swift module use as a Swift dependency.
 | <a id="create_swift_module_inputs-private_swiftinterface"></a>private_swiftinterface |  The `.private.swiftinterface` file emitted by the compiler for this module. May be `None` if no private module interface file was emitted.   |  `None` |
 | <a id="create_swift_module_inputs-swiftdoc"></a>swiftdoc |  The `.swiftdoc` file emitted by the compiler for this module.   |  none |
 | <a id="create_swift_module_inputs-swiftinterface"></a>swiftinterface |  The `.swiftinterface` file emitted by the compiler for this module. May be `None` if no module interface file was emitted.   |  `None` |
-| <a id="create_swift_module_inputs-swiftmodule"></a>swiftmodule |  The `.swiftmodule` file emitted by the compiler for this module.   |  none |
+| <a id="create_swift_module_inputs-swiftmodule"></a>swiftmodule |  The `.swiftmodule` `File` emitted by the compiler for this module. May be `None` for modules whose binary swiftmodule lives outside the build (see `swiftmodule_path`).   |  none |
+| <a id="create_swift_module_inputs-swiftmodule_path"></a>swiftmodule_path |  An optional string path to a prebuilt `.swiftmodule` that is not a Bazel `File` (e.g. an SDK swiftmodule referenced via `__BAZEL_XCODE_SDKROOT__`/`__BAZEL_XCODE_DEVELOPER_DIR__` placeholders). Consumed by the explicit Swift module map writer and resolved at action time by the Swift worker; consumers that iterate `swiftmodule` as `File`s should ignore this field.   |  `None` |
 | <a id="create_swift_module_inputs-swiftsourceinfo"></a>swiftsourceinfo |  The `.swiftsourceinfo` file emitted by the compiler for this module. May be `None` if no source info file was emitted.   |  `None` |
 
 **RETURNS**

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -343,6 +343,7 @@ bzl_library(
         "//swift:swift_common",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
+        "//swift/internal:system_module_transition",
         "//swift/internal:toolchain_utils",
         "@rules_cc//cc/common",
     ],

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -350,6 +350,18 @@ bzl_library(
 )
 
 bzl_library(
+    name = "system_swiftmodule",
+    srcs = ["system_swiftmodule.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        ":utils",
+        "//swift:providers",
+        "//swift/internal:system_module_transition",
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
     name = "action_names",
     srcs = ["action_names.bzl"],
     visibility = ["//swift:__subpackages__"],

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -90,15 +90,21 @@ load(":wmo.bzl", "find_num_threads_flag_value", "is_wmo_manually_requested")
 # SWIFT_FEATURE_VFSOVERLAY is enabled.
 _SWIFTMODULES_VFS_ROOT = "/__build_bazel_rules_swift/swiftmodules"
 
-def transitive_swift_dependency_inputs(transitive_modules):
+def transitive_swift_dependency_inputs(transitive_modules, include_interfaces = True):
     """Returns Swift dependency artifacts that must be present in the sandbox.
 
     Args:
         transitive_modules: A list of transitive Swift module contexts.
+        include_interfaces: If True (the default), include the textual
+            `.swiftinterface` (or `.private.swiftinterface`) for each
+            dependency in addition to the binary `.swiftmodule`. When the
+            consumer is using `swift.use_explicit_swift_module_map`, the
+            binary `.swiftmodule` is sufficient and the interface files are
+            unused inputs that only inflate the action's sandbox.
 
     Returns:
-        A list of `.swiftmodule` files and the preferred textual interface file
-        for each Swift dependency.
+        A list of `.swiftmodule` files and (when `include_interfaces` is
+        True) the preferred textual interface file for each Swift dependency.
     """
     inputs = []
 
@@ -110,12 +116,13 @@ def transitive_swift_dependency_inputs(transitive_modules):
         if swift_module.swiftmodule:
             inputs.append(swift_module.swiftmodule)
 
-        interface_file = (
-            swift_module.private_swiftinterface or
-            swift_module.swiftinterface
-        )
-        if interface_file:
-            inputs.append(interface_file)
+        if include_interfaces:
+            interface_file = (
+                swift_module.private_swiftinterface or
+                swift_module.swiftinterface
+            )
+            if interface_file:
+                inputs.append(interface_file)
 
     return inputs
 
@@ -325,6 +332,10 @@ def compile_module_interface(
         transitive_swiftmodules.append(swift_module.swiftmodule)
     transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
         transitive_modules,
+        include_interfaces = not is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+        ),
     )
 
     if clang_module:
@@ -717,6 +728,10 @@ def compile(
             )
     transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
         transitive_modules,
+        include_interfaces = not is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+        ),
     )
 
     # We need this when generating the VFS overlay file and also when

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -113,7 +113,10 @@ def transitive_swift_dependency_inputs(transitive_modules, include_interfaces = 
         if not swift_module:
             continue
 
-        if swift_module.swiftmodule:
+        # `system_swiftmodule` stores a placeholder string here instead of a
+        # `File`; the prebuilt SDK swiftmodule is resolved at action time via
+        # the explicit module map JSON, not as a Bazel input.
+        if swift_module.swiftmodule and type(swift_module.swiftmodule) == "File":
             inputs.append(swift_module.swiftmodule)
 
         if include_interfaces:
@@ -205,7 +208,8 @@ def create_compilation_context(defines, srcs, transitive_modules):
         swift_module = module.swift
         if not swift_module:
             continue
-        swiftmodules.append(swift_module.swiftmodule)
+        if type(swift_module.swiftmodule) == "File":
+            swiftmodules.append(swift_module.swiftmodule)
         if swift_module.defines:
             defines_set = sets.union(
                 defines_set,
@@ -329,7 +333,8 @@ def compile_module_interface(
         swift_module = module.swift
         if not swift_module:
             continue
-        transitive_swiftmodules.append(swift_module.swiftmodule)
+        if type(swift_module.swiftmodule) == "File":
+            transitive_swiftmodules.append(swift_module.swiftmodule)
     transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
         transitive_modules,
         include_interfaces = not is_feature_enabled(
@@ -720,7 +725,8 @@ def compile(
         swift_module = module.swift
         if not swift_module:
             continue
-        transitive_swiftmodules.append(swift_module.swiftmodule)
+        if type(swift_module.swiftmodule) == "File":
+            transitive_swiftmodules.append(swift_module.swiftmodule)
         if swift_module.defines:
             defines_set = sets.union(
                 defines_set,

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -169,7 +169,13 @@ def _explicit_swift_module_map_info(
     )
     return struct(
         file = explicit_swift_module_map_file,
-        inputs = transitive_swift_dependency_inputs(module_contexts),
+        inputs = transitive_swift_dependency_inputs(
+            module_contexts,
+            include_interfaces = not is_feature_enabled(
+                feature_configuration = feature_configuration,
+                feature_name = SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+            ),
+        ),
     )
 
 def create_compilation_context(defines, srcs, transitive_modules):

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -113,10 +113,7 @@ def transitive_swift_dependency_inputs(transitive_modules, include_interfaces = 
         if not swift_module:
             continue
 
-        # `system_swiftmodule` stores a placeholder string here instead of a
-        # `File`; the prebuilt SDK swiftmodule is resolved at action time via
-        # the explicit module map JSON, not as a Bazel input.
-        if swift_module.swiftmodule and type(swift_module.swiftmodule) == "File":
+        if swift_module.swiftmodule:
             inputs.append(swift_module.swiftmodule)
 
         if include_interfaces:
@@ -208,7 +205,7 @@ def create_compilation_context(defines, srcs, transitive_modules):
         swift_module = module.swift
         if not swift_module:
             continue
-        if type(swift_module.swiftmodule) == "File":
+        if swift_module.swiftmodule:
             swiftmodules.append(swift_module.swiftmodule)
         if swift_module.defines:
             defines_set = sets.union(
@@ -333,7 +330,7 @@ def compile_module_interface(
         swift_module = module.swift
         if not swift_module:
             continue
-        if type(swift_module.swiftmodule) == "File":
+        if swift_module.swiftmodule:
             transitive_swiftmodules.append(swift_module.swiftmodule)
     transitive_swift_dependency_inputs_list = transitive_swift_dependency_inputs(
         transitive_modules,
@@ -725,7 +722,7 @@ def compile(
         swift_module = module.swift
         if not swift_module:
             continue
-        if type(swift_module.swiftmodule) == "File":
+        if swift_module.swiftmodule:
             transitive_swiftmodules.append(swift_module.swiftmodule)
         if swift_module.defines:
             defines_set = sets.union(

--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -52,7 +52,16 @@ def write_explicit_swift_module_map_file(
             swift_context = module_context.swift
             if swift_context.swiftmodule:
                 has_swift_description = True
-                module_description["modulePath"] = swift_context.swiftmodule.path
+                # `system_swiftmodule` passes a placeholder string here (the
+                # toolchain-resolved prebuilt path) instead of a `File`. The
+                # worker substitutes `__BAZEL_XCODE_SDKROOT__` etc. inside
+                # the rendered JSON at action time, so writing the string
+                # through unchanged is correct.
+                module_description["modulePath"] = getattr(
+                    swift_context.swiftmodule,
+                    "path",
+                    swift_context.swiftmodule,
+                )
 
         has_clang_description = (
             "clangModulePath" in module_description or

--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -52,16 +52,21 @@ def write_explicit_swift_module_map_file(
             swift_context = module_context.swift
             if swift_context.swiftmodule:
                 has_swift_description = True
-                # `system_swiftmodule` passes a placeholder string here (the
-                # toolchain-resolved prebuilt path) instead of a `File`. The
-                # worker substitutes `__BAZEL_XCODE_SDKROOT__` etc. inside
-                # the rendered JSON at action time, so writing the string
-                # through unchanged is correct.
-                module_description["modulePath"] = getattr(
-                    swift_context.swiftmodule,
-                    "path",
-                    swift_context.swiftmodule,
+                module_description["modulePath"] = swift_context.swiftmodule.path
+            else:
+                # `system_swiftmodule` exposes the prebuilt SDK path as a
+                # placeholder string here (no Bazel `File`); the worker
+                # substitutes `__BAZEL_XCODE_SDKROOT__` /
+                # `__BAZEL_XCODE_DEVELOPER_DIR__` inside the rendered JSON
+                # at action time so swiftc opens the right file.
+                swiftmodule_path = getattr(
+                    swift_context,
+                    "swiftmodule_path",
+                    None,
                 )
+                if swiftmodule_path:
+                    has_swift_description = True
+                    module_description["modulePath"] = swiftmodule_path
 
         has_clang_description = (
             "clangModulePath" in module_description or

--- a/swift/internal/system_swiftinterface.bzl
+++ b/swift/internal/system_swiftinterface.bzl
@@ -22,8 +22,12 @@ load(
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_SUPPRESS_WARNINGS",
     "SWIFT_FEATURE_SYSTEM_MODULE",
+    "SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES",
     "SWIFT_FEATURE_USE_C_MODULES",
+    "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
+    "SWIFT_FEATURE_VFSOVERLAY",
 )
+load("@build_bazel_rules_swift//swift/internal:system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
 load("@build_bazel_rules_swift//swift/internal:toolchain_utils.bzl", "SWIFT_SDK_TOOLCHAIN_TYPE")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -54,6 +58,31 @@ def _system_swiftinterface_impl(ctx):
             SWIFT_FEATURE_SUPPRESS_WARNINGS,  # System swiftinterface files have many warnings that we can't do anything about
             SWIFT_FEATURE_SYSTEM_MODULE,
             SWIFT_FEATURE_USE_C_MODULES,
+            # The interface compile must always run with the explicit
+            # module map and `-disable-implicit-swift-modules`. SDK Swift
+            # interfaces strict-check that they're being compiled by the
+            # same compiler that produced the SDK; the implicit-modules
+            # path can drift on a swiftc/SDK version mismatch and fail
+            # the check. The explicit-map path threads each Swift
+            # dependency in deliberately, which is what the rest of the
+            # interface validation expects.
+            SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+        ],
+        # The interface compile is internal explicit-modules infrastructure;
+        # vfsoverlay is mutually exclusive with the explicit module map (see
+        # `compile_module_interface`), and the consumer's choice of vfsoverlay
+        # has no bearing on how this SDK module is built.
+        #
+        # `add_default_precompiled_modules` is force-disabled here so that
+        # `-disable-implicit-swift-modules` does *not* fire for SDK
+        # interface compiles. The scanner only declares the direct module
+        # deps in `modules = [...]`; with implicit loading off, swiftc
+        # rejects transitive references like `os` that are reachable from
+        # the consumer's `system_modules` dep but not from the
+        # `system_swiftinterface` rule's own deps.
+        unsupported_features = [
+            SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES,
+            SWIFT_FEATURE_VFSOVERLAY,
         ],
         swift_toolchain = swift_toolchain,
     )
@@ -95,7 +124,8 @@ def _system_swiftinterface_impl(ctx):
     ]
 
 system_swiftinterface = rule(
-    attrs = {
+    cfg = sdk_min_os_transition,
+    attrs = sdk_min_os_transition_attrs() | {
         "is_framework": attr.bool(
             default = False,
             doc = "Whether the compiled Swift interface represents a framework module.",

--- a/swift/internal/system_swiftinterface.bzl
+++ b/swift/internal/system_swiftinterface.bzl
@@ -19,10 +19,10 @@ load("@build_bazel_rules_swift//swift:swift_common.bzl", "swift_common")
 load("@build_bazel_rules_swift//swift/internal:compiling.bzl", "compile_module_interface")
 load(
     "@build_bazel_rules_swift//swift/internal:feature_names.bzl",
+    "SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES",
     "SWIFT_FEATURE_EMIT_C_MODULE",
     "SWIFT_FEATURE_SUPPRESS_WARNINGS",
     "SWIFT_FEATURE_SYSTEM_MODULE",
-    "SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES",
     "SWIFT_FEATURE_USE_C_MODULES",
     "SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP",
     "SWIFT_FEATURE_VFSOVERLAY",

--- a/swift/internal/system_swiftmodule.bzl
+++ b/swift/internal/system_swiftmodule.bzl
@@ -21,7 +21,6 @@ load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 
 def _system_swiftmodule_impl(ctx):
-    swiftmodule = ctx.file.swiftmodule
     deps = ctx.attr.modules
     swift_infos = get_providers(deps, SwiftInfo)
     cc_info = cc_common.merge_cc_infos(cc_infos = [
@@ -37,12 +36,12 @@ def _system_swiftmodule_impl(ctx):
         swift = create_swift_module_inputs(
             swiftdoc = None,
             swiftinterface = None,
-            swiftmodule = swiftmodule,
+            swiftmodule = ctx.attr.swiftmodule,
         ),
     )
 
     return [
-        DefaultInfo(files = depset([swiftmodule])),
+        DefaultInfo(),
         SwiftInfo(
             modules = [module_context],
             swift_infos = swift_infos,
@@ -71,21 +70,23 @@ recurse into the SDK module graph from consumers.
             mandatory = False,
             providers = [[CcInfo, SwiftInfo]],
         ),
-        "swiftmodule": attr.label(
-            allow_single_file = True,
+        "swiftmodule": attr.string(
             doc = """\
-The prebuilt `.swiftmodule` file from the toolchain to surface directly. This
-file is consumed without recompilation and lands in the consumer's explicit
-module map as the `modulePath` for this Swift module.
+Path to the prebuilt `.swiftmodule` file shipped by the toolchain (typically
+under `<toolchain>/usr/lib/swift/<platform>/prebuilt-modules/<sdk-version>/`).
+The string flows directly into the consumer's explicit Swift module map as
+the `modulePath`; the worker substitutes `__BAZEL_XCODE_SDKROOT__` and
+`__BAZEL_XCODE_DEVELOPER_DIR__` placeholders in the JSON map at action time
+so swiftc can open the SDK file without Bazel staging it as an input.
 """,
             mandatory = True,
         ),
     },
     doc = """\
-Surfaces a prebuilt SDK `.swiftmodule` (typically from
-`<toolchain>/usr/lib/swift/<platform>/prebuilt-modules/<sdk-version>/`) as a
-Bazel `File` so consumers can reference it via the explicit Swift module map
-without paying a per-target interface compile.
+Surfaces a prebuilt SDK `.swiftmodule` so consumers can reference it via the
+explicit Swift module map without paying a per-target interface compile. The
+path is treated like `system_swiftinterface`'s interface path: a placeholder
+string resolved at action time, not a Bazel-tracked input.
 """,
     implementation = _system_swiftmodule_impl,
 )

--- a/swift/internal/system_swiftmodule.bzl
+++ b/swift/internal/system_swiftmodule.bzl
@@ -36,7 +36,12 @@ def _system_swiftmodule_impl(ctx):
         swift = create_swift_module_inputs(
             swiftdoc = None,
             swiftinterface = None,
-            swiftmodule = ctx.attr.swiftmodule,
+            # Leave `swiftmodule` (the `File` slot) unset so consumers that
+            # iterate transitive Swift deps as `File`s don't choke on a
+            # string. The placeholder path is exposed via `swiftmodule_path`
+            # for the explicit Swift module map writer to consume.
+            swiftmodule = None,
+            swiftmodule_path = ctx.attr.swiftmodule,
         ),
     )
 

--- a/swift/internal/system_swiftmodule.bzl
+++ b/swift/internal/system_swiftmodule.bzl
@@ -1,0 +1,91 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Surface a prebuilt SDK `.swiftmodule` directly without recompiling."""
+
+load("@build_bazel_rules_swift//swift:providers.bzl", "SwiftInfo", "create_swift_module_context", "create_swift_module_inputs")
+load("@build_bazel_rules_swift//swift/internal:system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
+load("@build_bazel_rules_swift//swift/internal:utils.bzl", "get_providers")
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+
+def _system_swiftmodule_impl(ctx):
+    swiftmodule = ctx.file.swiftmodule
+    deps = ctx.attr.modules
+    swift_infos = get_providers(deps, SwiftInfo)
+    cc_info = cc_common.merge_cc_infos(cc_infos = [
+        dep[CcInfo]
+        for dep in deps
+        if CcInfo in dep
+    ])
+
+    module_context = create_swift_module_context(
+        name = ctx.attr.module_name,
+        is_framework = ctx.attr.is_framework,
+        is_system = True,
+        swift = create_swift_module_inputs(
+            swiftdoc = None,
+            swiftinterface = None,
+            swiftmodule = swiftmodule,
+        ),
+    )
+
+    return [
+        DefaultInfo(files = depset([swiftmodule])),
+        SwiftInfo(
+            modules = [module_context],
+            swift_infos = swift_infos,
+        ),
+        cc_info,
+    ]
+
+system_swiftmodule = rule(
+    cfg = sdk_min_os_transition,
+    attrs = sdk_min_os_transition_attrs() | {
+        "is_framework": attr.bool(
+            default = False,
+            doc = "Whether the prebuilt swiftmodule represents a framework module.",
+        ),
+        "module_name": attr.string(
+            doc = "The name of the Swift module represented by this target.",
+            mandatory = True,
+        ),
+        "modules": attr.label_list(
+            allow_empty = True,
+            doc = """\
+A list of system modules that this Swift module depends on. Named `modules`
+instead of `deps` so the standard Swift `swift_clang_module_aspect` doesn't
+recurse into the SDK module graph from consumers.
+""",
+            mandatory = False,
+            providers = [[CcInfo, SwiftInfo]],
+        ),
+        "swiftmodule": attr.label(
+            allow_single_file = True,
+            doc = """\
+The prebuilt `.swiftmodule` file from the toolchain to surface directly. This
+file is consumed without recompilation and lands in the consumer's explicit
+module map as the `modulePath` for this Swift module.
+""",
+            mandatory = True,
+        ),
+    },
+    doc = """\
+Surfaces a prebuilt SDK `.swiftmodule` (typically from
+`<toolchain>/usr/lib/swift/<platform>/prebuilt-modules/<sdk-version>/`) as a
+Bazel `File` so consumers can reference it via the explicit Swift module map
+without paying a per-target interface compile.
+""",
+    implementation = _system_swiftmodule_impl,
+)

--- a/swift/providers.bzl
+++ b/swift/providers.bzl
@@ -675,6 +675,7 @@ def create_swift_module_inputs(
         swiftdoc,
         swiftinterface = None,
         swiftmodule,
+        swiftmodule_path = None,
         swiftsourceinfo = None):
     """Creates a value representing a Swift module use as a Swift dependency.
 
@@ -701,8 +702,15 @@ def create_swift_module_inputs(
         swiftdoc: The `.swiftdoc` file emitted by the compiler for this module.
         swiftinterface: The `.swiftinterface` file emitted by the compiler for
             this module. May be `None` if no module interface file was emitted.
-        swiftmodule: The `.swiftmodule` file emitted by the compiler for this
-            module.
+        swiftmodule: The `.swiftmodule` `File` emitted by the compiler for this
+            module. May be `None` for modules whose binary swiftmodule lives
+            outside the build (see `swiftmodule_path`).
+        swiftmodule_path: An optional string path to a prebuilt `.swiftmodule`
+            that is not a Bazel `File` (e.g. an SDK swiftmodule referenced via
+            `__BAZEL_XCODE_SDKROOT__`/`__BAZEL_XCODE_DEVELOPER_DIR__`
+            placeholders). Consumed by the explicit Swift module map writer
+            and resolved at action time by the Swift worker; consumers that
+            iterate `swiftmodule` as `File`s should ignore this field.
         swiftsourceinfo: The `.swiftsourceinfo` file emitted by the compiler for
             this module. May be `None` if no source info file was emitted.
 
@@ -721,5 +729,6 @@ def create_swift_module_inputs(
         swiftdoc = swiftdoc,
         swiftinterface = swiftinterface,
         swiftmodule = swiftmodule,
+        swiftmodule_path = swiftmodule_path,
         swiftsourceinfo = swiftsourceinfo,
     )

--- a/swift/swift.bzl
+++ b/swift/swift.bzl
@@ -30,6 +30,7 @@ load(
 load("//swift/internal:system_clang_module.bzl", _system_clang_module = "system_clang_module")
 load("//swift/internal:system_module_group.bzl", _system_module_group = "system_module_group")
 load("//swift/internal:system_swiftinterface.bzl", _system_swiftinterface = "system_swiftinterface")
+load("//swift/internal:system_swiftmodule.bzl", _system_swiftmodule = "system_swiftmodule")
 load(
     ":providers.bzl",
     _SwiftInfo = "SwiftInfo",
@@ -103,6 +104,7 @@ swift_test = _swift_test
 system_clang_module = _system_clang_module
 system_module_group = _system_module_group
 system_swiftinterface = _system_swiftinterface
+system_swiftmodule = _system_swiftmodule
 universal_swift_compiler_plugin = _universal_swift_compiler_plugin
 
 # Re-export public aspects.

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -924,14 +924,35 @@ def compile_action_configs(
             features = [SWIFT_FEATURE_USE_C_MODULES],
             not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],  # If this feature is enabled we still use this file just with more contents
         ),
-        # TODO: Pass through system modules and pass this to all actions
-        # ActionConfigInfo(
-        #     actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
-        #     configurators = [
-        #         add_arg("-disable-implicit-swift-modules"),
-        #     ],
-        #     features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
-        # ),
+        # `-disable-implicit-swift-modules` forbids swiftc from doing
+        # implicit Swift module loading on every invocation, which is the
+        # main performance gap for sandboxed (non-worker) explicit-module
+        # builds vs. implicit-module builds with persistent workers. This
+        # requires that every Swift module dependency, including the
+        # standard library and core system modules (`Swift`, `_Concurrency`,
+        # `_StringProcessing`, `SwiftOnoneSupport`, ...), is routed through
+        # the explicit module map. `swift.add_default_precompiled_modules`
+        # is what causes the SDK system_modules dep to flow into every
+        # consumer's transitive deps, so its swiftmodules land in the
+        # explicit map JSON; without it, modules like `SwiftOnoneSupport`
+        # (loaded automatically by swiftc under `-Onone`) are missing and
+        # the compile fails.
+        ActionConfigInfo(
+            actions = all_compile_action_names() + [SWIFT_ACTION_DUMP_AST],
+            configurators = [add_arg("-Xfrontend", "-disable-implicit-swift-modules")],
+            features = [
+                SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+                SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES,
+            ],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [add_arg("-disable-implicit-swift-modules")],
+            features = [
+                SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP,
+                SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES,
+            ],
+        ),
         ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -2083,7 +2083,13 @@ def _swift_module_search_path_map_fn(module):
         The dirname of the module's `.swiftmodule` file.
     """
     if module.swift:
-        search_path = module.swift.swiftmodule.dirname
+        # `system_swiftmodule` stores the prebuilt SDK path as a placeholder
+        # string here (no Bazel `File`); `paths.dirname` works on both.
+        swiftmodule = module.swift.swiftmodule
+        if type(swiftmodule) == "File":
+            search_path = swiftmodule.dirname
+        else:
+            search_path = paths.dirname(swiftmodule)
 
         # If the dirname also ends in .swiftmodule, remove it as well so that
         # the compiler finds the module *directory*.

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -2083,13 +2083,18 @@ def _swift_module_search_path_map_fn(module):
         The dirname of the module's `.swiftmodule` file.
     """
     if module.swift:
-        # `system_swiftmodule` stores the prebuilt SDK path as a placeholder
-        # string here (no Bazel `File`); `paths.dirname` works on both.
+        # `system_swiftmodule` exposes its prebuilt path on `swiftmodule_path`
+        # (a placeholder string) instead of the `File`-typed `swiftmodule`,
+        # so the consumer can include it on the Swift module search path
+        # without Bazel needing to track the SDK file as an input.
         swiftmodule = module.swift.swiftmodule
-        if type(swiftmodule) == "File":
+        if swiftmodule:
             search_path = swiftmodule.dirname
         else:
-            search_path = paths.dirname(swiftmodule)
+            swiftmodule_path = getattr(module.swift, "swiftmodule_path", None)
+            if not swiftmodule_path:
+                return None
+            search_path = paths.dirname(swiftmodule_path)
 
         # If the dirname also ends in .swiftmodule, remove it as well so that
         # the compiler finds the module *directory*.

--- a/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
+++ b/test/fixtures/precompiled_modules/cross_import_overlay_pollution.swift
@@ -1,0 +1,9 @@
+import AppKit
+import Testing
+
+private func foo() {
+  let image = NSImage(data: Data())!
+  // This currently relies on a protocol conformance for NSImage that exists in _Testing_AppKit which is
+  // imported implicitly through a cross import overlay
+  Attachment.record(image, named: "foo", as: .png)
+}

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -216,8 +216,12 @@ def module_interface_test_suite(name, tags = []):
         tags = all_tags,
         mnemonic = "SwiftCompileModuleInterface",
         expected_inputs = [
-            "ToyModule.swiftinterface",
+            # The action's own source interface and the JSON map are required;
+            # dependency `.swiftinterface` files are intentionally omitted under
+            # `swift.use_explicit_swift_module_map` because the binary
+            # `.swiftmodule` listed in the map is sufficient.
             "DependentToyModule.swiftinterface",
+            "ToyModule.swiftmodule",
             "dependent_toy_module.swift-explicit-module-map.json",
         ],
         target_under_test = "//test/fixtures/module_interface:dependent_toy_module",

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -376,6 +376,11 @@ class _Module:
                     out.write("    is_framework = True,\n")
                 out.write(f'    module_name = "{self.name}",\n')
                 self._render_deps(out)
+                _write_transition_attrs(
+                    out,
+                    sdk=self.sdk,
+                    sdk_version=self.sdk_version,
+                )
                 _write_string_attr(
                     out,
                     name="system_swiftinterface",
@@ -437,6 +442,14 @@ def _parse_output(
 
         module.module_map_path = module.module_map_path or module_map_path
         if module_type == "swift":
+            # Only route Swift modules through `system_swiftinterface` when
+            # the toolchain has no prebuilt `.swiftmodule` available. SDK
+            # frameworks like AVFoundation reach `os` (and other modules)
+            # implicitly during interface compilation but don't list them
+            # in `-scan-dependencies` output, so the explicit-map compile
+            # fails with `module 'os' is needed but has not been provided`.
+            # Routing prebuilt-having modules through `system_module_group`
+            # avoids the per-module interface compile entirely.
             has_prebuilt_swiftmodule = bool(details.get("compiledModuleCandidates", []))
             if not has_prebuilt_swiftmodule:
                 module.set_swiftinterface(

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -105,9 +105,15 @@ load(
     "system_clang_module",
     "system_module_group",
     "system_swiftinterface",
+    "system_swiftmodule",
 )
 
 package(default_visibility = ["//visibility:public"])
+
+# Prebuilt SDK swiftmodules are symlinked into this directory by the
+# `xcode_explicit_module_repo` repository rule and consumed by
+# `system_swiftmodule(...)` targets emitted below.
+exports_files(glob(["prebuilt-modules/**"], allow_empty = True))
 
 swift_cross_import_overlay_group(name = "_empty_cross_import_overlays")
 
@@ -286,6 +292,10 @@ class _Module:
         default_factory=dict,
         compare=False,
     )
+    prebuilt_swiftmodule_paths_by_cpu: dict[str, str] = field(
+        default_factory=dict,
+        compare=False,
+    )
     deps_by_cpu: defaultdict[str, set[str]] = field(
         default_factory=lambda: defaultdict(set),
         compare=False,
@@ -307,9 +317,23 @@ class _Module:
         self.swiftinterface_paths_by_cpu[cpu] = swiftinterface_path
         self.is_framework = self.is_framework or is_framework
 
+    def set_prebuilt_swiftmodule(
+        self,
+        *,
+        cpu: str,
+        is_framework: bool,
+        swiftmodule_path: str,
+    ) -> None:
+        self.prebuilt_swiftmodule_paths_by_cpu[cpu] = swiftmodule_path
+        self.is_framework = self.is_framework or is_framework
+
     @property
     def all_dependencies(self) -> set[str]:
         return set().union(*self.deps_by_cpu.values())
+
+    @property
+    def should_use_prebuilt_swiftmodule(self) -> bool:
+        return bool(self.prebuilt_swiftmodule_paths_by_cpu)
 
     @property
     def should_compile_swiftinterface(self) -> bool:
@@ -345,6 +369,38 @@ class _Module:
 
         out.write("    }),\n")
 
+    def prebuilt_swiftmodule_link_paths_by_cpu(self) -> dict[str, str]:
+        """Per-cpu repo-relative paths where prebuilt swiftmodules will be symlinked."""
+        result = {}
+        for cpu, source in self.prebuilt_swiftmodule_paths_by_cpu.items():
+            basename = os.path.basename(source)
+            result[cpu] = f"prebuilt-modules/{self.sdk}/{self.name}.swiftmodule/{basename}"
+        return result
+
+    def prebuilt_swiftmodule_manifest_entries(self) -> list[tuple[str, str]]:
+        """(link_path, target_path) pairs for the prebuilt-module symlink manifest."""
+        seen = {}
+        for cpu, target in self.prebuilt_swiftmodule_paths_by_cpu.items():
+            link = self.prebuilt_swiftmodule_link_paths_by_cpu()[cpu]
+            seen[link] = target
+        return sorted(seen.items())
+
+    def _render_swift_label_attr(
+        self,
+        out: TextIO,
+        *,
+        name: str,
+        labels_by_cpu: dict[str, str],
+    ) -> None:
+        unique = set(labels_by_cpu.values())
+        if len(unique) == 1:
+            out.write(f'    {name} = "{next(iter(unique))}",\n')
+            return
+        out.write(f"    {name} = select({{\n")
+        for cpu, label in sorted(labels_by_cpu.items()):
+            out.write(f'        "{cpu}": "{label}",\n')
+        out.write("    }),\n")
+
     def render_target(self, out: TextIO) -> None:
         if self.module_type == "clang":
             assert self.module_map_path
@@ -364,14 +420,31 @@ class _Module:
             out.write(")\n")
         elif self.module_type == "swift":
             out.write("\n")
-            if self.should_compile_swiftinterface:
+            if self.should_use_prebuilt_swiftmodule:
+                out.write("system_swiftmodule(\n")
+            elif self.should_compile_swiftinterface:
                 out.write("system_swiftinterface(\n")
             else:
                 out.write("system_module_group(\n")
             out.write(
                 f'    name = "{_canonical_name(self.name, self.sdk, self.module_type)}",\n'
             )
-            if self.should_compile_swiftinterface:
+            if self.should_use_prebuilt_swiftmodule:
+                if self.is_framework:
+                    out.write("    is_framework = True,\n")
+                out.write(f'    module_name = "{self.name}",\n')
+                self._render_deps(out)
+                _write_transition_attrs(
+                    out,
+                    sdk=self.sdk,
+                    sdk_version=self.sdk_version,
+                )
+                self._render_swift_label_attr(
+                    out,
+                    name="swiftmodule",
+                    labels_by_cpu=self.prebuilt_swiftmodule_link_paths_by_cpu(),
+                )
+            elif self.should_compile_swiftinterface:
                 if self.is_framework:
                     out.write("    is_framework = True,\n")
                 out.write(f'    module_name = "{self.name}",\n')
@@ -442,16 +515,25 @@ def _parse_output(
 
         module.module_map_path = module.module_map_path or module_map_path
         if module_type == "swift":
-            # Only route Swift modules through `system_swiftinterface` when
-            # the toolchain has no prebuilt `.swiftmodule` available. SDK
-            # frameworks like AVFoundation reach `os` (and other modules)
-            # implicitly during interface compilation but don't list them
-            # in `-scan-dependencies` output, so the explicit-map compile
-            # fails with `module 'os' is needed but has not been provided`.
-            # Routing prebuilt-having modules through `system_module_group`
-            # avoids the per-module interface compile entirely.
-            has_prebuilt_swiftmodule = bool(details.get("compiledModuleCandidates", []))
-            if not has_prebuilt_swiftmodule:
+            # Prefer the prebuilt `.swiftmodule` shipped in the toolchain
+            # over compiling from textual interface: the prebuilt is just a
+            # file the consumer can reference via the explicit module map's
+            # `modulePath`, with no per-target compile action. The interface
+            # path is only used as a fallback when the toolchain ships no
+            # prebuilt for this module (e.g. `Cxx`, `CxxStdlib`,
+            # `Playgrounds`). Routing prebuilt-having modules through the
+            # prebuilt also sidesteps the swiftc scanner's gap of not
+            # reporting transitive deps of an interface compile (e.g.
+            # AVFoundation's interface implicitly reaches `os` but the
+            # scanner doesn't surface that).
+            candidates = details.get("compiledModuleCandidates", [])
+            if candidates:
+                module.set_prebuilt_swiftmodule(
+                    cpu=cpu,
+                    is_framework=bool(details.get("isFramework", False)),
+                    swiftmodule_path=candidates[0],
+                )
+            elif details.get("moduleInterfacePath"):
                 module.set_swiftinterface(
                     cpu=cpu,
                     is_framework=bool(details.get("isFramework", False)),
@@ -731,7 +813,16 @@ def _discover_all_modules(
     )
     _render_all_modules_group(all_module_names, sdk, deployment_target, buf)
 
-    return buf.getvalue(), all_module_names | {f"{n}_clang" for n in clang_names}
+    prebuilt_manifest: list[tuple[str, str]] = []
+    for module in all_modules:
+        if module.module_type == "swift" and module.should_use_prebuilt_swiftmodule:
+            prebuilt_manifest.extend(module.prebuilt_swiftmodule_manifest_entries())
+
+    return (
+        buf.getvalue(),
+        all_module_names | {f"{n}_clang" for n in clang_names},
+        prebuilt_manifest,
+    )
 
 
 def _parse_exclude_modules(values: list[str]) -> dict[str, set[str]]:
@@ -779,6 +870,16 @@ def _main() -> None:
         default=None,
         # Internal flag used by the `system_sdk` module extension; not part
         # of the user-facing CLI.
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--prebuilt-modules-manifest",
+        type=Path,
+        default=None,
+        # Internal flag: writes a JSON list of `{link, target}` pairs that
+        # the repository rule should symlink into the generated repo so the
+        # `system_swiftmodule(swiftmodule = ...)` labels resolve to real
+        # Bazel files. Not part of the user-facing CLI.
         help=argparse.SUPPRESS,
     )
     parser.add_argument(
@@ -839,6 +940,7 @@ def _main() -> None:
     all_modules_by_sdk: dict[str, set[str]] = {}
     all_modules: set[str] = set()
     per_sdk_text: dict[str, str] = {}
+    prebuilt_manifest: dict[str, str] = {}
     with ThreadPoolExecutor(max_workers=len(sdk_names)) as pool:
         futures = {
             pool.submit(
@@ -851,10 +953,17 @@ def _main() -> None:
         }
         for fut in as_completed(futures):
             sdk = futures[fut]
-            output, modules = fut.result()
+            output, modules, prebuilt_entries = fut.result()
             per_sdk_text[sdk] = output
             all_modules_by_sdk[sdk] = modules
             all_modules |= modules
+            for link, target in prebuilt_entries:
+                existing = prebuilt_manifest.get(link)
+                if existing is not None and existing != target:
+                    raise SystemExit(
+                        f"prebuilt-module symlink conflict: {link} -> {existing} vs {target}"
+                    )
+                prebuilt_manifest[link] = target
 
     for sdk in sdk_names:
         buf.write(per_sdk_text[sdk])
@@ -900,6 +1009,14 @@ def _main() -> None:
     if args.module_names is not None:
         with open(args.module_names, "w") as f:
             json.dump(sorted(all_modules), f, indent=2)
+
+    if args.prebuilt_modules_manifest is not None:
+        manifest = [
+            {"link": link, "target": prebuilt_manifest[link]}
+            for link in sorted(prebuilt_manifest)
+        ]
+        with open(args.prebuilt_modules_manifest, "w") as f:
+            json.dump(manifest, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -110,11 +110,6 @@ load(
 
 package(default_visibility = ["//visibility:public"])
 
-# Prebuilt SDK swiftmodules are symlinked into this directory by the
-# `xcode_explicit_module_repo` repository rule and consumed by
-# `system_swiftmodule(...)` targets emitted below.
-exports_files(glob(["prebuilt-modules/**"], allow_empty = True))
-
 swift_cross_import_overlay_group(name = "_empty_cross_import_overlays")
 
 system_module_group(
@@ -369,38 +364,6 @@ class _Module:
 
         out.write("    }),\n")
 
-    def prebuilt_swiftmodule_link_paths_by_cpu(self) -> dict[str, str]:
-        """Per-cpu repo-relative paths where prebuilt swiftmodules will be symlinked."""
-        result = {}
-        for cpu, source in self.prebuilt_swiftmodule_paths_by_cpu.items():
-            basename = os.path.basename(source)
-            result[cpu] = f"prebuilt-modules/{self.sdk}/{self.name}.swiftmodule/{basename}"
-        return result
-
-    def prebuilt_swiftmodule_manifest_entries(self) -> list[tuple[str, str]]:
-        """(link_path, target_path) pairs for the prebuilt-module symlink manifest."""
-        seen = {}
-        for cpu, target in self.prebuilt_swiftmodule_paths_by_cpu.items():
-            link = self.prebuilt_swiftmodule_link_paths_by_cpu()[cpu]
-            seen[link] = target
-        return sorted(seen.items())
-
-    def _render_swift_label_attr(
-        self,
-        out: TextIO,
-        *,
-        name: str,
-        labels_by_cpu: dict[str, str],
-    ) -> None:
-        unique = set(labels_by_cpu.values())
-        if len(unique) == 1:
-            out.write(f'    {name} = "{next(iter(unique))}",\n')
-            return
-        out.write(f"    {name} = select({{\n")
-        for cpu, label in sorted(labels_by_cpu.items()):
-            out.write(f'        "{cpu}": "{label}",\n')
-        out.write("    }),\n")
-
     def render_target(self, out: TextIO) -> None:
         if self.module_type == "clang":
             assert self.module_map_path
@@ -439,10 +402,10 @@ class _Module:
                     sdk=self.sdk,
                     sdk_version=self.sdk_version,
                 )
-                self._render_swift_label_attr(
+                _write_string_attr(
                     out,
                     name="swiftmodule",
-                    labels_by_cpu=self.prebuilt_swiftmodule_link_paths_by_cpu(),
+                    values_by_cpu=self.prebuilt_swiftmodule_paths_by_cpu,
                 )
             elif self.should_compile_swiftinterface:
                 if self.is_framework:
@@ -531,7 +494,11 @@ def _parse_output(
                 module.set_prebuilt_swiftmodule(
                     cpu=cpu,
                     is_framework=bool(details.get("isFramework", False)),
-                    swiftmodule_path=candidates[0],
+                    swiftmodule_path=_normalize_system_path(
+                        candidates[0],
+                        developer_dir=developer_dir,
+                        sdkroot=sdkroot,
+                    ),
                 )
             elif details.get("moduleInterfacePath"):
                 module.set_swiftinterface(
@@ -813,15 +780,9 @@ def _discover_all_modules(
     )
     _render_all_modules_group(all_module_names, sdk, deployment_target, buf)
 
-    prebuilt_manifest: list[tuple[str, str]] = []
-    for module in all_modules:
-        if module.module_type == "swift" and module.should_use_prebuilt_swiftmodule:
-            prebuilt_manifest.extend(module.prebuilt_swiftmodule_manifest_entries())
-
     return (
         buf.getvalue(),
         all_module_names | {f"{n}_clang" for n in clang_names},
-        prebuilt_manifest,
     )
 
 
@@ -870,16 +831,6 @@ def _main() -> None:
         default=None,
         # Internal flag used by the `system_sdk` module extension; not part
         # of the user-facing CLI.
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
-        "--prebuilt-modules-manifest",
-        type=Path,
-        default=None,
-        # Internal flag: writes a JSON list of `{link, target}` pairs that
-        # the repository rule should symlink into the generated repo so the
-        # `system_swiftmodule(swiftmodule = ...)` labels resolve to real
-        # Bazel files. Not part of the user-facing CLI.
         help=argparse.SUPPRESS,
     )
     parser.add_argument(
@@ -940,7 +891,6 @@ def _main() -> None:
     all_modules_by_sdk: dict[str, set[str]] = {}
     all_modules: set[str] = set()
     per_sdk_text: dict[str, str] = {}
-    prebuilt_manifest: dict[str, str] = {}
     with ThreadPoolExecutor(max_workers=len(sdk_names)) as pool:
         futures = {
             pool.submit(
@@ -953,17 +903,10 @@ def _main() -> None:
         }
         for fut in as_completed(futures):
             sdk = futures[fut]
-            output, modules, prebuilt_entries = fut.result()
+            output, modules = fut.result()
             per_sdk_text[sdk] = output
             all_modules_by_sdk[sdk] = modules
             all_modules |= modules
-            for link, target in prebuilt_entries:
-                existing = prebuilt_manifest.get(link)
-                if existing is not None and existing != target:
-                    raise SystemExit(
-                        f"prebuilt-module symlink conflict: {link} -> {existing} vs {target}"
-                    )
-                prebuilt_manifest[link] = target
 
     for sdk in sdk_names:
         buf.write(per_sdk_text[sdk])
@@ -1009,14 +952,6 @@ def _main() -> None:
     if args.module_names is not None:
         with open(args.module_names, "w") as f:
             json.dump(sorted(all_modules), f, indent=2)
-
-    if args.prebuilt_modules_manifest is not None:
-        manifest = [
-            {"link": link, "target": prebuilt_manifest[link]}
-            for link in sorted(prebuilt_manifest)
-        ]
-        with open(args.prebuilt_modules_manifest, "w") as f:
-            json.dump(manifest, f, indent=2)
 
 
 if __name__ == "__main__":

--- a/tools/explicit_modules/xcode_explicit_module_repo.bzl
+++ b/tools/explicit_modules/xcode_explicit_module_repo.bzl
@@ -47,6 +47,8 @@ def _xcode_explicit_module_repo_impl(rctx):
             "BUILD.bazel",
             "--module-names",
             "module_names.json",
+            "--prebuilt-modules-manifest",
+            "prebuilt_modules.json",
         ] + _exclude_module_args(rctx.attr.exclude_modules) + list(rctx.attr.sdks),
         environment = {"DEVELOPER_DIR": developer_dir},
     )
@@ -58,6 +60,16 @@ def _xcode_explicit_module_repo_impl(rctx):
                 result.stderr,
             ),
         )
+
+    # Surface every prebuilt SDK swiftmodule as a real Bazel `File` so
+    # `system_swiftmodule(swiftmodule = ...)` labels resolve. The scanner
+    # records each per-cpu prebuilt path in `prebuilt_modules.json`; we
+    # symlink the toolchain file into the repo at the matching relative
+    # path. Symlinking (rather than copying) is cheap and avoids dragging
+    # hundreds of MB of swiftmodules into the repo cache.
+    manifest = json.decode(rctx.read("prebuilt_modules.json"))
+    for entry in manifest:
+        rctx.symlink(entry["target"], entry["link"])
 
 xcode_explicit_module_repo = repository_rule(
     implementation = _xcode_explicit_module_repo_impl,

--- a/tools/explicit_modules/xcode_explicit_module_repo.bzl
+++ b/tools/explicit_modules/xcode_explicit_module_repo.bzl
@@ -47,8 +47,6 @@ def _xcode_explicit_module_repo_impl(rctx):
             "BUILD.bazel",
             "--module-names",
             "module_names.json",
-            "--prebuilt-modules-manifest",
-            "prebuilt_modules.json",
         ] + _exclude_module_args(rctx.attr.exclude_modules) + list(rctx.attr.sdks),
         environment = {"DEVELOPER_DIR": developer_dir},
     )
@@ -60,16 +58,6 @@ def _xcode_explicit_module_repo_impl(rctx):
                 result.stderr,
             ),
         )
-
-    # Surface every prebuilt SDK swiftmodule as a real Bazel `File` so
-    # `system_swiftmodule(swiftmodule = ...)` labels resolve. The scanner
-    # records each per-cpu prebuilt path in `prebuilt_modules.json`; we
-    # symlink the toolchain file into the repo at the matching relative
-    # path. Symlinking (rather than copying) is cheap and avoids dragging
-    # hundreds of MB of swiftmodules into the repo cache.
-    manifest = json.decode(rctx.read("prebuilt_modules.json"))
-    for entry in manifest:
-        rctx.symlink(entry["target"], entry["link"])
 
 xcode_explicit_module_repo = repository_rule(
     implementation = _xcode_explicit_module_repo_impl,


### PR DESCRIPTION
## Summary

- Add `system_swiftmodule` rule that surfaces a prebuilt SDK `.swiftmodule` directly through the explicit Swift module map, avoiding a per-target interface compile for SDK modules that ship a prebuilt. The path flows in as a placeholder string (`__BAZEL_XCODE_SDKROOT__` / `__BAZEL_XCODE_DEVELOPER_DIR__`) and is resolved by the worker at action time, so the SDK file is never staged as a Bazel input.
- Wire up `-Xfrontend -disable-implicit-swift-modules` (previously a TODO) for compile and module-interface actions when both `swift.use_explicit_swift_module_map` and `swift.add_default_precompiled_modules` are enabled, making the explicit map authoritative.
- Drop transitive `.swiftinterface` files from compile-action inputs under `swift.use_explicit_swift_module_map` — the binary `.swiftmodule` referenced by the map is sufficient, and the textual interfaces only inflate the sandbox.
- Teach the explicit-modules scanner to prefer `compiledModuleCandidates` over `moduleInterfacePath`, which also sidesteps the swiftc scanner's gap of not reporting transitive deps reachable only through an interface compile (e.g. AVFoundation reaching `os`).

## Test plan

- [ ] `bazel test //test/...` on macOS
- [ ] Validate against a downstream consumer using `swift.use_explicit_swift_module_map`
- [ ] Confirm rules_apple builds cleanly with the included compatibility shim