### PR TITLE
Don't drop -target from swiftinterface files

### DIFF
--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -199,7 +199,10 @@ swift_binary(
     # version, that is what we're testing
     features = ["-treat_warnings_as_errors"],
     tags = FIXTURE_TAGS,
-    target_compatible_with = ["@platforms//os:ios"],
+    target_compatible_with = ["@platforms//os:ios"] + select({
+        "@build_bazel_apple_support//configs:apple": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     deps = ["@system_sdk//:Testing"],
 )
 
@@ -209,6 +212,10 @@ transition_binary(
     platform = "@build_bazel_apple_support//platforms:ios_arm64",
     tags = FIXTURE_TAGS,
     target = ":available_testing_import",
+    target_compatible_with = select({
+        "@build_bazel_apple_support//configs:apple": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
     transitive_features = [
         "swift.emit_c_module",
         "swift.use_c_modules",

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -208,7 +208,7 @@ swift_binary(
 
 transition_binary(
     name = "available_testing_import_ios_12",
-    minimum_os = "12.0",
+    ios_minimum_os = "12.0",
     platform = "@build_bazel_apple_support//platforms:ios_arm64",
     tags = FIXTURE_TAGS,
     target = ":available_testing_import",

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -192,6 +192,30 @@ transition_test(
     ],
 )
 
+swift_binary(
+    name = "available_testing_import",
+    srcs = ["available_testing_import.swift"],
+    # Ignore linker warning about deployment target being lower than framework
+    # version, that is what we're testing
+    features = ["-treat_warnings_as_errors"],
+    tags = FIXTURE_TAGS,
+    target_compatible_with = ["@platforms//os:ios"],
+    deps = ["@system_sdk//:Testing"],
+)
+
+transition_binary(
+    name = "available_testing_import_ios_12",
+    minimum_os = "12.0",
+    platform = "@build_bazel_apple_support//platforms:ios_arm64",
+    tags = FIXTURE_TAGS,
+    target = ":available_testing_import",
+    transitive_features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+        "swift.use_explicit_swift_module_map",
+    ],
+)
+
 # Imports C-only modules whose modulemaps live under `<sdk>/usr/include/<name>.modulemap`
 swift_binary(
     name = "c_module_imports",

--- a/test/fixtures/precompiled_modules/available_testing_import.swift
+++ b/test/fixtures/precompiled_modules/available_testing_import.swift
@@ -1,0 +1,17 @@
+import Testing
+
+@main
+struct AvailableTestingImport {
+    static func main() {
+        if #available(macOS 14.0, iOS 16.0, tvOS 16.0, *) {
+            printTestingType()
+        } else {
+            print("Testing is unavailable")
+        }
+    }
+
+    @available(macOS 14.0, iOS 16.0, tvOS 16.0, *)
+    private static func printTestingType() {
+        print("Testing is available: \(Testing.Test.self)")
+    }
+}

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -167,6 +167,7 @@ def precompiled_modules_test_suite(name, tags = []):
         name = "{}_build_test".format(name),
         targets = [
             "//test/fixtures/precompiled_modules:application_extension_unavailable_transitioned",
+            "//test/fixtures/precompiled_modules:available_testing_import_ios_12",
             "//test/fixtures/precompiled_modules:foundation_requires_explicit_dep_transitioned",
             "//test/fixtures/precompiled_modules:hello",
             "//test/fixtures/precompiled_modules:hello_with_explicit_deps_transitioned",

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -27,10 +27,10 @@ def _transition_impl(settings, attr):
         _COMPILATION_MODE: attr.compilation_mode or settings[_COMPILATION_MODE],
         _FEATURES: settings[_FEATURES] + attr.transitive_features,
         _HOST_FEATURES: settings[_HOST_FEATURES] + attr.transitive_features,
-        _IOS_MINIMUM_OS: attr.minimum_os or settings[_IOS_MINIMUM_OS],
-        _MACOS_MINIMUM_OS: attr.minimum_os or settings[_MACOS_MINIMUM_OS],
+        _IOS_MINIMUM_OS: attr.ios_minimum_os or settings[_IOS_MINIMUM_OS],
+        _MACOS_MINIMUM_OS: attr.macos_minimum_os or attr.minimum_os or settings[_MACOS_MINIMUM_OS],
         _PLATFORMS: [attr.platform] if attr.platform else settings[_PLATFORMS],
-        _TVOS_MINIMUM_OS: attr.minimum_os or settings[_TVOS_MINIMUM_OS],
+        _TVOS_MINIMUM_OS: attr.tvos_minimum_os or settings[_TVOS_MINIMUM_OS],
     }
 
 _transition = transition(
@@ -49,7 +49,16 @@ _TRANSITION_ATTRS = {
         values = ["", "dbg", "fastbuild", "opt"],
     ),
     "minimum_os": attr.string(
-        doc = "Optional value to set the Apple platform minimum OS to.",
+        doc = "Optional value to set `--macos_minimum_os` to.",
+    ),
+    "ios_minimum_os": attr.string(
+        doc = "Optional value to set `--ios_minimum_os` to.",
+    ),
+    "macos_minimum_os": attr.string(
+        doc = "Optional value to set `--macos_minimum_os` to.",
+    ),
+    "tvos_minimum_os": attr.string(
+        doc = "Optional value to set `--tvos_minimum_os` to.",
     ),
     "platform": attr.string(
         doc = "Optional target platform label (e.g. `@build_bazel_apple_support//platforms:macos_x86_64`).",

--- a/test/transitions.bzl
+++ b/test/transitions.bzl
@@ -7,15 +7,19 @@ load("//swift:providers.bzl", "SwiftInfo")
 _COMPILATION_MODE = "//command_line_option:compilation_mode"
 _FEATURES = "//command_line_option:features"
 _HOST_FEATURES = "//command_line_option:host_features"
+_IOS_MINIMUM_OS = "//command_line_option:ios_minimum_os"
 _MACOS_MINIMUM_OS = "//command_line_option:macos_minimum_os"
 _PLATFORMS = "//command_line_option:platforms"
+_TVOS_MINIMUM_OS = "//command_line_option:tvos_minimum_os"
 
 _TRANSITION_OPTIONS = [
     _COMPILATION_MODE,
     _FEATURES,
     _HOST_FEATURES,
+    _IOS_MINIMUM_OS,
     _MACOS_MINIMUM_OS,
     _PLATFORMS,
+    _TVOS_MINIMUM_OS,
 ]
 
 def _transition_impl(settings, attr):
@@ -23,8 +27,10 @@ def _transition_impl(settings, attr):
         _COMPILATION_MODE: attr.compilation_mode or settings[_COMPILATION_MODE],
         _FEATURES: settings[_FEATURES] + attr.transitive_features,
         _HOST_FEATURES: settings[_HOST_FEATURES] + attr.transitive_features,
+        _IOS_MINIMUM_OS: attr.minimum_os or settings[_IOS_MINIMUM_OS],
         _MACOS_MINIMUM_OS: attr.minimum_os or settings[_MACOS_MINIMUM_OS],
         _PLATFORMS: [attr.platform] if attr.platform else settings[_PLATFORMS],
+        _TVOS_MINIMUM_OS: attr.minimum_os or settings[_TVOS_MINIMUM_OS],
     }
 
 _transition = transition(
@@ -43,7 +49,7 @@ _TRANSITION_ATTRS = {
         values = ["", "dbg", "fastbuild", "opt"],
     ),
     "minimum_os": attr.string(
-        doc = "Optional value to set `--macos_minimum_os` to.",
+        doc = "Optional value to set the Apple platform minimum OS to.",
     ),
     "platform": attr.string(
         doc = "Optional target platform label (e.g. `@build_bazel_apple_support//platforms:macos_x86_64`).",

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -295,22 +295,8 @@ void ExtractFlagsFromInterfaceFile(
   while (std::getline(interface_file, line)) {
     absl::string_view line_view = line;
     if (absl::ConsumePrefix(&line_view, "// swift-module-flags: ")) {
-      bool skip_next = false;
       while (std::optional<std::string> flag = ConsumeArg(&line_view)) {
-        if (skip_next) {
-          skip_next = false;
-        } else if (*flag == "-target") {
-          // We have to skip the target triple in the interface file because it
-          // might be slightly different from the one the rest of our
-          // dependencies were compiled with. For example, if we are targeting
-          // `arm64-apple-macos`, that is the architecture that any Clang
-          // module dependencies will have used. If the module uses
-          // `arm64e-apple-macos` instead, then it will not be compatible with
-          // those Clang modules.
-          skip_next = true;
-        } else {
-          consumer(*flag);
-        }
+        consumer(*flag);
       }
       return;
     }


### PR DESCRIPTION
Previously we were dropping this under the assumption that if we didn't
we would end up with incompatible PCMs because the minimum OS version
would be different. We solve that by passing `-clang-target` instead,
which sets the minimum OS version for PCM imports separately from the
deployment target version.

If we ignore the -target from the swiftinterface file if the OS version
being built for is lower than the swiftinterface file's target it can
lead to compiler failures _if_ the swiftinterface's module is depending
on newer Swift features. This happens today with the Testing module
which targets iOS 13+ and uses concurrency features that don't compile
on iOS 12.

This matches Xcode's behavior as well.

This logic was originally taken from upstream who are not using
`-clang-target` yet
