### PR TITLE
Use developer dir symlink for swiftinterfaces

### DIFF
--- a/swift/internal/system_swiftinterface.bzl
+++ b/swift/internal/system_swiftinterface.bzl
@@ -39,6 +39,10 @@ def _direct_clang_module_for_name(deps, module_name):
 
 def _system_swiftinterface_impl(ctx):
     swift_toolchain = swift_common.get_toolchain(ctx, toolchain_type = SWIFT_SDK_TOOLCHAIN_TYPE)
+    if ctx.attr.system_swiftinterface and ctx.file.swiftinterface:
+        fail("exactly one of system_swiftinterface or swiftinterface must be set")
+
+    swiftinterface_file = ctx.file.swiftinterface or ctx.attr.system_swiftinterface
     deps = ctx.attr.modules
     swift_infos = [dep[SwiftInfo] for dep in deps if SwiftInfo in dep]
     cc_info = cc_common.merge_cc_infos(cc_infos = [
@@ -65,7 +69,7 @@ def _system_swiftinterface_impl(ctx):
         feature_configuration = feature_configuration,
         is_framework = ctx.attr.is_framework,
         module_name = ctx.attr.module_name,
-        swiftinterface_file = ctx.attr.system_swiftinterface,
+        swiftinterface_file = swiftinterface_file,
         swift_infos = swift_infos,
         swift_toolchain = swift_toolchain,
         target_name = ctx.attr.name,
@@ -121,7 +125,10 @@ The path to a system Swift textual interface.
 Variables `__BAZEL_XCODE_SDKROOT__` and `__BAZEL_XCODE_DEVELOPER_DIR__` will be
 substituted.
 """,
-            mandatory = True,
+        ),
+        "swiftinterface": attr.label(
+            allow_single_file = [".swiftinterface"],
+            doc = "A declared Swift textual interface file to compile.",
         ),
     },
     doc = """\

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -20,6 +20,8 @@ package(default_visibility = ["//test:__subpackages__"])
 
 licenses(["notice"])
 
+exports_files(["LowerVersionLib.swiftinterface"])
+
 swift_binary(
     name = "hello",
     srcs = ["main.swift"],

--- a/test/hermetic_pcm/BUILD
+++ b/test/hermetic_pcm/BUILD
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//swift:swift.bzl", "system_swiftinterface")
 load("//swift:swift_compiler_plugin.bzl", "swift_compiler_plugin")
 load("//swift:swift_interop_hint.bzl", "swift_interop_hint")
 load("//swift:swift_library.bzl", "swift_library")
@@ -148,6 +149,41 @@ sh_test(
         ":supports_hermetic_swiftmodule": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
+)
+
+system_swiftinterface(
+    name = "non_xcode_swiftinterface_module",
+    module_name = "LowerVersionLib",
+    modules = [
+        "@system_sdk//:Foundation",
+        "@system_sdk//:Swift",
+        "@system_sdk//:SwiftShims",
+        "@system_sdk//:_Concurrency",
+        "@system_sdk//:_StringProcessing",
+        "@system_sdk//:_SwiftConcurrencyShims",
+    ],
+    swiftinterface = "//test/fixtures/precompiled_modules:LowerVersionLib.swiftinterface",
+    target_compatible_with = ["@platforms//os:macos"],
+)
+
+extract_swiftmodule(
+    name = "non_xcode_swiftinterface_swiftmodule",
+    target = ":non_xcode_swiftinterface_module",
+)
+
+# A swiftinterface outside DEVELOPER_DIR can come from an external framework.
+# It must still be compiled through a relative path so the resulting swiftmodule
+# does not serialize a host-specific absolute source path.
+sh_test(
+    name = "non_xcode_swiftinterface_swiftmodule_test",
+    srcs = ["check_hermetic_swiftmodule.sh"],
+    args = [
+        "$(rootpath :non_xcode_swiftinterface_swiftmodule)",
+        "--no-default-expected",
+        "test/fixtures/precompiled_modules/LowerVersionLib.swiftinterface",
+    ],
+    data = [":non_xcode_swiftinterface_swiftmodule"],
+    target_compatible_with = ["@platforms//os:macos"],
 )
 
 # Same hermeticity check, but the consumer swift_library depends on a

--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -52,6 +52,24 @@ cc_library(
 )
 
 cc_library(
+    name = "hermetic_symlink",
+    srcs = ["hermetic_symlink.cc"],
+    hdrs = ["hermetic_symlink.h"],
+    copts = select({
+        "//tools:clang-cl": [
+            "-Xclang=-fno-split-cold-code",
+            "/std=c++17",
+        ],
+        "//tools:msvc": [
+            "/std=c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+        ],
+    }),
+)
+
+cc_library(
     name = "pcm_hermetic_runner",
     srcs = ["pcm_hermetic_runner.cc"],
     hdrs = ["pcm_hermetic_runner.h"],
@@ -68,6 +86,7 @@ cc_library(
         ],
     }),
     deps = [
+        ":hermetic_symlink",
         "//tools/common:process",
     ],
 )
@@ -100,6 +119,7 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
+        ":hermetic_symlink",
         ":pcm_hermetic_runner",
         "//tools/common:bazel_substitutions",
         "//tools/common:file_system",

--- a/tools/worker/hermetic_symlink.cc
+++ b/tools/worker/hermetic_symlink.cc
@@ -1,0 +1,127 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools/worker/hermetic_symlink.h"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace bazel_rules_swift {
+
+std::string NormalizeDeveloperDir(std::string developer_dir) {
+  while (developer_dir.size() > 1 && developer_dir.back() == '/') {
+    developer_dir.pop_back();
+  }
+  return developer_dir;
+}
+
+std::string DeveloperDirSymlinkName() {
+  const char* xcode_version = std::getenv("XCODE_VERSION_OVERRIDE");
+  // NOTE: Probably can't happen but multi-xcode race conditions are low risk
+  // anyways
+  if (xcode_version == nullptr || xcode_version[0] == '\0') {
+    return "__bazel_developer_dir";
+  }
+
+  std::string suffix = xcode_version;
+  for (char& ch : suffix) {
+    if (ch == '.') {
+      ch = '_';
+    }
+  }
+  return "__bazel_developer_dir_" + suffix;
+}
+
+bool EnsureDirectorySymlink(const std::filesystem::path& link,
+                            const std::filesystem::path& target) {
+  std::error_code ec;
+  auto parent = link.parent_path();
+  if (!parent.empty()) {
+    std::filesystem::create_directories(parent, ec);
+    if (ec) {
+      std::cerr << "error: failed to create symlink parent " << parent << ": "
+                << ec.message() << "\n";
+      return false;
+    }
+  }
+
+  std::filesystem::create_directory_symlink(target, link, ec);
+  if (!ec) {
+    return true;
+  }
+
+  // With sandboxing disabled, multiple actions share the same execroot and can
+  // race on creation. If the symlink already exists and points at the same
+  // target, use it. Do not remove it which would introduce a new race.
+  if (ec == std::errc::file_exists) {
+    std::error_code read_ec;
+    auto existing = std::filesystem::read_symlink(link, read_ec);
+    if (!read_ec && existing == target) {
+      return true;
+    }
+    std::cerr << "error: symlink " << link << " already exists but points to '"
+              << (read_ec ? std::string("<unreadable>") : existing.string())
+              << "' instead of '" << target.string() << "'\n";
+    return false;
+  }
+
+  std::cerr << "error: failed to create symlink " << link << " -> "
+            << target.string() << ": " << ec.message() << "\n";
+  return false;
+}
+
+bool EnsureDeveloperDirSymlink(const std::string& developer_dir) {
+  std::filesystem::path link =
+      std::filesystem::current_path() / DeveloperDirSymlinkName();
+  std::filesystem::path developer_path = NormalizeDeveloperDir(developer_dir);
+  return EnsureDirectorySymlink(link, developer_path);
+}
+
+std::string SymlinkedInterfacePath(
+    std::string_view interface_path,
+    std::function<std::string()> developer_dir_supplier) {
+  std::filesystem::path source{std::string(interface_path)};
+  // Relative swiftinterface paths will be recorded relatively, so we don't need
+  // workarounds
+  if (!source.is_absolute()) {
+    return source.string();
+  }
+
+  std::string developer_dir = NormalizeDeveloperDir(developer_dir_supplier());
+  if (developer_dir.empty()) {
+    std::cerr << "error: DEVELOPER_DIR is not set, but is required to "
+                 "compile Swift interfaces with absolute paths\n";
+    std::exit(EXIT_FAILURE);
+  }
+
+  std::filesystem::path developer_path{developer_dir};
+  auto relative_to_developer = source.lexically_relative(developer_path);
+  if (relative_to_developer.empty()) {
+    std::cerr << "error: absolute path " << source
+              << " is not within DEVELOPER_DIR " << developer_path
+              << ", which is required to compile Swift interfaces with "
+                 "absolute paths\n";
+    std::exit(EXIT_FAILURE);
+  }
+
+  if (!EnsureDeveloperDirSymlink(developer_dir)) {
+    std::exit(EXIT_FAILURE);
+  }
+
+  return (std::filesystem::path(DeveloperDirSymlinkName()) /
+          relative_to_developer)
+      .string();
+}
+
+}  // namespace bazel_rules_swift

--- a/tools/worker/hermetic_symlink.h
+++ b/tools/worker/hermetic_symlink.h
@@ -1,0 +1,52 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_HERMETIC_SYMLINK_H_
+#define BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_HERMETIC_SYMLINK_H_
+
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <string_view>
+
+namespace bazel_rules_swift {
+
+// Removes trailing slashes from `developer_dir`, preserving a root path.
+std::string NormalizeDeveloperDir(std::string developer_dir);
+
+// Returns the current working directory-relative symlink name for the active
+// Xcode version's developer directory, or an empty string if the active Xcode
+// version is unavailable.
+std::string DeveloperDirSymlinkName();
+
+// Ensures that `link` points to `target`. This is safe under local
+// non-sandboxed execution, where concurrent actions can race to create the same
+// symlink.
+bool EnsureDirectorySymlink(const std::filesystem::path& link,
+                            const std::filesystem::path& target);
+
+// Ensures that DeveloperDirSymlinkName() in the current working directory
+// points to `developer_dir`. This is safe under local non-sandboxed execution,
+// where concurrent actions can race to create the same symlink.
+bool EnsureDeveloperDirSymlink(const std::string& developer_dir);
+
+// Returns a path to `interface_path` through a hermetic symlink when needed, so
+// Swift does not serialize an absolute Xcode path into the swiftmodule.
+std::string SymlinkedInterfacePath(
+    std::string_view interface_path,
+    std::function<std::string()> developer_dir_supplier);
+
+}  // namespace bazel_rules_swift
+
+#endif  // BUILD_BAZEL_RULES_SWIFT_TOOLS_WORKER_HERMETIC_SYMLINK_H_

--- a/tools/worker/pcm_hermetic_runner.cc
+++ b/tools/worker/pcm_hermetic_runner.cc
@@ -21,11 +21,11 @@
 #include <vector>
 
 #include "tools/common/process.h"
+#include "tools/worker/hermetic_symlink.h"
 
 namespace {
 
 constexpr const char* kDebugEnv = "RULES_SWIFT_HERMETIC_PCM_DEBUG";
-constexpr const char* kDeveloperDirSymlinkName = "__bazel_pcm_developer_dir";
 
 bool ShouldDropFlagAndValue(const std::string& arg) {
   return arg == "-external-plugin-path" ||
@@ -116,37 +116,6 @@ std::vector<std::string> ParseFrontendCommand(const std::string& output) {
   return TokenizeShellLine(last_line);
 }
 
-bool Symlink(const std::string& target, const std::string& link_name,
-             std::ostream* stderr_stream) {
-  std::filesystem::path link = std::filesystem::current_path() / link_name;
-  std::error_code ec;
-  std::filesystem::create_directory_symlink(target, link, ec);
-  if (!ec) {
-    return true;
-  }
-
-  // With sandboxing disabled, multiple PCM actions share the same execroot
-  // and can race on creation. If the symlink already exists and points at
-  // the same target, use it. We intentionally never remove the symlink: Bazel
-  // cleans the execroot, and removing here would be a new race.
-  if (ec == std::errc::file_exists) {
-    std::error_code read_ec;
-    auto existing = std::filesystem::read_symlink(link, read_ec);
-    if (!read_ec && existing == std::filesystem::path(target)) {
-      return true;
-    }
-    (*stderr_stream) << "error: hermetic-pcm: symlink " << link
-                     << " already exists but points to '"
-                     << (read_ec ? std::string("<unreadable>")
-                                 : existing.string())
-                     << "' instead of '" << target << "'\n";
-    return false;
-  }
-  (*stderr_stream) << "error: hermetic-pcm: failed to create symlink " << link
-                   << " -> " << target << ": " << ec.message() << "\n";
-  return false;
-}
-
 std::string ResourceDirFromFrontend(const std::string& frontend_binary) {
   if (frontend_binary.empty()) return {};
   std::filesystem::path p(frontend_binary);
@@ -165,9 +134,7 @@ int RunHermeticPcm(const std::vector<std::string>& args,
     (*stderr_stream) << "error: hermetic-pcm: DEVELOPER_DIR is not set\n";
     return 1;
   }
-  while (developer_dir.size() > 1 && developer_dir.back() == '/') {
-    developer_dir.pop_back();
-  }
+  developer_dir = bazel_rules_swift::NormalizeDeveloperDir(developer_dir);
 
   std::string captured;
   int rc = CaptureFrontendCommand(args, stderr_stream, &captured);
@@ -193,11 +160,13 @@ int RunHermeticPcm(const std::vector<std::string>& args,
                      << "'\n";
     return 1;
   }
-  ReplaceAll(resource_dir, developer_dir, kDeveloperDirSymlinkName);
-
-  if (!Symlink(developer_dir, kDeveloperDirSymlinkName, stderr_stream)) {
+  if (!bazel_rules_swift::EnsureDeveloperDirSymlink(developer_dir)) {
     return 1;
   }
+
+  std::string developer_dir_symlink_name =
+      bazel_rules_swift::DeveloperDirSymlinkName();
+  ReplaceAll(resource_dir, developer_dir, developer_dir_symlink_name);
 
   std::vector<std::string> rewritten;
   rewritten.reserve(frontend.size() + 2);
@@ -208,7 +177,7 @@ int RunHermeticPcm(const std::vector<std::string>& args,
       continue;
     }
     std::string rewritten_arg = arg;
-    ReplaceAll(rewritten_arg, developer_dir, kDeveloperDirSymlinkName);
+    ReplaceAll(rewritten_arg, developer_dir, developer_dir_symlink_name);
     rewritten.push_back(std::move(rewritten_arg));
   }
 

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -34,7 +34,7 @@
 #include "tools/worker/output_file_map.h"
 #include "tools/worker/pcm_hermetic_runner.h"
 
-bool ArgumentEnablesWMO(const std::string& arg) {
+bool ArgumentEnablesWMO(const std::string &arg) {
   return arg == "-wmo" || arg == "-whole-module-optimization" ||
          arg == "-force-single-frontend-invocation";
 }
@@ -46,11 +46,11 @@ using bazel_rules_swift::TargetTriple;
 
 // Creates a temporary file and writes the given arguments to it, one per line.
 static std::unique_ptr<TempFile> WriteResponseFile(
-    const std::vector<std::string>& args) {
+    const std::vector<std::string> &args) {
   auto response_file = TempFile::Create("swiftc_params.XXXXXX");
   std::ofstream response_file_stream(response_file->GetPath());
 
-  for (const auto& arg : args) {
+  for (const auto &arg : args) {
     // When Clang/Swift write out a response file to communicate from driver to
     // frontend, they just quote every argument to be safe; we duplicate that
     // instead of trying to be "smarter" and only quoting when necessary.
@@ -69,7 +69,7 @@ static std::unique_ptr<TempFile> WriteResponseFile(
 }
 
 // Unescape and unquote an argument read from a line of a response file.
-static std::string Unescape(const std::string& arg) {
+static std::string Unescape(const std::string &arg) {
   std::string result;
   auto length = arg.size();
   for (size_t i = 0; i < length; ++i) {
@@ -111,7 +111,7 @@ static std::string Unescape(const std::string& arg) {
 // any leading whitespace and also handling quoted/escaped arguments), advancing
 // the view to the end of the argument in a similar fashion to
 // `absl::ConsumePrefix()`.
-static std::optional<std::string> ConsumeArg(absl::string_view* line) {
+static std::optional<std::string> ConsumeArg(absl::string_view *line) {
   size_t whitespace_count = 0;
   size_t length = line->size();
   while (whitespace_count < length && (*line)[whitespace_count] == ' ') {
@@ -171,7 +171,7 @@ static std::optional<std::string> ConsumeArg(absl::string_view* line) {
 // If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
 // function returns true. Otherwise, `str` is left unmodified and the function
 // returns `false`.
-static bool StripPrefix(const std::string& prefix, std::string& str) {
+static bool StripPrefix(const std::string &prefix, std::string &str) {
   if (str.find(prefix) != 0) {
     return false;
   }
@@ -259,7 +259,7 @@ void ExtractFlagsFromInterfaceFile(
 
 }  // namespace
 
-SwiftRunner::SwiftRunner(const std::vector<std::string>& args,
+SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
                          std::string index_import_path,
                          bool force_response_file)
     : job_env_(GetCurrentEnvironment()),
@@ -271,7 +271,7 @@ SwiftRunner::SwiftRunner(const std::vector<std::string>& args,
   args_ = ProcessArguments(args);
 }
 
-int SwiftRunner::Run(std::ostream* stderr_stream, bool stdout_to_stderr) {
+int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
   // In rules_swift < 3.x the .swiftsourceinfo files are unconditionally written
   // to the module path. In rules_swift >= 3.x these same files are no longer
   // tracked by Bazel unless explicitly requested. When using non-sandboxed
@@ -341,7 +341,7 @@ int SwiftRunner::Run(std::ostream* stderr_stream, bool stdout_to_stderr) {
       }
     }
 
-    const std::filesystem::path& exec_root = std::filesystem::current_path();
+    const std::filesystem::path &exec_root = std::filesystem::current_path();
     // Copy back from the global index store to bazel's index store
     ii_args.push_back((exec_root / global_index_store_import_path_).string());
     ii_args.push_back((exec_root / index_store_path_).string());
@@ -357,11 +357,11 @@ class StreamIteratorEnd {};
 // Basic iterator over an ifstream
 class StreamIterator {
  public:
-  StreamIterator(std::ifstream& file) : file_{file} { next(); }
+  StreamIterator(std::ifstream &file) : file_{file} { next(); }
 
-  const std::string& operator*() const { return str_; }
+  const std::string &operator*() const { return str_; }
 
-  StreamIterator& operator++() {
+  StreamIterator &operator++() {
     next();
     return *this;
   }
@@ -371,24 +371,24 @@ class StreamIterator {
  private:
   void next() { std::getline(file_, str_); }
 
-  std::ifstream& file_;
+  std::ifstream &file_;
   std::string str_;
 };
 
 class ArgsFile {
  public:
-  ArgsFile(std::ifstream& file) : file_(file) {}
+  ArgsFile(std::ifstream &file) : file_(file) {}
 
   StreamIterator begin() { return StreamIterator{file_}; }
 
   StreamIteratorEnd end() { return StreamIteratorEnd{}; }
 
  private:
-  std::ifstream& file_;
+  std::ifstream &file_;
 };
 
 bool SwiftRunner::ProcessPossibleResponseFile(
-    const std::string& arg, std::function<void(const std::string&)> consumer) {
+    const std::string &arg, std::function<void(const std::string &)> consumer) {
   auto path = arg.substr(1);
   std::ifstream original_file(path);
   ArgsFile args_file(original_file);
@@ -421,7 +421,7 @@ bool SwiftRunner::ProcessPossibleResponseFile(
   std::string arg_from_file;
   std::vector<std::string> new_args;
   for (auto it = args.begin(); it != args.end(); ++it) {
-    changed |= ProcessArgument(it, *it, [&](const std::string& processed_arg) {
+    changed |= ProcessArgument(it, *it, [&](const std::string &processed_arg) {
       new_args.push_back(processed_arg);
     });
   }
@@ -440,7 +440,7 @@ bool SwiftRunner::ProcessPossibleResponseFile(
 }
 
 std::string SwiftRunner::ProcessExplicitSwiftModuleMapFile(
-    const std::string& path) {
+    const std::string &path) {
   std::string module_map_path = path;
   std::ifstream module_map_file(module_map_path);
   if (!module_map_file.good()) {
@@ -465,14 +465,14 @@ std::string SwiftRunner::ProcessExplicitSwiftModuleMapFile(
 
 template <typename Iterator>
 bool SwiftRunner::ProcessArgument(
-    Iterator& itr, const std::string& arg,
-    std::function<void(const std::string&)> consumer) {
+    Iterator &itr, const std::string &arg,
+    std::function<void(const std::string &)> consumer) {
   bool changed = false;
 
   // Helper function for adding path remapping flags that depend on information
   // only known at execution time.
-  auto add_prefix_map_flags = [&](const std::string& flag,
-                                  const std::string& new_path = ".") {
+  auto add_prefix_map_flags = [&](const std::string &flag,
+                                  const std::string &new_path = ".") {
     // Get the actual current working directory (the execution root), which
     // we didn't know at analysis time.
     consumer(flag);
@@ -674,7 +674,7 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
 }
 
 std::vector<std::string> SwiftRunner::ProcessArguments(
-    const std::vector<std::string>& args) {
+    const std::vector<std::string> &args) {
   std::vector<std::string> new_args;
   std::vector<std::string> response_file_args;
 
@@ -693,9 +693,9 @@ std::vector<std::string> SwiftRunner::ProcessArguments(
   // If we're forcing response files, push the remaining processed args onto a
   // different vector that we write out below. If not, push them directly onto
   // the vector being returned.
-  auto& args_destination = force_response_file_ ? response_file_args : new_args;
+  auto &args_destination = force_response_file_ ? response_file_args : new_args;
   while (it != parsed_args.end()) {
-    ProcessArgument(it, *it, [&](const std::string& arg) {
+    ProcessArgument(it, *it, [&](const std::string &arg) {
       args_destination.push_back(arg);
     });
     ++it;

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -705,7 +705,7 @@ std::vector<std::string> SwiftRunner::ProcessArguments(
     ExtractFlagsFromInterfaceFile(
         module_or_interface_path_, target_triple_,
         [&]() {
-          const char* developer_dir = std::getenv("DEVELOPER_DIR");
+          const char *developer_dir = std::getenv("DEVELOPER_DIR");
           if (developer_dir != nullptr) return std::string(developer_dir);
           return std::string();
         },

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -14,9 +14,9 @@
 
 #include "tools/worker/swift_runner.h"
 
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <optional>
 #include <sstream>
 #include <utility>
@@ -30,10 +30,11 @@
 #include "tools/common/process.h"
 #include "tools/common/target_triple.h"
 #include "tools/common/temp_file.h"
+#include "tools/worker/hermetic_symlink.h"
 #include "tools/worker/output_file_map.h"
 #include "tools/worker/pcm_hermetic_runner.h"
 
-bool ArgumentEnablesWMO(const std::string &arg) {
+bool ArgumentEnablesWMO(const std::string& arg) {
   return arg == "-wmo" || arg == "-whole-module-optimization" ||
          arg == "-force-single-frontend-invocation";
 }
@@ -45,11 +46,11 @@ using bazel_rules_swift::TargetTriple;
 
 // Creates a temporary file and writes the given arguments to it, one per line.
 static std::unique_ptr<TempFile> WriteResponseFile(
-    const std::vector<std::string> &args) {
+    const std::vector<std::string>& args) {
   auto response_file = TempFile::Create("swiftc_params.XXXXXX");
   std::ofstream response_file_stream(response_file->GetPath());
 
-  for (const auto &arg : args) {
+  for (const auto& arg : args) {
     // When Clang/Swift write out a response file to communicate from driver to
     // frontend, they just quote every argument to be safe; we duplicate that
     // instead of trying to be "smarter" and only quoting when necessary.
@@ -68,7 +69,7 @@ static std::unique_ptr<TempFile> WriteResponseFile(
 }
 
 // Unescape and unquote an argument read from a line of a response file.
-static std::string Unescape(const std::string &arg) {
+static std::string Unescape(const std::string& arg) {
   std::string result;
   auto length = arg.size();
   for (size_t i = 0; i < length; ++i) {
@@ -110,7 +111,7 @@ static std::string Unescape(const std::string &arg) {
 // any leading whitespace and also handling quoted/escaped arguments), advancing
 // the view to the end of the argument in a similar fashion to
 // `absl::ConsumePrefix()`.
-static std::optional<std::string> ConsumeArg(absl::string_view *line) {
+static std::optional<std::string> ConsumeArg(absl::string_view* line) {
   size_t whitespace_count = 0;
   size_t length = line->size();
   while (whitespace_count < length && (*line)[whitespace_count] == ' ') {
@@ -170,7 +171,7 @@ static std::optional<std::string> ConsumeArg(absl::string_view *line) {
 // If `str` starts with `prefix`, `str` is mutated to remove `prefix` and the
 // function returns true. Otherwise, `str` is left unmodified and the function
 // returns `false`.
-static bool StripPrefix(const std::string &prefix, std::string &str) {
+static bool StripPrefix(const std::string& prefix, std::string& str) {
   if (str.find(prefix) != 0) {
     return false;
   }
@@ -218,61 +219,11 @@ std::optional<std::string> InferInterfacePath(
   return std::nullopt;
 }
 
-// Necessary so the MODULE_INTERFACE_PATH in the swiftmodule doesn't have an
-// absolute path to Xcode
-void CreateVFSOverlayForInterface(
-    absl::string_view interface_path,
-    std::function<void(absl::string_view)> consumer) {
-  std::filesystem::path source{std::string(interface_path)};
-  if (!source.is_absolute()) {
-    consumer(source.string());
-    return;
-  }
-
-  std::filesystem::path module_dir = source.parent_path().filename();
-  if (module_dir.empty()) {
-    module_dir = "swiftmodule";
-  }
-  std::filesystem::path virtual_dir =
-      std::filesystem::path(".rules_swift_interface_sources") / module_dir;
-  std::filesystem::path virtual_path = virtual_dir / source.filename();
-  std::filesystem::path overlay_path =
-      virtual_dir / "swiftinterface-vfsoverlay.yaml";
-
-  std::error_code ec;
-  std::filesystem::create_directories(virtual_dir, ec);
-  if (ec) {
-    consumer(source.string());
-    return;
-  }
-
-  std::ofstream overlay_file(overlay_path);
-  if (!overlay_file) {
-    consumer(source.string());
-    return;
-  }
-  overlay_file << "{\"version\":0,\"case-sensitive\":true,"
-               << "\"overlay-relative\":false,\"use-external-names\":false,"
-               << "\"roots\":[{\"type\":\"directory\",\"name\":"
-               << std::quoted(virtual_dir.string()) << ",\"contents\":["
-               << "{\"type\":\"file\",\"name\":"
-               << std::quoted(source.filename().string())
-               << ",\"external-contents\":" << std::quoted(source.string())
-               << "}]}]}";
-  overlay_file.close();
-  if (!overlay_file) {
-    consumer(source.string());
-    return;
-  }
-
-  consumer("-vfsoverlay" + overlay_path.string());
-  consumer(virtual_path.string());
-}
-
 // Extracts flags from the given `.swiftinterface` file and passes them to the
 // given consumer.
 void ExtractFlagsFromInterfaceFile(
     absl::string_view module_or_interface_path, absl::string_view target_triple,
+    std::function<std::string()> developer_dir_supplier,
     std::function<void(absl::string_view)> consumer) {
   std::string interface_path;
   if (absl::EndsWith(module_or_interface_path, ".swiftinterface")) {
@@ -288,9 +239,12 @@ void ExtractFlagsFromInterfaceFile(
 
   // Add the path to the interface file as a source file argument, then extract
   // the flags from it and add them as well.
-  CreateVFSOverlayForInterface(interface_path, consumer);
+  std::string symlinked_interface_path =
+      bazel_rules_swift::SymlinkedInterfacePath(interface_path,
+                                                developer_dir_supplier);
+  consumer(symlinked_interface_path);
 
-  std::ifstream interface_file{std::string(interface_path)};
+  std::ifstream interface_file{std::string(symlinked_interface_path)};
   std::string line;
   while (std::getline(interface_file, line)) {
     absl::string_view line_view = line;
@@ -305,7 +259,7 @@ void ExtractFlagsFromInterfaceFile(
 
 }  // namespace
 
-SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
+SwiftRunner::SwiftRunner(const std::vector<std::string>& args,
                          std::string index_import_path,
                          bool force_response_file)
     : job_env_(GetCurrentEnvironment()),
@@ -317,7 +271,7 @@ SwiftRunner::SwiftRunner(const std::vector<std::string> &args,
   args_ = ProcessArguments(args);
 }
 
-int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
+int SwiftRunner::Run(std::ostream* stderr_stream, bool stdout_to_stderr) {
   // In rules_swift < 3.x the .swiftsourceinfo files are unconditionally written
   // to the module path. In rules_swift >= 3.x these same files are no longer
   // tracked by Bazel unless explicitly requested. When using non-sandboxed
@@ -387,7 +341,7 @@ int SwiftRunner::Run(std::ostream *stderr_stream, bool stdout_to_stderr) {
       }
     }
 
-    const std::filesystem::path &exec_root = std::filesystem::current_path();
+    const std::filesystem::path& exec_root = std::filesystem::current_path();
     // Copy back from the global index store to bazel's index store
     ii_args.push_back((exec_root / global_index_store_import_path_).string());
     ii_args.push_back((exec_root / index_store_path_).string());
@@ -403,11 +357,11 @@ class StreamIteratorEnd {};
 // Basic iterator over an ifstream
 class StreamIterator {
  public:
-  StreamIterator(std::ifstream &file) : file_{file} { next(); }
+  StreamIterator(std::ifstream& file) : file_{file} { next(); }
 
-  const std::string &operator*() const { return str_; }
+  const std::string& operator*() const { return str_; }
 
-  StreamIterator &operator++() {
+  StreamIterator& operator++() {
     next();
     return *this;
   }
@@ -417,24 +371,24 @@ class StreamIterator {
  private:
   void next() { std::getline(file_, str_); }
 
-  std::ifstream &file_;
+  std::ifstream& file_;
   std::string str_;
 };
 
 class ArgsFile {
  public:
-  ArgsFile(std::ifstream &file) : file_(file) {}
+  ArgsFile(std::ifstream& file) : file_(file) {}
 
   StreamIterator begin() { return StreamIterator{file_}; }
 
   StreamIteratorEnd end() { return StreamIteratorEnd{}; }
 
  private:
-  std::ifstream &file_;
+  std::ifstream& file_;
 };
 
 bool SwiftRunner::ProcessPossibleResponseFile(
-    const std::string &arg, std::function<void(const std::string &)> consumer) {
+    const std::string& arg, std::function<void(const std::string&)> consumer) {
   auto path = arg.substr(1);
   std::ifstream original_file(path);
   ArgsFile args_file(original_file);
@@ -467,7 +421,7 @@ bool SwiftRunner::ProcessPossibleResponseFile(
   std::string arg_from_file;
   std::vector<std::string> new_args;
   for (auto it = args.begin(); it != args.end(); ++it) {
-    changed |= ProcessArgument(it, *it, [&](const std::string &processed_arg) {
+    changed |= ProcessArgument(it, *it, [&](const std::string& processed_arg) {
       new_args.push_back(processed_arg);
     });
   }
@@ -486,7 +440,7 @@ bool SwiftRunner::ProcessPossibleResponseFile(
 }
 
 std::string SwiftRunner::ProcessExplicitSwiftModuleMapFile(
-    const std::string &path) {
+    const std::string& path) {
   std::string module_map_path = path;
   std::ifstream module_map_file(module_map_path);
   if (!module_map_file.good()) {
@@ -511,14 +465,14 @@ std::string SwiftRunner::ProcessExplicitSwiftModuleMapFile(
 
 template <typename Iterator>
 bool SwiftRunner::ProcessArgument(
-    Iterator &itr, const std::string &arg,
-    std::function<void(const std::string &)> consumer) {
+    Iterator& itr, const std::string& arg,
+    std::function<void(const std::string&)> consumer) {
   bool changed = false;
 
   // Helper function for adding path remapping flags that depend on information
   // only known at execution time.
-  auto add_prefix_map_flags = [&](const std::string &flag,
-                                  const std::string &new_path = ".") {
+  auto add_prefix_map_flags = [&](const std::string& flag,
+                                  const std::string& new_path = ".") {
     // Get the actual current working directory (the execution root), which
     // we didn't know at analysis time.
     consumer(flag);
@@ -720,7 +674,7 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
 }
 
 std::vector<std::string> SwiftRunner::ProcessArguments(
-    const std::vector<std::string> &args) {
+    const std::vector<std::string>& args) {
   std::vector<std::string> new_args;
   std::vector<std::string> response_file_args;
 
@@ -739,9 +693,9 @@ std::vector<std::string> SwiftRunner::ProcessArguments(
   // If we're forcing response files, push the remaining processed args onto a
   // different vector that we write out below. If not, push them directly onto
   // the vector being returned.
-  auto &args_destination = force_response_file_ ? response_file_args : new_args;
+  auto& args_destination = force_response_file_ ? response_file_args : new_args;
   while (it != parsed_args.end()) {
-    ProcessArgument(it, *it, [&](const std::string &arg) {
+    ProcessArgument(it, *it, [&](const std::string& arg) {
       args_destination.push_back(arg);
     });
     ++it;
@@ -749,7 +703,13 @@ std::vector<std::string> SwiftRunner::ProcessArguments(
 
   if (!module_or_interface_path_.empty()) {
     ExtractFlagsFromInterfaceFile(
-        module_or_interface_path_, target_triple_, [&](absl::string_view arg) {
+        module_or_interface_path_, target_triple_,
+        [&]() {
+          const char* developer_dir = std::getenv("DEVELOPER_DIR");
+          if (developer_dir != nullptr) return std::string(developer_dir);
+          return std::string();
+        },
+        [&](absl::string_view arg) {
           args_destination.push_back(std::string(arg));
         });
   }


### PR DESCRIPTION
Previously every swiftinterface being built would race for the same
symlink dirs. Now we use the same approach as PCMs to avoid that race
(which only happens with sandboxing disabled).
