### PR TITLE
Fix test observer warnings-as-errors build

### DIFF
--- a/tools/test_observer/SwiftTestingRunner.swift
+++ b/tools/test_observer/SwiftTestingRunner.swift
@@ -80,7 +80,9 @@ public final class SwiftTestingRunner: Sendable {
     for try await testOrSuite in try await listTests() {
       switch testOrSuite {
       case .suite(let suiteID):
-        discoveredSuites.withLock { $0.insert(suiteID) }
+        discoveredSuites.withLock { discoveredSuites in
+          _ = discoveredSuites.insert(suiteID)
+        }
       case .test(let test):
         collector.addTest(test)
       }
@@ -174,9 +176,17 @@ public final class SwiftTestingRunner: Sendable {
     // We only care about test events that have a test ID and an instant (when they occurred).
     guard
       case .string(let kind) = payload["kind"],
-      case .string(let testID) = payload["testID"],
-      // Ignore suites. The xUnit recorder reconstructs the hierarchy.
-      !discoveredSuites.withLock({ $0.contains(testID) }),
+      case .string(let testID) = payload["testID"]
+    else {
+      return
+    }
+
+    // Ignore suites. The xUnit recorder reconstructs the hierarchy.
+    let isDiscoveredSuite = discoveredSuites.withLock { discoveredSuites in
+      discoveredSuites.contains(testID)
+    }
+    guard
+      !isDiscoveredSuite,
       case .object(let instantJSON) = payload["instant"],
       case .number(let absolute) = instantJSON["absolute"]
     else {


### PR DESCRIPTION
## Summary

- Explicitly discard the result of `Set.insert` inside the test observer’s `withLock` mutation.
- Avoid the confusable trailing-closure pattern when checking discovered Swift Testing suites.

## Testing

- `bazel build //tools/test_observer:test_observer --features=swift.treat_warnings_as_errors`