### PR TITLE
Add -prefix-serialized-debugging-options

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -415,6 +415,7 @@ def compile_action_configs(
             actions = all_compile_action_names(),
             configurators = [
                 add_arg("-Xfrontend", "-serialize-debugging-options"),
+                add_arg("-Xfrontend", "-prefix-serialized-debugging-options"),
             ],
             not_features = [
                 [SWIFT_FEATURE_OPT],


### PR DESCRIPTION
No known downsides

Kinda cherry picks c16e39268e1f09ffaeeca01f496f834dccf51804 and
0162ea1382acd52e691ce90dc7e39fe3d23a7033 but modernized

Fixes https://github.com/bazelbuild/rules_swift/issues/842
