### PR TITLE
Unify early exit for now tests behavior

### DIFF
--- a/test/xctest_runner_tests.bzl
+++ b/test/xctest_runner_tests.bzl
@@ -42,7 +42,7 @@ def xctest_runner_test_suite(name, tags = []):
         expected_return_code = 1,
         expected_logs = [
             "Executed 0 tests, with 0 failures",
-            "ERROR: No tests were executed",
+            "ERROR: No tests were discovered",
         ],
         tags = all_tags,
         target_under_test = "//test/fixtures/xctest_runner:EmptyUnitTests",

--- a/tools/test_discoverer/TestDiscoverer.swift
+++ b/tools/test_discoverer/TestDiscoverer.swift
@@ -129,17 +129,18 @@ struct TestDiscoverer: ParsableCommand {
               print("Fatal error running swift-testing tests: \\(error)")
               exit(1)
             }
+            let recorder = XUnitTestRecorder.shared
+            guard recorder.didTestsRun else {
+              print("ERROR: No tests were discovered.")
+              exit(1)
+            }
             do {
-              try XUnitTestRecorder.shared.writeXML()
+              try recorder.writeXML()
             } catch {
               print("Fatal error writing test results to XML: \\(error)")
               exit(1)
             }
-            guard XUnitTestRecorder.shared.testCount > 0 else {
-              print("ERROR: No tests were executed")
-              exit(1)
-            }
-            exit(XUnitTestRecorder.shared.hasFailure ? 1 : 0)
+            exit(recorder.hasFailure ? 1 : 0)
           }
           _asyncMainDrainQueue()
         }

--- a/tools/test_observer/XUnitTestRecorder.swift
+++ b/tools/test_observer/XUnitTestRecorder.swift
@@ -66,6 +66,13 @@ public final class XUnitTestRecorder: Sendable {
   /// The context that is mutated by the test reader, protected by a lock.
   private let context: Locked<Context> = Locked(.init())
 
+  /// Indicates whether any tests have run.
+  public var didTestsRun: Bool {
+    context.withLock { context in
+      context.testCount > 0
+    }
+  }
+
   /// Indicates whether any failures have been recorded.
   public var hasFailure: Bool {
     context.withLock { context in


### PR DESCRIPTION
We were already doing this, but upstream added it later

PiperOrigin-RevId: 752328314
(cherry picked from commit 9d7762b5ac7cb67907b457c417b5aa67f5be2610)
