### PR TITLE
Factor out the computation of the entry point name for binary rules into its own helper function.

### DIFF
--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -374,6 +374,24 @@ instead.\
         disallow_dynamic_library = True,
     )
 
+def entry_point_function_name(module_name):
+    """Returns the name of the entry point function for a module.
+
+    To avoid linking issues for binaries that can also be linked as libraries
+    for tests (`swift_binary`, `swift_compiler_plugin`), we derive a unique name
+    for the entry point based on the module name instead of using `_main`, and
+    then we use the relevant linker flag to ensure that the correct entry point
+    is used for the binary itself. This mirrors the behavior of Swift Package
+    Manager.
+
+    Args:
+        module_name: The name of the module.
+
+    Returns:
+        The name of the entry point function for the module.
+    """
+    return "{}_main".format(module_name)
+
 def malloc_linking_context(ctx):
     """Returns the linking context to use for the malloc implementation.
 

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -28,6 +28,7 @@ load(
     "//swift/internal:linking.bzl",
     "configure_features_for_binary",
     "create_linking_context_from_compilation_outputs",
+    "entry_point_function_name",
     "malloc_linking_context",
     "register_link_binary_action",
 )
@@ -95,7 +96,7 @@ def _swift_binary_impl(ctx):
         module_name = ctx.attr.module_name
         if not module_name:
             module_name = derive_swift_module_name(ctx.label)
-        entry_point_function_name = "{}_main".format(module_name)
+        entry_point_name = entry_point_function_name(module_name)
 
         include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 
@@ -114,7 +115,7 @@ def _swift_binary_impl(ctx):
                 "-Xfrontend",
                 "-entry-point-function-name",
                 "-Xfrontend",
-                entry_point_function_name,
+                entry_point_name,
             ],
             defines = ctx.attr.defines,
             feature_configuration = feature_configuration,
@@ -136,7 +137,7 @@ def _swift_binary_impl(ctx):
         )
     else:
         compile_result = None
-        entry_point_function_name = None
+        entry_point_name = None
         compilation_outputs = cc_common.create_compilation_outputs()
 
     additional_linking_contexts.append(malloc_linking_context(ctx))
@@ -159,9 +160,9 @@ def _swift_binary_impl(ctx):
     ) + ctx.fragments.cpp.linkopts
 
     # When linking the binary, make sure we use the correct entry point name.
-    if entry_point_function_name:
+    if entry_point_name:
         entry_point_linkopts = toolchains.swift.entry_point_linkopts_provider(
-            entry_point_name = entry_point_function_name,
+            entry_point_name = entry_point_name,
         ).linkopts
     else:
         entry_point_linkopts = []

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -34,6 +34,7 @@ load(
     "//swift/internal:linking.bzl",
     "configure_features_for_binary",
     "create_linking_context_from_compilation_outputs",
+    "entry_point_function_name",
     "malloc_linking_context",
     "register_link_binary_action",
 )
@@ -74,7 +75,7 @@ def _swift_compiler_plugin_impl(ctx):
     module_name = ctx.attr.module_name
     if not module_name:
         module_name = derive_swift_module_name(ctx.label)
-    entry_point_function_name = "{}_main".format(module_name)
+    entry_point_name = entry_point_function_name(module_name)
 
     compile_result = compile(
         actions = ctx.actions,
@@ -94,7 +95,7 @@ def _swift_compiler_plugin_impl(ctx):
             "-Xfrontend",
             "-entry-point-function-name",
             "-Xfrontend",
-            entry_point_function_name,
+            entry_point_name,
         ],
         defines = ctx.attr.defines,
         feature_configuration = feature_configuration,
@@ -155,7 +156,7 @@ def _swift_compiler_plugin_impl(ctx):
             # When linking the plugin binary, make sure we use the correct entry
             # point name.
             toolchains.swift.entry_point_linkopts_provider(
-                entry_point_name = entry_point_function_name,
+                entry_point_name = entry_point_name,
             ).linkopts
         ),
         variables_extension = variables_extension,


### PR DESCRIPTION
PiperOrigin-RevId: 799134162
(cherry picked from commit ac6b252352ff06979c64f4b71d8c9c45532ee206)
