### PR TITLE
Add a `feature_configuration` argument to `derive_swift_module_name`.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -96,7 +96,7 @@ A provider whose type/layout is an implementation detail and should not
 ## derive_swift_module_name
 
 <pre>
-derive_swift_module_name(<a href="#derive_swift_module_name-args">*args</a>)
+derive_swift_module_name(<a href="#derive_swift_module_name-args">*args</a>, <a href="#derive_swift_module_name-feature_configuration">feature_configuration</a>)
 </pre>
 
 Returns a derived module name from the given build label.
@@ -122,6 +122,7 @@ This mapping is intended to be fairly predictable, but not reversible.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
+| <a id="derive_swift_module_name-feature_configuration"></a>feature_configuration |  The Swift feature configuration being used when compiling the target. This currently does nothing; it will be used by upcoming changes to manage the migration of module names to raw identifiers that use the Bazel target label.   |  `None` |
 | <a id="derive_swift_module_name-args"></a>args |  Either a single argument of type `Label`, or two arguments of type `str` where the first argument is the package name and the second argument is the target name.   |  none |
 
 **RETURNS**

--- a/swift/module_name.bzl
+++ b/swift/module_name.bzl
@@ -16,7 +16,11 @@
 
 load("@bazel_skylib//lib:types.bzl", "types")
 
-def derive_swift_module_name(*args):
+visibility("public")
+
+def derive_swift_module_name(
+        *args,
+        feature_configuration = None):  # @unused
     """Returns a derived module name from the given build label.
 
     For targets whose module name is not explicitly specified, the module name
@@ -38,6 +42,10 @@ def derive_swift_module_name(*args):
         *args: Either a single argument of type `Label`, or two arguments of
             type `str` where the first argument is the package name and the
             second argument is the target name.
+        feature_configuration: The Swift feature configuration being used when
+            compiling the target. This currently does nothing; it will be used
+            by upcoming changes to manage the migration of module names to raw
+            identifiers that use the Bazel target label.
 
     Returns:
         The module name derived from the label.

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -95,7 +95,10 @@ def _swift_binary_impl(ctx):
     if srcs:
         module_name = ctx.attr.module_name
         if not module_name:
-            module_name = derive_swift_module_name(ctx.label)
+            module_name = derive_swift_module_name(
+                ctx.label,
+                feature_configuration = feature_configuration,
+            )
         entry_point_name = entry_point_function_name(module_name)
 
         include_dev_srch_paths = include_developer_search_paths(ctx.attr)

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -280,7 +280,10 @@ def _module_info_for_target(
         # was some other `Objc`-providing target, derive the module name
         # now.
         if not module_name:
-            module_name = derive_swift_module_name(target.label)
+            module_name = derive_swift_module_name(
+                target.label,
+                feature_configuration = feature_configuration,
+            )
 
     module_map_file = _generate_module_map(
         actions = aspect_ctx.actions,
@@ -765,9 +768,8 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
 
         exclude_headers = interop_info.exclude_headers
         module_map_file = interop_info.module_map
-        module_name = (
-            interop_info.module_name or derive_swift_module_name(target.label)
-        )
+        module_name = interop_info.module_name
+
         swift_infos.extend(interop_info.swift_infos)
         requested_features.extend(interop_info.requested_features)
         unsupported_features.extend(interop_info.unsupported_features)
@@ -786,6 +788,12 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
         toolchains = toolchains,
         unsupported_features = unsupported_features,
     )
+
+    if interop_info and not module_name:
+        module_name = derive_swift_module_name(
+            target.label,
+            feature_configuration = feature_configuration,
+        )
 
     if interop_info or ObjcInfo in target or CcInfo in target:
         return providers + _handle_module(

--- a/swift/swift_compiler_plugin.bzl
+++ b/swift/swift_compiler_plugin.bzl
@@ -74,7 +74,10 @@ def _swift_compiler_plugin_impl(ctx):
 
     module_name = ctx.attr.module_name
     if not module_name:
-        module_name = derive_swift_module_name(ctx.label)
+        module_name = derive_swift_module_name(
+            ctx.label,
+            feature_configuration = feature_configuration,
+        )
     entry_point_name = entry_point_function_name(module_name)
 
     compile_result = compile(

--- a/swift/swift_library.bzl
+++ b/swift/swift_library.bzl
@@ -149,10 +149,6 @@ def _swift_library_impl(ctx):
         extra_features.append(SWIFT_FEATURE_EMIT_SWIFTINTERFACE)
         extra_features.append(SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE)
 
-    module_name = ctx.attr.module_name
-    if not module_name:
-        module_name = derive_swift_module_name(ctx.label)
-
     toolchains = find_all_toolchains(ctx)
     feature_configuration = configure_features(
         ctx = ctx,
@@ -160,6 +156,13 @@ def _swift_library_impl(ctx):
         toolchains = toolchains,
         unsupported_features = ctx.disabled_features,
     )
+
+    module_name = ctx.attr.module_name
+    if not module_name:
+        module_name = derive_swift_module_name(
+            ctx.label,
+            feature_configuration = feature_configuration,
+        )
 
     swift_infos = get_providers(deps, SwiftInfo)
     private_swift_infos = get_providers(private_deps, SwiftInfo)

--- a/swift/swift_test.bzl
+++ b/swift/swift_test.bzl
@@ -339,7 +339,10 @@ def _swift_test_impl(ctx):
 
     module_name = ctx.attr.module_name
     if not module_name:
-        module_name = derive_swift_module_name(ctx.label)
+        module_name = derive_swift_module_name(
+            ctx.label,
+            feature_configuration = feature_configuration,
+        )
 
     include_dev_srch_paths = include_developer_search_paths(ctx.attr)
 


### PR DESCRIPTION
This is currently unused, but will be used later to detect the presence
of a feature that migrates modules from the current naming to one based
on Bazel target labels.

Naturally, this cannot be used by macros because they will not have
access to a feature configuration. Those will need to be migrated
separately, once all clients are on Swift 6.2/Xcode 26. The migration
will be "don't call the function" anymore, because there will be nothing
to derive; the module name will be the label verbatim. Likewise,
eventually this function can disappear in the rules themselves as well,
once the migration is complete.

(cherry picked from commit 596c252e521e9549a2b8940605305eb7a3931289)
