### PR TITLE
Stop using `-Xfrontend` for `-module-alias`.

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -2076,12 +2076,8 @@ def _swift_module_search_path_map_fn(module):
 def _module_alias_flags(name, original):
     """Returns compiler flags to set the given module alias."""
 
-    # TODO(b/257269318): Remove `-Xfrontend`; this is only needed to workaround
-    # a bug in toolchains still using the legacy C++ driver.
     return [
-        "-Xfrontend",
         "-module-alias",
-        "-Xfrontend",
         "{original}={name}".format(
             name = name,
             original = original,


### PR DESCRIPTION
The C++ driver was fixed and we don't need to maintain compatibility with it anyway.

PiperOrigin-RevId: 800413675
(cherry picked from commit de9656c8c71873ba3cd64ef3323f06721e77b25b)
