### PR TITLE
Make the presence of a `swift_overlay` imply the same thing as the `auto_module` hint if no other `swift_interop_hint` is provided.

### DIFF
--- a/swift/BUILD
+++ b/swift/BUILD
@@ -65,6 +65,7 @@ bzl_library(
     deps = [
         ":module_name",
         ":providers",
+        ":swift_interop_info",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
         "//swift/internal:features",

--- a/swift/BUILD
+++ b/swift/BUILD
@@ -65,7 +65,6 @@ bzl_library(
     deps = [
         ":module_name",
         ":providers",
-        ":swift_interop_info",
         "//swift/internal:compiling",
         "//swift/internal:feature_names",
         "//swift/internal:features",

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -65,6 +65,7 @@ load(
     "create_clang_module_inputs",
     "create_swift_module_context",
 )
+load(":swift_interop_info.bzl", "create_swift_interop_info")
 
 _MULTIPLE_TARGET_ASPECT_ATTRS = [
     "deps",
@@ -685,7 +686,10 @@ def _find_swift_interop_info(target, aspect_ctx):
     # We don't break this loop early when we find a matching hint, because we
     # want to give an error message if there are two aspect hints that provide
     # `SwiftInteropInfo` (or if both the rule and an aspect hint do).
+    found_overlay = False
     for hint in aspect_ctx.rule.attr.aspect_hints:
+        if SwiftOverlayCompileInfo in hint:
+            found_overlay = True
         if SwiftInteropInfo in hint:
             if interop_target:
                 if interop_from_rule:
@@ -707,6 +711,11 @@ def _find_swift_interop_info(target, aspect_ctx):
 
     if interop_target:
         return interop_target[SwiftInteropInfo], default_direct_swift_infos, default_swift_infos
+    if found_overlay:
+        # If no explicit interop hint was present but a `swift_overlay` was, we
+        # still want that to imply the same thing as the `auto_module` hint
+        # since it's the obvious right thing to do.
+        return create_swift_interop_info(), default_direct_swift_infos, default_swift_infos
     return None, default_direct_swift_infos, default_swift_infos
 
 def _find_swift_overlay_compile_info(aspect_ctx):

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -65,7 +65,6 @@ load(
     "create_clang_module_inputs",
     "create_swift_module_context",
 )
-load(":swift_interop_info.bzl", "create_swift_interop_info")
 
 _MULTIPLE_TARGET_ASPECT_ATTRS = [
     "deps",
@@ -686,10 +685,7 @@ def _find_swift_interop_info(target, aspect_ctx):
     # We don't break this loop early when we find a matching hint, because we
     # want to give an error message if there are two aspect hints that provide
     # `SwiftInteropInfo` (or if both the rule and an aspect hint do).
-    found_overlay = False
     for hint in aspect_ctx.rule.attr.aspect_hints:
-        if SwiftOverlayCompileInfo in hint:
-            found_overlay = True
         if SwiftInteropInfo in hint:
             if interop_target:
                 if interop_from_rule:
@@ -711,11 +707,6 @@ def _find_swift_interop_info(target, aspect_ctx):
 
     if interop_target:
         return interop_target[SwiftInteropInfo], default_direct_swift_infos, default_swift_infos
-    if found_overlay:
-        # If no explicit interop hint was present but a `swift_overlay` was, we
-        # still want that to imply the same thing as the `auto_module` hint
-        # since it's the obvious right thing to do.
-        return create_swift_interop_info(), default_direct_swift_infos, default_swift_infos
     return None, default_direct_swift_infos, default_swift_infos
 
 def _find_swift_overlay_compile_info(aspect_ctx):


### PR DESCRIPTION
This makes is easier to add overlays to `cc_library` targets, which aren't interoperable with Swift by default, because now you can just add the overlay instead of both hints.

Cherry picks (just a revert chain):

- 4020f9e57b0b
- d5e94f0e02a8
- 826eef6277f8