### PR TITLE
Allow a target using `create_swift_interop_info` to supply a different compilation context for Swift module map generation than the one that it propagates in its `CcInfo`.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -35,8 +35,9 @@ On this page:
 ## create_swift_interop_info
 
 <pre>
-create_swift_interop_info(*, <a href="#create_swift_interop_info-direct_swift_infos">direct_swift_infos</a>, <a href="#create_swift_interop_info-exclude_headers">exclude_headers</a>, <a href="#create_swift_interop_info-module_map">module_map</a>, <a href="#create_swift_interop_info-module_name">module_name</a>,
-                          <a href="#create_swift_interop_info-requested_features">requested_features</a>, <a href="#create_swift_interop_info-suppressed">suppressed</a>, <a href="#create_swift_interop_info-swift_infos">swift_infos</a>, <a href="#create_swift_interop_info-unsupported_features">unsupported_features</a>)
+create_swift_interop_info(*, <a href="#create_swift_interop_info-compilation_context">compilation_context</a>, <a href="#create_swift_interop_info-direct_swift_infos">direct_swift_infos</a>, <a href="#create_swift_interop_info-exclude_headers">exclude_headers</a>, <a href="#create_swift_interop_info-module_map">module_map</a>,
+                          <a href="#create_swift_interop_info-module_name">module_name</a>, <a href="#create_swift_interop_info-requested_features">requested_features</a>, <a href="#create_swift_interop_info-suppressed">suppressed</a>, <a href="#create_swift_interop_info-swift_infos">swift_infos</a>,
+                          <a href="#create_swift_interop_info-unsupported_features">unsupported_features</a>)
 </pre>
 
 Returns a provider that lets a target expose C/Objective-C APIs to Swift.
@@ -77,6 +78,7 @@ implicit attributes) but also to exclude dependencies if necessary.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
+| <a id="create_swift_interop_info-compilation_context"></a>compilation_context |  A `CcCompilationContext` that provides the headers for the module, or `None` (the default) if the headers should be derived from the target's `CcInfo` provider. This should only be used if a target explicitly needs to use a different compilation context for Swift than it does for C/Objective-C, which is a very rare situation.   |  `None` |
 | <a id="create_swift_interop_info-direct_swift_infos"></a>direct_swift_infos |  A list of `SwiftInfo` providers from dependencies, which will be merged with the new `SwiftInfo` created by the aspect as direct data.   |  `[]` |
 | <a id="create_swift_interop_info-exclude_headers"></a>exclude_headers |  A `list` of `File`s representing headers that should be excluded from the module if the module map is generated.   |  `[]` |
 | <a id="create_swift_interop_info-module_map"></a>module_map |  A `File` representing an existing module map that should be used to represent the module, or `None` (the default) if the module map should be generated based on the headers in the target's compilation context. If this argument is provided, then `module_name` must also be provided.   |  `None` |

--- a/swift/internal/swift_interop_info.bzl
+++ b/swift/internal/swift_interop_info.bzl
@@ -32,6 +32,13 @@ Contains minimal information required to allow `swift_clang_module_aspect` to
 manage the creation of a `SwiftInfo` provider for a C/Objective-C target.
 """,
     fields = {
+        "compilation_context": """\
+A `CcCompilationContext` that provides the headers for the module, or `None`
+(the default) if the headers should be derived from the target's `CcInfo`
+provider. This should only be used if a target explicitly needs to use a
+different compilation context for Swift than it does for C/Objective-C, which is
+a very rare situation.
+""",
         "direct_swift_infos": """\
 A list of `SwiftInfo` providers from dependencies of the target, which will be
 merged with the new `SwiftInfo` created by the aspect as direct.

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -301,6 +301,7 @@ def _module_info_for_target(
 
 def _handle_module(
         aspect_ctx,
+        compilation_context,
         exclude_headers,
         feature_configuration,
         module_map_file,
@@ -314,6 +315,8 @@ def _handle_module(
 
     Args:
         aspect_ctx: The aspect's context.
+        compilation_context: The `CcCompilationContext` that provides the
+            headers for the module.
         exclude_headers: A `list` of `File`s representing header files to
             exclude, if any, if we are generating the module map.
         feature_configuration: The current feature configuration.
@@ -344,11 +347,6 @@ def _handle_module(
     )
 
     all_swift_infos = direct_swift_infos + swift_infos + implicit_swift_infos
-
-    if CcInfo in target:
-        compilation_context = target[CcInfo].compilation_context
-    else:
-        compilation_context = None
 
     # Collect the names of Clang modules that the module being built directly
     # depends on.
@@ -768,6 +766,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
     requested_features = aspect_ctx.features
     unsupported_features = aspect_ctx.disabled_features
 
+    compilation_context = None
     interop_info, direct_swift_infos, swift_infos = _find_swift_interop_info(target, aspect_ctx)
     if interop_info:
         # If the module should be suppressed, return immediately and propagate
@@ -779,6 +778,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
         module_map_file = interop_info.module_map
         module_name = interop_info.module_name
 
+        compilation_context = interop_info.compilation_context
         direct_swift_infos.extend(interop_info.direct_swift_infos)
         swift_infos.extend(interop_info.swift_infos)
         requested_features.extend(interop_info.requested_features)
@@ -787,6 +787,12 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
         exclude_headers = []
         module_map_file = None
         module_name = None
+
+    # If the target has a `CcInfo` and we didn't get an explicit compilation
+    # context from `SwiftInteropInfo`, then we can use the `CcInfo`'s
+    # compilation context.
+    if not compilation_context and CcInfo in target:
+        compilation_context = target[CcInfo].compilation_context
 
     toolchains = find_all_toolchains(
         aspect_ctx,
@@ -808,6 +814,7 @@ def _swift_clang_module_aspect_impl(target, aspect_ctx, toolchain_type):
     if interop_info or ObjcInfo in target or CcInfo in target:
         return providers + _handle_module(
             aspect_ctx = aspect_ctx,
+            compilation_context = compilation_context,
             exclude_headers = exclude_headers,
             feature_configuration = feature_configuration,
             module_map_file = module_map_file,

--- a/swift/swift_interop_info.bzl
+++ b/swift/swift_interop_info.bzl
@@ -32,6 +32,7 @@ load("//swift/internal:swift_interop_info.bzl", "SwiftInteropInfo")
 
 def create_swift_interop_info(
         *,
+        compilation_context = None,
         direct_swift_infos = [],
         exclude_headers = [],
         module_map = None,
@@ -73,6 +74,12 @@ def create_swift_interop_info(
     implicit attributes) but also to exclude dependencies if necessary.
 
     Args:
+        compilation_context: A `CcCompilationContext` that provides the headers
+            for the module, or `None` (the default) if the headers should be
+            derived from the target's `CcInfo` provider. This should only be
+            used if a target explicitly needs to use a different compilation
+            context for Swift than it does for C/Objective-C, which is a very
+            rare situation.
         direct_swift_infos: A list of `SwiftInfo` providers from dependencies,
             which will be merged with the new `SwiftInfo` created by the aspect
             as direct data.
@@ -118,6 +125,7 @@ def create_swift_interop_info(
                  "is specified.")
 
     return SwiftInteropInfo(
+        compilation_context = compilation_context,
         direct_swift_infos = direct_swift_infos,
         exclude_headers = exclude_headers,
         module_map = module_map,


### PR DESCRIPTION
PiperOrigin-RevId: 918009765
(cherry picked from commit 7e87858d618005ed503d63df5a792b75f4e0b7a1)
