### PR TITLE
Only disable parse_headers when calling cc_common.compile on a set of headers that include the Swift generated header.

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1229,6 +1229,7 @@ def _create_cc_compilation_context(
         defines,
         feature_configuration,
         includes,
+        has_generated_header = False,
         public_hdrs,
         target_name,
         toolchains = None):
@@ -1250,6 +1251,8 @@ def _create_cc_compilation_context(
             `configure_features`.
         includes: Include paths that should be propagated by the new compilation
             context.
+        has_generated_header: If True, the `public_hdrs` include a generated
+            Objective-C header.
         public_hdrs: Public headers that should be propagated by the new
             compilation context (for example, the module's generated header).
         target_name: The name of the target for which the code is being
@@ -1272,14 +1275,24 @@ def _create_cc_compilation_context(
     # layering checks will fail when the Objective-C code tries to import the
     # `swift_library`'s headers.
     if public_hdrs:
+        # If we have a generated header, we need to create the feature
+        # configuration that disables `parse_headers` for the compilation
+        # action.
+        if has_generated_header:
+            cc_feature_configuration = (
+                feature_configuration._cc_feature_configuration_no_parse_headers()
+            )
+        else:
+            cc_feature_configuration = get_cc_feature_configuration(
+                feature_configuration = feature_configuration,
+            )
+
         compilation_context, _ = cc_common.compile(
             actions = actions,
             cc_toolchain = toolchains.cc,
             compilation_contexts = compilation_contexts,
             defines = defines,
-            feature_configuration = get_cc_feature_configuration(
-                feature_configuration = feature_configuration,
-            ),
+            feature_configuration = cc_feature_configuration,
             name = target_name,
             includes = includes,
             public_hdrs = public_hdrs,

--- a/swift/internal/features.bzl
+++ b/swift/internal/features.bzl
@@ -141,14 +141,12 @@ def configure_features(
     requested_features = list(requested_features)
     unsupported_features = list(unsupported_features)
 
-    # Always disable these two features so that any `cc_common` APIs called by
+    # Always disable this feature so that any `cc_common` APIs called by
     # `swift_common` APIs don't cause certain actions to be created (for
     # example, when using `cc_common.compile` to create the compilation context
     # for a generated header).
-    unsupported_features.extend([
-        "cc_include_scanning",
-        "parse_headers",
-    ])
+    unsupported_features = list(unsupported_features)
+    unsupported_features.append("cc_include_scanning")
 
     if ctx.coverage_instrumented():
         requested_features.append(SWIFT_FEATURE_COVERAGE)
@@ -190,8 +188,24 @@ def configure_features(
         requested_features = all_requestable_features,
         unsupported_features = all_unsupported_features,
     )
+
+    # Swift generated Objective-C headers are not compatible with
+    # `parse_headers` actions. But, we don't want to disable `parse_headers` for
+    # all actions performed by the toolchain, only the one that compiles the
+    # generated header into an explicit module. So, we (lazily) create a second
+    # feature configuration that will be used by that specific action.
+    def cc_feature_configuration_no_parse_headers():
+        return cc_common.configure_features(
+            ctx = ctx,
+            cc_toolchain = swift_toolchain.cc_toolchain_info,
+            language = swift_toolchain.cc_language,
+            requested_features = all_requestable_features,
+            unsupported_features = all_unsupported_features + ["parse_headers"],
+        )
+
     return struct(
         _cc_feature_configuration = cc_feature_configuration,
+        _cc_feature_configuration_no_parse_headers = cc_feature_configuration_no_parse_headers,
         _enabled_features = all_requestable_features,
         # This is naughty, but APIs like `cc_common.compile` do far worse and
         # "cheat" by accessing the full rule context through a back-reference in


### PR DESCRIPTION
Disabling `parse_headers` universally for any action in a Swift context
is too aggressive, because it prevents those actions from running on
legitimate headers used in, say, a mixed C/Swift library. It also
impacts feature configurations created in aspects applied to C
libraries.

Only the generated header is known to be non-compliant for this action,
so we lazily create a second feature configuration that is only passed
to that specific compilation. Even though this compilation may include
the other public headers, we don't skip `parse_headers` on those because
there would have been a _previous_ compilation earlier in the
`swift_common.compile` to compile the set of headers _excluding_ the
generated header, and that one will execute the `parse_headers` actions.

After additional testing, I may move `cc_include_scanning` into this
lazy feature config, for the same reason.

Cherry picks 7d8f6badea0d40f20e6ec40c3ab7ebd5ca40a47a but isn't entirely
wired up since this is related to the upstream mixed library
implementation. But this is here if we ever take that version of it
