### PR TITLE
Add a mechanism to pass through arbitrary flags to other tools that the Swift worker invokes, and apply it to the generated header rewriter.

### DIFF
--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -126,6 +126,7 @@ cc_library(
         "//tools/common:process",
         "//tools/common:target_triple",
         "//tools/common:temp_file",
+        "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/strings",
         "@com_github_nlohmann_json//:json",
     ],

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -361,6 +361,10 @@ int SwiftRunner::Run(std::ostream* stderr_stream, bool stdout_to_stderr) {
     std::vector<std::string> rewriter_args;
     rewriter_args.reserve(args_.size() + 2 - initial_args_to_skip);
     rewriter_args.push_back(generated_header_rewriter_path_);
+    const std::vector<std::string>& passthrough_args =
+        passthrough_tool_args_["generated_header_rewriter"];
+    rewriter_args.insert(rewriter_args.end(), passthrough_args.begin(),
+                         passthrough_args.end());
     rewriter_args.push_back("--");
     rewriter_args.insert(rewriter_args.end(),
                          args_.begin() + initial_args_to_skip, args_.end());
@@ -603,6 +607,8 @@ bool SwiftRunner::ProcessArgument(
         changed = true;
       } else if (StripPrefix("-generated-header-rewriter=", new_arg)) {
         changed = true;
+      } else if (StripPrefix("-tool-arg=", new_arg)) {
+        changed = true;
       } else if (StripPrefix("-bazel-target-label=", new_arg)) {
         changed = true;
       } else if (StripPrefix("-global-index-store-import-path=", new_arg)) {
@@ -690,6 +696,11 @@ std::vector<std::string> SwiftRunner::ParseArguments(Iterator itr) {
         global_index_store_import_path_ = arg;
       } else if (StripPrefix("-generated-header-rewriter=", arg)) {
         generated_header_rewriter_path_ = arg;
+      } else if (StripPrefix("-tool-arg=", arg)) {
+        std::pair<std::string, std::string> arg_and_value =
+            absl::StrSplit(arg, absl::MaxSplits('=', 1));
+        passthrough_tool_args_[arg_and_value.first].push_back(
+            std::string(arg_and_value.second));
       } else if (StripPrefix("-bazel-target-label=", arg)) {
         target_label_ = arg;
       } else if (arg == "-file-prefix-pwd-is-dot") {

--- a/tools/worker/swift_runner.h
+++ b/tools/worker/swift_runner.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "tools/common/bazel_substitutions.h"
 #include "tools/common/temp_file.h"
 
@@ -163,6 +164,12 @@ class SwiftRunner {
   // The path to the generated header rewriter tool, if one is being used for
   // this compilation.
   std::string generated_header_rewriter_path_;
+
+  // A map containing arguments that should be passed through to additional
+  // tools that support them. Each key in the map represents the name of a
+  // recognized tool.
+  absl::flat_hash_map<std::string, std::vector<std::string>>
+      passthrough_tool_args_;
 
   // The Bazel target label that spawned the worker request, which can be used
   // in custom diagnostic messages printed by the worker.


### PR DESCRIPTION
Cherry picks bb62c89a7bb2a9a90206f813821f12b47aabb3d8
