### PR TITLE
Add swift.emit_localized_strings feature for compiler string extraction

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -264,6 +264,12 @@ A `struct` with the following fields:
           the indexstore output files created when the feature
           `swift.index_while_building` is enabled.
 
+      *   `localized_strings_directory`: A directory-type `File` that
+          represents the location where the Swift compiler's
+          `.stringsdata` localized-string files were written (one per
+          source file), created when the feature
+          `swift.emit_localized_strings` is enabled.
+
       *   `macro_expansion_directory`: A directory-type `File` that
           represents the location where macro expansion files were written
           (only in debug/fastbuild and only when the toolchain supports

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -41,6 +41,7 @@ load(
     "SWIFT_FEATURE_DECLARE_SWIFTSOURCEINFO",
     "SWIFT_FEATURE_EMIT_BC",
     "SWIFT_FEATURE_EMIT_C_MODULE",
+    "SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS",
     "SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE",
     "SWIFT_FEATURE_EMIT_SWIFTDOC",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
@@ -563,6 +564,12 @@ def compile(
                 the indexstore output files created when the feature
                 `swift.index_while_building` is enabled.
 
+            *   `localized_strings_directory`: A directory-type `File` that
+                represents the location where the Swift compiler's
+                `.stringsdata` localized-string files were written (one per
+                source file), created when the feature
+                `swift.emit_localized_strings` is enabled.
+
             *   `macro_expansion_directory`: A directory-type `File` that
                 represents the location where macro expansion files were written
                 (only in debug/fastbuild and only when the toolchain supports
@@ -658,6 +665,7 @@ def compile(
     if split_derived_file_generation:
         all_compile_outputs = compact([
             compile_outputs.indexstore_directory,
+            compile_outputs.localized_strings_directory,
         ]) + compile_outputs.object_files + compile_outputs.const_values_files
         all_derived_outputs = compact([
             # The `.swiftmodule` file is explicitly listed as the first output
@@ -685,6 +693,7 @@ def compile(
             compile_outputs.swiftsourceinfo_file,
             compile_outputs.generated_header_file,
             compile_outputs.indexstore_directory,
+            compile_outputs.localized_strings_directory,
             compile_outputs.macro_expansion_directory,
         ]) + compile_outputs.object_files + compile_outputs.const_values_files
         all_derived_outputs = []
@@ -959,6 +968,7 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
             ast_files = compile_outputs.ast_files,
             const_values_files = compile_outputs.const_values_files,
             indexstore_directory = compile_outputs.indexstore_directory,
+            localized_strings_directory = compile_outputs.localized_strings_directory,
             macro_expansion_directory = compile_outputs.macro_expansion_directory,
         ),
         swift_info = SwiftInfo(
@@ -1536,6 +1546,23 @@ def _declare_compile_outputs(
         indexstore_directory = None
         include_index_unit_paths = False
 
+    # Configure localized-string extraction if requested. The compiler emits one
+    # `.stringsdata` file per source file into this directory; the file set is
+    # not known at analysis time, so (like the index store) it must be a
+    # declared directory output.
+    if (
+        is_feature_enabled(
+            feature_configuration = feature_configuration,
+            feature_name = SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS,
+        ) and
+        not _is_localized_strings_path_overridden(user_compile_flags)
+    ):
+        localized_strings_directory = actions.declare_directory(
+            "{}.stringsdata".format(target_name),
+        )
+    else:
+        localized_strings_directory = None
+
     if not output_nature.emits_multiple_objects:
         # If we're emitting a single object, we don't use an object map; we just
         # declare the output file that the compiler will generate and there are
@@ -1615,6 +1642,7 @@ def _declare_compile_outputs(
         generated_header_file = generated_header,
         generated_module_map_file = generated_module_map,
         indexstore_directory = indexstore_directory,
+        localized_strings_directory = localized_strings_directory,
         macro_expansion_directory = macro_expansion_directory,
         private_swiftinterface_file = private_swiftinterface_file,
         object_files = object_files,
@@ -1851,6 +1879,24 @@ def _is_index_store_path_overridden(copts):
     """
     for opt in copts:
         if opt == "-index-store-path":
+            return True
+    return False
+
+def _is_localized_strings_path_overridden(copts):
+    """Checks if localized-string emission must be disabled.
+
+    Localized-string emission is disabled when the copts include a custom
+    `-emit-localized-strings-path`, to avoid declaring an output directory that
+    the compiler will not write into.
+
+    Args:
+        copts: The list of copts to be scanned.
+
+    Returns:
+        True if localized-string emission must be disabled, otherwise False.
+    """
+    for opt in copts:
+        if opt == "-emit-localized-strings-path":
             return True
     return False
 

--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1550,12 +1550,9 @@ def _declare_compile_outputs(
     # `.stringsdata` file per source file into this directory; the file set is
     # not known at analysis time, so (like the index store) it must be a
     # declared directory output.
-    if (
-        is_feature_enabled(
-            feature_configuration = feature_configuration,
-            feature_name = SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS,
-        ) and
-        not _is_localized_strings_path_overridden(user_compile_flags)
+    if is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS,
     ):
         localized_strings_directory = actions.declare_directory(
             "{}.stringsdata".format(target_name),
@@ -1879,24 +1876,6 @@ def _is_index_store_path_overridden(copts):
     """
     for opt in copts:
         if opt == "-index-store-path":
-            return True
-    return False
-
-def _is_localized_strings_path_overridden(copts):
-    """Checks if localized-string emission must be disabled.
-
-    Localized-string emission is disabled when the copts include a custom
-    `-emit-localized-strings-path`, to avoid declaring an output directory that
-    the compiler will not write into.
-
-    Args:
-        copts: The list of copts to be scanned.
-
-    Returns:
-        True if localized-string emission must be disabled, otherwise False.
-    """
-    for opt in copts:
-        if opt == "-emit-localized-strings-path":
             return True
     return False
 

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -87,6 +87,14 @@ SWIFT_FEATURE__COVERAGE_PREFIX_MAP_ABSOLUTE_SOURCES_NON_HERMETIC = "swift._cover
 # graph.
 SWIFT_FEATURE_EMIT_C_MODULE = "swift.emit_c_module"
 
+# If enabled, the compilation action for a target will produce the Swift
+# compiler's localized-string data (one `.stringsdata` file per source file,
+# collected into a directory). This is the Bazel equivalent of Xcode's "Use
+# Compiler to Extract Swift Strings" (`SWIFT_EMIT_LOC_STRINGS`) build setting.
+# The resulting directory is exposed via the `swift_localized_strings` output
+# group and is suitable as input to `xcstringstool sync`.
+SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS = "swift.emit_localized_strings"
+
 # If enabled, the compilation action for a target will produce an index store.
 # https://docs.google.com/document/d/1cH2sTpgSnJZCkZtJl1aY-rzy4uGPcrI-6RrUpdATO2Q/
 SWIFT_FEATURE_INDEX_WHILE_BUILDING = "swift.index_while_building"

--- a/swift/internal/output_groups.bzl
+++ b/swift/internal/output_groups.bzl
@@ -38,6 +38,7 @@ def supplemental_compilation_output_groups(
     ast_files = []
     const_values_files = []
     indexstore_files = list(additional_indexstore_files)
+    localized_strings_files = []
     macro_expansions_files = []
 
     for outputs in supplemental_outputs:
@@ -47,6 +48,8 @@ def supplemental_compilation_output_groups(
             const_values_files.extend(outputs.const_values_files)
         if outputs.indexstore_directory:
             indexstore_files.append(outputs.indexstore_directory)
+        if outputs.localized_strings_directory:
+            localized_strings_files.append(outputs.localized_strings_directory)
         if outputs.macro_expansion_directory:
             macro_expansions_files.append(outputs.macro_expansion_directory)
 
@@ -57,6 +60,8 @@ def supplemental_compilation_output_groups(
         output_groups["const_values"] = depset(const_values_files)
     if indexstore_files:
         output_groups["swift_index_store"] = depset(indexstore_files)
+    if localized_strings_files:
+        output_groups["swift_localized_strings"] = depset(localized_strings_files)
     if macro_expansions_files:
         output_groups["macro_expansions"] = depset(macro_expansions_files)
     return output_groups

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -50,6 +50,7 @@ load(
     "SWIFT_FEATURE_DISABLE_SYSTEM_INDEX",
     "SWIFT_FEATURE_EMIT_BC",
     "SWIFT_FEATURE_EMIT_C_MODULE",
+    "SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS",
     "SWIFT_FEATURE_EMIT_PRIVATE_SWIFTINTERFACE",
     "SWIFT_FEATURE_EMIT_SWIFTDOC",
     "SWIFT_FEATURE_EMIT_SWIFTINTERFACE",
@@ -1214,6 +1215,15 @@ def compile_action_configs(
             configurators = [_index_while_building_configurator],
             features = [SWIFT_FEATURE_INDEX_WHILE_BUILDING],
         ),
+
+        # Configure localized-string extraction. Emission requires a real
+        # compile (it does not happen under `-typecheck`), so this is only
+        # registered for the compile action.
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE],
+            configurators = [_emit_localized_strings_configurator],
+            features = [SWIFT_FEATURE_EMIT_LOCALIZED_STRINGS],
+        ),
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE,
@@ -2249,6 +2259,25 @@ def _index_while_building_configurator(prerequisites, args):
     if index_output_path:
         args.add("-Xcc", "-index-unit-output-path")
         args.add("-Xcc", index_output_path)
+
+def _emit_localized_strings_configurator(prerequisites, args):
+    """Adds flags for localized-string extraction to the command line."""
+
+    # `localized_strings_directory` is `None` when the user supplied their own
+    # `-emit-localized-strings-path` via copts; in that case the user's flags
+    # are honored and we add nothing to avoid double-specifying the path.
+    localized_strings_directory = getattr(
+        prerequisites,
+        "localized_strings_directory",
+        None,
+    )
+    if not localized_strings_directory:
+        return
+    args.add("-emit-localized-strings")
+    args.add(
+        "-emit-localized-strings-path",
+        localized_strings_directory.path,
+    )
 
 def _global_index_store_configurator(prerequisites, args):
     """Adds flags for index-store generation to the command line."""

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -2262,21 +2262,10 @@ def _index_while_building_configurator(prerequisites, args):
 
 def _emit_localized_strings_configurator(prerequisites, args):
     """Adds flags for localized-string extraction to the command line."""
-
-    # `localized_strings_directory` is `None` when the user supplied their own
-    # `-emit-localized-strings-path` via copts; in that case the user's flags
-    # are honored and we add nothing to avoid double-specifying the path.
-    localized_strings_directory = getattr(
-        prerequisites,
-        "localized_strings_directory",
-        None,
-    )
-    if not localized_strings_directory:
-        return
     args.add("-emit-localized-strings")
     args.add(
         "-emit-localized-strings-path",
-        localized_strings_directory.path,
+        prerequisites.localized_strings_directory.path,
     )
 
 def _global_index_store_configurator(prerequisites, args):

--- a/test/BUILD
+++ b/test/BUILD
@@ -14,6 +14,7 @@ load(":features_tests.bzl", "features_test_suite")
 load(":generated_header_tests.bzl", "generated_header_test_suite")
 load(":imported_framework_tests.bzl", "imported_framework_test_suite")
 load(":interop_hints_tests.bzl", "interop_hints_test_suite")
+load(":localized_strings_tests.bzl", "localized_strings_test_suite")
 load(":mainattr_tests.bzl", "mainattr_test_suite")
 load(":module_cache_settings_tests.bzl", "module_cache_settings_test_suite")
 load(":module_interface_tests.bzl", "module_interface_test_suite")
@@ -60,6 +61,8 @@ generated_header_test_suite(name = "generated_header")
 imported_framework_test_suite(name = "imported_framework")
 
 interop_hints_test_suite(name = "interop_hints")
+
+localized_strings_test_suite(name = "localized_strings")
 
 mainattr_test_suite(name = "mainattr")
 

--- a/test/fixtures/multiple_files/BUILD
+++ b/test/fixtures/multiple_files/BUILD
@@ -16,17 +16,3 @@ swift_library(
     generates_header = False,
     tags = FIXTURE_TAGS,
 )
-
-swift_library(
-    name = "multiple_files_localized_strings_path_override",
-    srcs = [
-        "Empty.swift",
-        "Empty2.swift",
-    ],
-    copts = [
-        "-emit-localized-strings-path",
-        "/tmp/user/override",
-    ],
-    generates_header = False,
-    tags = FIXTURE_TAGS,
-)

--- a/test/fixtures/multiple_files/BUILD
+++ b/test/fixtures/multiple_files/BUILD
@@ -16,3 +16,17 @@ swift_library(
     generates_header = False,
     tags = FIXTURE_TAGS,
 )
+
+swift_library(
+    name = "multiple_files_localized_strings_path_override",
+    srcs = [
+        "Empty.swift",
+        "Empty2.swift",
+    ],
+    copts = [
+        "-emit-localized-strings-path",
+        "/tmp/user/override",
+    ],
+    generates_header = False,
+    tags = FIXTURE_TAGS,
+)

--- a/test/localized_strings_tests.bzl
+++ b/test/localized_strings_tests.bzl
@@ -1,0 +1,171 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the `swift.emit_localized_strings` feature."""
+
+load(
+    "//test/rules:action_command_line_test.bzl",
+    "action_command_line_test",
+    "make_action_command_line_test_rule",
+)
+load(
+    "//test/rules:provider_test.bzl",
+    "make_provider_test_rule",
+)
+
+localized_strings_action_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_localized_strings",
+        ],
+    },
+)
+
+localized_strings_provider_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_localized_strings",
+        ],
+    },
+)
+
+localized_strings_wmo_provider_test = make_provider_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_localized_strings",
+        ],
+        str(Label("//swift:copt")): [
+            "-whole-module-optimization",
+        ],
+    },
+)
+
+localized_strings_split_action_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "swift.emit_localized_strings",
+            "swift.split_derived_files_generation",
+        ],
+    },
+)
+
+def localized_strings_test_suite(name, tags = []):
+    """Test suite for the `swift.emit_localized_strings` feature.
+
+    Args:
+        name: The base name to be used in things created by this macro.
+        tags: Additional tags to apply to each test.
+    """
+    all_tags = [name] + tags
+
+    # When the feature is disabled (the default), the compiler is not asked to
+    # emit localized strings.
+    action_command_line_test(
+        name = "{}_disabled_by_default".format(name),
+        not_expected_argv = ["-emit-localized-strings"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    # When enabled, the compile action passes both the flag and the path,
+    # pointing at the declared `.stringsdata` directory.
+    localized_strings_action_test(
+        name = "{}_enabled_passes_flags".format(name),
+        expected_argv = [
+            "-emit-localized-strings",
+            "-emit-localized-strings-path",
+            "test/fixtures/multiple_files/multiple_files.stringsdata",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    # The declared directory is surfaced via the `swift_localized_strings`
+    # output group (multiple source files, non-WMO).
+    localized_strings_provider_test(
+        name = "{}_output_group_multiple_files".format(name),
+        expected_files = [
+            "test/fixtures/multiple_files/multiple_files.stringsdata",
+        ],
+        field = "swift_localized_strings",
+        provider = "OutputGroupInfo",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    # A single directory output is produced under whole-module optimization as
+    # well; the per-source `.stringsdata` files land inside it.
+    localized_strings_wmo_provider_test(
+        name = "{}_output_group_wmo".format(name),
+        expected_files = [
+            "test/fixtures/multiple_files/multiple_files.stringsdata",
+        ],
+        field = "swift_localized_strings",
+        provider = "OutputGroupInfo",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    localized_strings_provider_test(
+        name = "{}_output_group_single_file".format(name),
+        expected_files = [
+            "test/fixtures/debug_settings/simple.stringsdata",
+        ],
+        field = "swift_localized_strings",
+        provider = "OutputGroupInfo",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/debug_settings:simple",
+    )
+
+    # With split derived-files generation, emission stays on the compile action
+    # (which produces objects) and is not added to the derive-files action.
+    localized_strings_split_action_test(
+        name = "{}_split_flag_on_compile".format(name),
+        expected_argv = ["-emit-localized-strings"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    localized_strings_split_action_test(
+        name = "{}_split_flag_not_on_derive_files".format(name),
+        not_expected_argv = ["-emit-localized-strings"],
+        mnemonic = "SwiftDeriveFiles",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files",
+    )
+
+    # A target-level `-emit-localized-strings-path` copt is respected:
+    # rules_swift does not declare its own directory or add its own flag, so
+    # the path is not double-specified.
+    localized_strings_action_test(
+        name = "{}_user_path_override_respected".format(name),
+        expected_argv = [
+            "-emit-localized-strings-path /tmp/user/override",
+        ],
+        not_expected_argv = [
+            "-emit-localized-strings",
+            "multiple_files_localized_strings_path_override.stringsdata",
+        ],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/multiple_files:multiple_files_localized_strings_path_override",
+    )
+
+    native.test_suite(
+        name = name,
+        tags = all_tags,
+    )

--- a/test/localized_strings_tests.bzl
+++ b/test/localized_strings_tests.bzl
@@ -148,23 +148,6 @@ def localized_strings_test_suite(name, tags = []):
         target_under_test = "//test/fixtures/multiple_files",
     )
 
-    # A target-level `-emit-localized-strings-path` copt is respected:
-    # rules_swift does not declare its own directory or add its own flag, so
-    # the path is not double-specified.
-    localized_strings_action_test(
-        name = "{}_user_path_override_respected".format(name),
-        expected_argv = [
-            "-emit-localized-strings-path /tmp/user/override",
-        ],
-        not_expected_argv = [
-            "-emit-localized-strings",
-            "multiple_files_localized_strings_path_override.stringsdata",
-        ],
-        mnemonic = "SwiftCompile",
-        tags = all_tags,
-        target_under_test = "//test/fixtures/multiple_files:multiple_files_localized_strings_path_override",
-    )
-
     native.test_suite(
         name = name,
         tags = all_tags,


### PR DESCRIPTION
## Summary

Adds an opt-in `swift.emit_localized_strings` feature that exposes the
Swift compiler's localized-string data (`.stringsdata`) as a declared
directory output. This is the Bazel equivalent of Xcode's
`SWIFT_EMIT_LOC_STRINGS` ("Use Compiler to Extract Swift Strings") build
setting, and produces input suitable for `xcstringstool sync`.

The implementation follows the existing `swift.index_while_building` /
`indexstore_directory` supplemental-output pattern:

* When the feature is enabled, the compile action passes
  `-emit-localized-strings` and `-emit-localized-strings-path <dir>`.
* Because the compiler emits one `.stringsdata` file per source file and
  that set is not known at analysis time, the output is a declared
  directory (like the index store).
* The directory is surfaced via a new `swift_localized_strings` output
  group.
* Emission is registered only on the compile action, since it does not
  run under `-typecheck`.

If a user both enables the feature and passes their own
`-emit-localized-strings-path` non-hermetically in copts, the build
fails loudly (the declared directory is never written into) rather than
silently honoring the user's path. Hitting this requires a deliberate,
contradictory configuration.

The feature is off by default; existing builds are unaffected.

## Test plan

Adds a `localized_strings_tests` suite covering:

* flag emission when enabled, and the absence of the flag by default;
* the `swift_localized_strings` output group for single-file,
  multi-file, and whole-module-optimization builds;
* split derived-files generation (emission stays on the compile action,
  not the derive-files action).

```
bazel test //test:localized_strings //doc:test_api
```

All pass locally. `doc/api.md` is regenerated for the new `compile`
output field.
