### PR TITLE
Use -swift-module-file over -I

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -134,8 +134,9 @@ def _explicit_swift_module_map_info(
         feature_configuration = feature_configuration,
         feature_name = SWIFT_FEATURE_USE_C_MODULES,
     ):
-        # Keep non-system Swift deps on search paths, but include system
-        # modules to make sure everything loads them with the same behavior
+        # Keep non-system Swift deps on per-module frontend flags, but include
+        # system modules to make sure everything loads them with the same
+        # behavior.
         module_contexts = [
             module
             for module in transitive_modules

--- a/swift/internal/feature_names.bzl
+++ b/swift/internal/feature_names.bzl
@@ -221,7 +221,7 @@ SWIFT_FEATURE_USE_C_MODULES = "swift.use_c_modules"
 SWIFT_FEATURE_ADD_DEFAULT_PRECOMPILED_MODULES = "swift.add_default_precompiled_modules"
 
 # If enabled, Swift modules for dependencies will be passed to the compiler
-# using a JSON file instead of `-I` search paths.
+# using a JSON file instead of per-module frontend flags.
 SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP = "swift.use_explicit_swift_module_map"
 
 # If enabled, Swift compilation actions will use the same global Clang module

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -931,10 +931,22 @@ def compile_action_configs(
         # ),
         ActionConfigInfo(
             actions = all_compile_action_names() + [
-                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
             ],
             configurators = [_dependencies_swiftmodules_configurator],
+            not_features = [
+                [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
+            ],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
+            configurators = [
+                lambda prerequisites, args: _dependencies_swiftmodules_configurator(
+                    prerequisites,
+                    args,
+                    is_frontend = True,
+                ),
+            ],
             not_features = [
                 [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
             ],
@@ -980,22 +992,22 @@ def compile_action_configs(
             configurators = [_plugin_search_paths_configurator],
         ),
 
-        # swift-symbolgraph-extract doesn't yet support explicit Swift module maps.
+        # swift-symbolgraph-extract doesn't yet support explicit Swift modules.
         ActionConfigInfo(
             actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
             configurators = [_dependencies_swiftmodules_and_swiftdocs_configurator],
             features = [SWIFT_FEATURE_EMIT_SWIFTDOC],
         ),
 
-        # swift-synthesize-interface doesn't yet support explicit Swift module maps.
+        # swift-synthesize-interface doesn't yet support explicit Swift modules.
         ActionConfigInfo(
             actions = [SWIFT_ACTION_SYNTHESIZE_INTERFACE],
-            configurators = [_dependencies_swiftmodules_configurator],
+            configurators = [_dependencies_swiftmodule_search_paths_configurator],
             features = [SWIFT_FEATURE_EMIT_SWIFTDOC],
         ),
         ActionConfigInfo(
             actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
-            configurators = [_dependencies_swiftmodules_configurator],
+            configurators = [_dependencies_swiftmodule_search_paths_configurator],
             not_features = [SWIFT_FEATURE_EMIT_SWIFTDOC],
         ),
     ])
@@ -2071,6 +2083,28 @@ def _swift_module_search_path_map_fn(module):
     else:
         return None
 
+def _swift_module_file_map_fn(module):
+    """Returns a frontend flag that maps a module name to its `.swiftmodule`.
+
+    This function is intended to be used as a mapping function for modules
+    passed into `Args.add_all`.
+
+    Args:
+        module: The module structure (as returned by
+            `create_swift_module_context`) extracted from the transitive
+            modules of a `SwiftInfo` provider.
+
+    Returns:
+        The `-swift-module-file` flag for the module's `.swiftmodule` file.
+    """
+    if module.swift and module.swift.swiftmodule:
+        return "-swift-module-file={name}={path}".format(
+            name = module.name,
+            path = module.swift.swiftmodule.path,
+        )
+    else:
+        return None
+
 def _module_alias_flags(name, original):
     """Returns compiler flags to set the given module alias."""
 
@@ -2119,7 +2153,7 @@ def _dependencies_swiftmodules_and_swiftdocs_configurator(prerequisites, args):
                  prerequisites.direct_swiftdocs,
     )
 
-def _dependencies_swiftmodules_configurator(prerequisites, args):
+def _dependencies_swiftmodule_search_paths_configurator(prerequisites, args):
     """Adds Swift dependency search paths and action inputs."""
     args.add_all(
         prerequisites.transitive_modules,
@@ -2127,6 +2161,26 @@ def _dependencies_swiftmodules_configurator(prerequisites, args):
         map_each = _swift_module_search_path_map_fn,
         uniquify = True,
     )
+
+    return ConfigResultInfo(
+        inputs = prerequisites.transitive_swift_dependency_inputs,
+    )
+
+def _dependencies_swiftmodules_configurator(prerequisites, args, is_frontend = False):
+    """Adds explicit Swift dependency module files and action inputs."""
+    if is_frontend:
+        args.add_all(
+            prerequisites.transitive_modules,
+            map_each = _swift_module_file_map_fn,
+            uniquify = True,
+        )
+    else:
+        args.add_all(
+            prerequisites.transitive_modules,
+            before_each = "-Xfrontend",
+            map_each = _swift_module_file_map_fn,
+            uniquify = True,
+        )
 
     return ConfigResultInfo(
         inputs = prerequisites.transitive_swift_dependency_inputs,

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -126,7 +126,7 @@ def features_test_suite(name, tags = []):
         tags = all_tags,
         expected_argv = [
             "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic",
+            "-Xfrontend -swift-module-file=first=$(BIN_DIR)/test/fixtures/basic/first.swiftmodule",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -138,7 +138,7 @@ def features_test_suite(name, tags = []):
         tags = all_tags,
         expected_argv = [
             "-emit-object",
-            "-I$(BIN_DIR)/test/fixtures/basic/first",
+            "-Xfrontend -swift-module-file=first=$(BIN_DIR)/test/fixtures/basic/first/first.swiftmodule",
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
         ],
         mnemonic = "SwiftCompile",
@@ -225,6 +225,7 @@ def features_test_suite(name, tags = []):
         ],
         not_expected_argv = [
             "-I$(BIN_DIR)/test/fixtures/basic",
+            "-swift-module-file=first",
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/basic:second",
@@ -249,6 +250,7 @@ def features_test_suite(name, tags = []):
         ],
         not_expected_argv = [
             "-I$(BIN_DIR)/test/fixtures/basic/second",
+            "-swift-module-file=first",
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/basic:second",

--- a/test/module_interface_tests.bzl
+++ b/test/module_interface_tests.bzl
@@ -17,6 +17,7 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load(
     "//test/rules:action_command_line_test.bzl",
+    "action_command_line_test",
     "make_action_command_line_test_rule",
 )
 load(
@@ -154,6 +155,20 @@ def module_interface_test_suite(name, tags = []):
             "ToyModule.swiftinterface",
             "DependentToyModule.swiftinterface",
         ],
+        target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
+    )
+
+    action_command_line_test(
+        name = "{}_compile_module_interface_uses_swift_module_file".format(name),
+        tags = all_tags,
+        expected_argv = [
+            "-swift-module-file=ToyModule=$(BIN_DIR)/test/fixtures/module_interface/toy_module_outs/ToyModule.swiftmodule",
+        ],
+        not_expected_argv = [
+            "-Xfrontend -swift-module-file=ToyModule",
+            "-I$(BIN_DIR)/test/fixtures/module_interface/toy_module_outs",
+        ],
+        mnemonic = "SwiftCompileModuleInterface",
         target_under_test = "//test/fixtures/module_interface:dependent_toy_module",
     )
 


### PR DESCRIPTION
When you have many -I flags the behavior previously was O(N^2) which
lead to slow compiles. We have the VFS overlay or explicit module map
features for this but sourcekit ignores those flags right now. This is a
different attempt at doing this in a way that works fine for Xcode
but doesn't have perf issues. This is also compatible with disabling
implicit modules
