### PR TITLE
Revert "Use -swift-module-file for explicit modules (#1787)"

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -130,8 +130,23 @@ def _explicit_swift_module_map_info(
     ):
         module_contexts = transitive_modules
         filename = "{}.swift-explicit-module-map.json".format(target_name)
+    elif is_feature_enabled(
+        feature_configuration = feature_configuration,
+        feature_name = SWIFT_FEATURE_USE_C_MODULES,
+    ):
+        # Keep non-system Swift deps on search paths, but include system
+        # modules to make sure everything loads them with the same behavior
+        module_contexts = [
+            module
+            for module in transitive_modules
+            if module.is_system
+        ]
+        if not module_contexts:
+            return struct(file = None, inputs = [])
+
+        filename = "{}.swift-system-explicit-module-map.json".format(target_name)
     else:
-        return None
+        return struct(file = None, inputs = [])
 
     explicit_swift_module_map_file = actions.declare_file(filename)
     write_explicit_swift_module_map_file(
@@ -139,7 +154,10 @@ def _explicit_swift_module_map_info(
         explicit_swift_module_map_file = explicit_swift_module_map_file,
         module_contexts = module_contexts,
     )
-    return explicit_swift_module_map_file
+    return struct(
+        file = explicit_swift_module_map_file,
+        inputs = transitive_swift_dependency_inputs(module_contexts),
+    )
 
 def create_compilation_context(defines, srcs, transitive_modules):
     """Cretes a compilation context for a Swift target.
@@ -325,7 +343,8 @@ def compile_module_interface(
         additional_inputs = additional_inputs,
         bin_dir = feature_configuration._bin_dir,
         cc_compilation_context = merged_compilation_context,
-        explicit_swift_module_map_file = explicit_swift_module_map_info,
+        explicit_swift_module_map_file = explicit_swift_module_map_info.file,
+        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs,
         genfiles_dir = feature_configuration._genfiles_dir,
         indexstore_directory = indexstore_directory,
         is_swift = True,
@@ -779,7 +798,8 @@ to use swift_common.compile(include_dev_srch_paths = ...) instead.\
         deps_modules_file = deps_modules_file,
         developer_dirs = toolchains.swift.developer_dirs,
         experimental_features = experimental_features,
-        explicit_swift_module_map_file = explicit_swift_module_map_info,
+        explicit_swift_module_map_file = explicit_swift_module_map_info.file,
+        explicit_swift_module_map_inputs = explicit_swift_module_map_info.inputs,
         genfiles_dir = feature_configuration._genfiles_dir,
         include_dev_srch_paths = include_dev_srch_paths_value,
         is_swift = True,

--- a/swift/internal/system_module_group.bzl
+++ b/swift/internal/system_module_group.bzl
@@ -17,13 +17,23 @@
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//swift:providers.bzl", "SwiftInfo", "create_swift_module_context")
+load(":system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
 load(":utils.bzl", "get_providers")
+
+def _inferred_module_name(ctx):
+    target_name = ctx.label.name
+    sdk_name = ctx.attr.sdk_name
+    if sdk_name:
+        prefix = sdk_name + "_"
+        if target_name.startswith(prefix):
+            return target_name[len(prefix):]
+    return target_name
 
 def _system_module_group_impl(ctx):
     modules = []
     if ctx.attr.creates_module:
         modules.append(create_swift_module_context(
-            name = ctx.label.name.split("_", 1)[-1],
+            name = _inferred_module_name(ctx),
             is_system = True,
         ))
 
@@ -39,13 +49,14 @@ def _system_module_group_impl(ctx):
     ]
 
 system_module_group = rule(
-    attrs = {
+    attrs = sdk_min_os_transition_attrs() | {
         "creates_module": attr.bool(
             default = True,
             doc = "Whether this group propagates a direct system module inferred from the target name.",
         ),
         "modules": attr.label_list(providers = [[CcInfo, SwiftInfo]]),
     },
+    cfg = sdk_min_os_transition,
     doc = """\
 Aggregates `system_clang_module` (and other `system_module_group`) targets,
 merging their `CcInfo` and `SwiftInfo` providers. Uses a `modules` attribute

--- a/swift/internal/system_module_transition.bzl
+++ b/swift/internal/system_module_transition.bzl
@@ -29,18 +29,20 @@ _SDK_NAME_TO_MIN_OS_OPTION = {
 def sdk_min_os_transition_attrs():
     return {
         "sdk_name": attr.string(
-            mandatory = True,
             doc = "The SDK name whose version should be used for `--minimum_os_version`.",
         ),
         "sdk_version": attr.string(
-            mandatory = True,
             doc = "The SDK version to use as the minimum OS version.",
         ),
     }
 
 def _sdk_min_os_transition_impl(settings, attr):
-    if not attr.sdk_name or not attr.sdk_version:
-        fail("sdk_name and sdk_version must be set.")
+    # Empty module group
+    if not attr.sdk_name:
+        return settings
+
+    if not attr.sdk_version:
+        fail("sdk_version must be set when sdk_name is set.")
 
     values = {option: settings[option] for option in _MIN_OS_OPTIONS}
     current_min_os_option = _SDK_NAME_TO_MIN_OS_OPTION.get(attr.sdk_name)

--- a/swift/internal/system_swiftinterface.bzl
+++ b/swift/internal/system_swiftinterface.bzl
@@ -24,7 +24,6 @@ load(
     "SWIFT_FEATURE_SYSTEM_MODULE",
     "SWIFT_FEATURE_USE_C_MODULES",
 )
-load("@build_bazel_rules_swift//swift/internal:system_module_transition.bzl", "sdk_min_os_transition", "sdk_min_os_transition_attrs")
 load("@build_bazel_rules_swift//swift/internal:toolchain_utils.bzl", "SWIFT_SDK_TOOLCHAIN_TYPE")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -100,11 +99,7 @@ def _system_swiftinterface_impl(ctx):
     ]
 
 system_swiftinterface = rule(
-    # NOTE: This makes sure transitions only changing the min OS don't
-    # duplicate this artifact, but the worker replaces the -target with the one
-    # hardcoded in the swiftinterface file anyways.
-    cfg = sdk_min_os_transition,
-    attrs = sdk_min_os_transition_attrs() | {
+    attrs = {
         "is_framework": attr.bool(
             default = False,
             doc = "Whether the compiled Swift interface represents a framework module.",

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -904,22 +904,22 @@ def compile_action_configs(
                 SWIFT_ACTION_DUMP_AST,
             ],
             configurators = [
-                _swift_module_file_dependencies_swiftmodules_configurator,
+                _explicit_swift_module_map_configurator,
             ],
             features = [SWIFT_FEATURE_USE_C_MODULES],
-            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
+            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],  # If this feature is enabled we still use this file just with more contents
         ),
         ActionConfigInfo(
             actions = [SWIFT_ACTION_COMPILE_MODULE_INTERFACE],
             configurators = [
-                lambda prerequisites, args: _swift_module_file_dependencies_swiftmodules_configurator(
+                lambda prerequisites, args: _explicit_swift_module_map_configurator(
                     prerequisites,
                     args,
                     is_frontend = True,
                 ),
             ],
             features = [SWIFT_FEATURE_USE_C_MODULES],
-            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],
+            not_features = [SWIFT_FEATURE_USE_EXPLICIT_SWIFT_MODULE_MAP],  # If this feature is enabled we still use this file just with more contents
         ),
         # TODO: Pass through system modules and pass this to all actions
         # ActionConfigInfo(
@@ -2071,48 +2071,6 @@ def _swift_module_search_path_map_fn(module):
     else:
         return None
 
-def _swift_module_file_map_fn(module):
-    """Returns a frontend flag that maps a module name to its `.swiftmodule`.
-
-    This function is intended to be used as a mapping function for modules
-    passed into `Args.add_all`.
-
-    Args:
-        module: The module structure (as returned by
-            `create_swift_module_context`) extracted from the transitive
-            modules of a `SwiftInfo` provider.
-
-    Returns:
-        The `-swift-module-file` flag for the module's `.swiftmodule` file.
-    """
-    if module.swift and module.swift.swiftmodule:
-        return "-swift-module-file={name}={path}".format(
-            name = module.name,
-            path = module.swift.swiftmodule.path,
-        )
-    else:
-        return None
-
-def _swift_module_file_dependencies_swiftmodules_configurator(prerequisites, args, is_frontend = False):
-    """Adds explicit Swift dependency module files and action inputs."""
-    if is_frontend:
-        args.add_all(
-            prerequisites.transitive_modules,
-            map_each = _swift_module_file_map_fn,
-            uniquify = True,
-        )
-    else:
-        args.add_all(
-            prerequisites.transitive_modules,
-            before_each = "-Xfrontend",
-            map_each = _swift_module_file_map_fn,
-            uniquify = True,
-        )
-
-    return ConfigResultInfo(
-        inputs = prerequisites.transitive_swift_dependency_inputs,
-    )
-
 def _module_alias_flags(name, original):
     """Returns compiler flags to set the given module alias."""
 
@@ -2238,6 +2196,9 @@ def _cross_import_overlays_configurator(prerequisites, args):
 
 def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = False):
     """Adds the explicit Swift module map file to the command line."""
+    if not prerequisites.explicit_swift_module_map_file:
+        return ConfigResultInfo()
+
     if is_frontend:
         args.add(
             prerequisites.explicit_swift_module_map_file,
@@ -2249,7 +2210,7 @@ def _explicit_swift_module_map_configurator(prerequisites, args, is_frontend = F
             format = "-Xwrapped-swift=-driver-explicit-swift-module-map-file=%s",
         )
     return ConfigResultInfo(
-        inputs = prerequisites.transitive_swift_dependency_inputs + [
+        inputs = prerequisites.explicit_swift_module_map_inputs + [
             prerequisites.explicit_swift_module_map_file,
         ],
     )

--- a/test/fixtures/precompiled_modules/BUILD
+++ b/test/fixtures/precompiled_modules/BUILD
@@ -194,6 +194,18 @@ transition_test(
     ],
 )
 
+transition_test(
+    name = "xctest_with_testing_no_modulemap_transitioned",
+    compilation_mode = "dbg",  # forces a different stack protector mode which can expose issues
+    tags = FIXTURE_TAGS,
+    target = ":xctest_with_testing",
+    transitive_features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+        # NOTE: Must not enable swift.use_explicit_swift_module_map which affects linking logic
+    ],
+)
+
 swift_binary(
     name = "available_testing_import",
     srcs = ["available_testing_import.swift"],

--- a/test/hermetic_pcm/BUILD
+++ b/test/hermetic_pcm/BUILD
@@ -162,8 +162,6 @@ system_swiftinterface(
         "@system_sdk//:_StringProcessing",
         "@system_sdk//:_SwiftConcurrencyShims",
     ],
-    sdk_name = "MacOSX",
-    sdk_version = "10.15",
     swiftinterface = "//test/fixtures/precompiled_modules:LowerVersionLib.swiftinterface",
     target_compatible_with = ["@platforms//os:macos"],
 )

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -176,6 +176,7 @@ def precompiled_modules_test_suite(name, tags = []):
             "//test/fixtures/precompiled_modules:min_os_bin_transitioned",
             "//test/fixtures/precompiled_modules:objc_interop_bin_transitioned",
             "//test/fixtures/precompiled_modules:xctest_with_testing_transitioned",
+            "//test/fixtures/precompiled_modules:xctest_with_testing_no_modulemap_transitioned",
         ] + [
             "//test/fixtures/precompiled_modules:" + t
             for t in CROSS_PLATFORM_TARGETS

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -31,17 +31,6 @@ _explicit_precompiled_modules_test = make_action_command_line_test_rule(
     },
 )
 
-_json_explicit_swift_modules_test = make_action_command_line_test_rule(
-    config_settings = {
-        "//command_line_option:features": [
-            "swift.use_c_modules",
-            "swift.emit_c_module",
-            "-swift.add_default_precompiled_modules",
-            "swift.use_explicit_swift_module_map",
-        ],
-    },
-)
-
 def precompiled_modules_test_suite(name, tags = []):
     """Test precompiled modules behavior.
 
@@ -164,7 +153,7 @@ def precompiled_modules_test_suite(name, tags = []):
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/precompiled_modules:linking_cross_import_overlay",
         expected_argv = [
-            "-Xfrontend -swift-module-file=Testing",
+            "-Xwrapped-swift=-driver-explicit-swift-module-map-file=$(BIN_DIR)/test/fixtures/precompiled_modules/linking_cross_import_overlay.swift-system-explicit-module-map.json",
             "-Xfrontend -disable-cross-import-overlay-search",
             "-Xfrontend -swift-module-cross-import -Xfrontend Testing -Xfrontend __BAZEL_XCODE_DEVELOPER_DIR__/Platforms/MacOSX.platform/Developer/Library/Frameworks/Testing.framework/Modules/Testing.swiftcrossimport/AppKit.swiftoverlay",
         ],
@@ -172,19 +161,6 @@ def precompiled_modules_test_suite(name, tags = []):
             ":has_testing_appkit_overlay": [],
             "//conditions:default": ["@platforms//:incompatible"],
         }),
-    )
-
-    _json_explicit_swift_modules_test(
-        name = "{}_json_explicit_swift_module_map_disables_swift_module_file_test".format(name),
-        tags = all_tags,
-        mnemonic = "SwiftCompile",
-        target_under_test = "//test/fixtures/precompiled_modules:linking_cross_import_overlay",
-        expected_argv = [
-            "-Xwrapped-swift=-driver-explicit-swift-module-map-file=$(BIN_DIR)/test/fixtures/precompiled_modules/linking_cross_import_overlay.swift-explicit-module-map.json",
-        ],
-        not_expected_argv = [
-            "-swift-module-file",
-        ],
     )
 
     build_test(

--- a/tools/explicit_modules/scan.py
+++ b/tools/explicit_modules/scan.py
@@ -167,6 +167,7 @@ def _render_clang_module_groups(
     modules: list["_Module"],
     clang_only_names: set[str],
     sdk: str,
+    sdk_version: str,
     out: TextIO,
 ):
     """Aggregate clang modules + their Swift overlays.
@@ -203,12 +204,14 @@ def _render_clang_module_groups(
                 deps.append(dep)
         _write_labels(out, set(deps))
         out.write("    ],\n")
+        _write_transition_attrs(out, sdk=sdk, sdk_version=sdk_version)
         out.write(")\n")
 
 
 def _render_all_modules_group(
     all_module_names: set[str],
     sdk: str,
+    sdk_version: str,
     out: TextIO,
 ) -> None:
     out.write("\n")
@@ -218,6 +221,7 @@ def _render_all_modules_group(
     out.write("    modules = [\n")
     _write_labels(out, {f"{sdk}_{name}" for name in all_module_names})
     out.write("    ],\n")
+    _write_transition_attrs(out, sdk=sdk, sdk_version=sdk_version)
     out.write(")\n")
 
 
@@ -377,13 +381,13 @@ class _Module:
                     name="system_swiftinterface",
                     values_by_cpu=self.swiftinterface_paths_by_cpu,
                 )
+            else:
+                self._render_deps(out)
                 _write_transition_attrs(
                     out,
                     sdk=self.sdk,
                     sdk_version=self.sdk_version,
                 )
-            else:
-                self._render_deps(out)
             out.write(")\n")
         else:
             raise SystemExit(
@@ -709,9 +713,10 @@ def _discover_all_modules(
         all_modules,
         clang_names - swift_names,
         sdk,
+        deployment_target,
         buf,
     )
-    _render_all_modules_group(all_module_names, sdk, buf)
+    _render_all_modules_group(all_module_names, sdk, deployment_target, buf)
 
     return buf.getvalue(), all_module_names | {f"{n}_clang" for n in clang_names}
 


### PR DESCRIPTION
This uncovered a new case of differing linker behavior with system
modules. I think we just have to use the json file for system stuff.

https://bazelbuild.slack.com/archives/C09TMF7SK5M/p1780345143085759

This reverts commit c9897bcd0cbd455bd2d2b45f70b0475424845051.
