### PR TITLE
Only pass system pcms through explicit json file

### DIFF
--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -359,6 +359,13 @@ bzl_library(
 )
 
 bzl_library(
+    name = "explicit_module_map_file",
+    srcs = ["explicit_module_map_file.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = ["@bazel_skylib//lib:paths"],
+)
+
+bzl_library(
     name = "action_names",
     srcs = ["action_names.bzl"],
     visibility = ["//swift:__subpackages__"],
@@ -368,13 +375,6 @@ bzl_library(
     name = "env_expansion",
     srcs = ["env_expansion.bzl"],
     visibility = ["//swift:__subpackages__"],
-)
-
-bzl_library(
-    name = "explicit_module_map_file",
-    srcs = ["explicit_module_map_file.bzl"],
-    visibility = ["//swift:__subpackages__"],
-    deps = ["@bazel_skylib//lib:paths"],
 )
 
 bzl_library(

--- a/swift/internal/BUILD
+++ b/swift/internal/BUILD
@@ -374,6 +374,7 @@ bzl_library(
     name = "explicit_module_map_file",
     srcs = ["explicit_module_map_file.bzl"],
     visibility = ["//swift:__subpackages__"],
+    deps = ["@bazel_skylib//lib:paths"],
 )
 
 bzl_library(

--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -14,6 +14,8 @@
 
 """Generates the JSON manifest used to pass Swift modules to the compiler."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
 def write_explicit_swift_module_map_file(
         *,
         actions,
@@ -32,49 +34,38 @@ def write_explicit_swift_module_map_file(
         module_contexts: A list of module contexts that provide the Swift
             dependencies for the compilation.
     """
+
+    # If a module has a clang + swift half, they are separate entries in the json file
     module_descriptions = {}
-
     for module_context in module_contexts:
-        # You can only have 1 entry per module name. If we have a system module
-        # that has both a clang and swift half, we need to merge them.
-        existing = module_descriptions.get(module_context.name)
-        module_description = existing or {
+        base_description = {
+            "isFramework": module_context.is_framework,
+            "isSystem": module_context.is_system,
             "moduleName": module_context.name,
-            "isFramework": False,
         }
-        if module_context.is_system:
-            module_description["isSystem"] = module_context.is_system
-        if module_context.is_framework:
-            module_description["isFramework"] = module_context.is_framework
 
-        has_swift_description = "modulePath" in module_description
-        if module_context.swift:
-            swift_context = module_context.swift
-            if swift_context.swiftmodule:
-                if type(swift_context.swiftmodule) == "File":
-                    swiftmodule_path = swift_context.swiftmodule.path
-                else:
-                    swiftmodule_path = swift_context.swiftmodule
-                has_swift_description = True
-                module_description["modulePath"] = swiftmodule_path
+        if module_context.swift and module_context.swift.swiftmodule:
+            if type(module_context.swift.swiftmodule) == "File":
+                swiftmodule_path = module_context.swift.swiftmodule.path
+            else:
+                swiftmodule_path = module_context.swift.swiftmodule
+            module_descriptions["swift:{}".format(module_context.name)] = base_description | {
+                "modulePath": swiftmodule_path,
+            }
 
-        has_clang_description = (
-            "clangModulePath" in module_description or
-            "clangModuleMapPath" in module_description
-        )
         if module_context.clang:
+            clang_description = {}
             clang_context = module_context.clang
             if clang_context.module_map:
-                if not module_context.is_system:
-                    # If path is not an attribute of `module_map`, then `module_map` is a string and we use it as our path.
-                    module_description["clangModuleMapPath"] = getattr(clang_context.module_map, "path", clang_context.module_map)
-                has_clang_description = True
+                # If path is not an attribute of `module_map`, then `module_map` is a string and we use it as our path.
+                path = getattr(clang_context.module_map, "path", clang_context.module_map)
+                if path and paths.is_absolute(path):
+                    fail("clang module map paths must be relative to the execroot, but got an absolute path: {}".format(path))
+                clang_description["clangModuleMapPath"] = getattr(clang_context.module_map, "path", clang_context.module_map)
             if clang_context.precompiled_module:
-                module_description["clangModulePath"] = clang_context.precompiled_module.path
-                has_clang_description = True
-
-        if has_swift_description or has_clang_description:
-            module_descriptions[module_context.name] = module_description
+                clang_description["clangModulePath"] = clang_context.precompiled_module.path
+            if clang_description:
+                module_descriptions["clang:{}".format(module_context.name)] = base_description | clang_description | {"isBridgingHeaderDependency": False}
 
     actions.write(
         content = json.encode(module_descriptions.values()),

--- a/swift/internal/explicit_module_map_file.bzl
+++ b/swift/internal/explicit_module_map_file.bzl
@@ -61,7 +61,7 @@ def write_explicit_swift_module_map_file(
                 path = getattr(clang_context.module_map, "path", clang_context.module_map)
                 if path and paths.is_absolute(path):
                     fail("clang module map paths must be relative to the execroot, but got an absolute path: {}".format(path))
-                clang_description["clangModuleMapPath"] = getattr(clang_context.module_map, "path", clang_context.module_map)
+                clang_description["clangModuleMapPath"] = path
             if clang_context.precompiled_module:
                 clang_description["clangModulePath"] = clang_context.precompiled_module.path
             if clang_description:

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1060,13 +1060,27 @@ def compile_action_configs(
         # whichever are being used for this build.
         ActionConfigInfo(
             actions = all_compile_action_names() + [
-                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_PRECOMPILE_C_MODULE,
                 SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [_dependencies_clang_modules_configurator],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ),
+        # These actions do not support reading system modules from the
+        # explicit module map json file
+        ActionConfigInfo(
+            actions = [
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
+                SWIFT_ACTION_PRECOMPILE_C_MODULE,
+            ],
+            configurators = [
+                lambda prerequisites, args: _dependencies_clang_modules_configurator(
+                    prerequisites,
+                    args,
+                    ignore_system = False,
+                ),
+            ],
             features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
         ActionConfigInfo(
@@ -1874,7 +1888,7 @@ def _clang_modulemap_dependency_args(module, ignore_system = True):
 
     return ["-fmodule-map-file={}".format(module_map_path)]
 
-def _clang_module_dependency_args(module):
+def _clang_module_dependency_args(module, ignore_system = True):
     """Returns `swiftc` arguments for a precompiled Clang module, if possible.
 
     If a precompiled module is present for this module, then flags for both it
@@ -1886,11 +1900,15 @@ def _clang_module_dependency_args(module):
     Args:
         module: A struct containing information about the module, as defined by
             `create_swift_module_context`.
+        ignore_system: If True system modules produce no arguments.
 
     Returns:
         A list of arguments, possibly empty, to pass to `swiftc` (without the
         `-Xcc` prefix).
     """
+    if module.is_system and ignore_system:
+        return []
+
     if module.clang.precompiled_module:
         # If we're consuming an explicit module, we must also provide the
         # textual module map, whether or not it's a system module.
@@ -1904,6 +1922,9 @@ def _clang_module_dependency_args(module):
         # If we have no explicit module, then only include module maps for
         # non-system modules.
         return _clang_modulemap_dependency_args(module)
+
+def _clang_module_dependency_args_include_system(module):
+    return _clang_module_dependency_args(module, ignore_system = False)
 
 def _dependencies_clang_modulemaps_configurator(prerequisites, args):
     """Configures Clang module maps from dependencies."""
@@ -1939,7 +1960,7 @@ def _dependencies_clang_modulemaps_configurator(prerequisites, args):
         prefer_precompiled_modules = False,
     )
 
-def _dependencies_clang_modules_configurator(prerequisites, args):
+def _dependencies_clang_modules_configurator(prerequisites, args, ignore_system = True):
     """Configures precompiled Clang modules from dependencies."""
     modules = [
         module
@@ -1950,10 +1971,11 @@ def _dependencies_clang_modules_configurator(prerequisites, args):
     # Uniquify the arguments because different modules might be defined in the
     # same module map file, so it only needs to be present once on the command
     # line.
+    mapper = _clang_module_dependency_args if ignore_system else _clang_module_dependency_args_include_system
     args.add_all(
         modules,
         before_each = "-Xcc",
-        map_each = _clang_module_dependency_args,
+        map_each = mapper,
         uniquify = True,
     )
 
@@ -2054,6 +2076,12 @@ def _swift_module_search_path_map_fn(module):
     Returns:
         The dirname of the module's `.swiftmodule` file.
     """
+
+    # System swiftmodule files always come through the explicit json file which
+    # affects linking behavior
+    if module.is_system:
+        return None
+
     if module.swift:
         swiftmodule = module.swift.swiftmodule
         if type(swiftmodule) == "File":

--- a/test/hermetic_pcm/check_hermetic_swiftmodule.sh
+++ b/test/hermetic_pcm/check_hermetic_swiftmodule.sh
@@ -23,7 +23,6 @@ else
     "-fno-implicit-modules"
     "-fno-implicit-module-maps"
     "-fmodule-file=Foundation="
-    "-fmodule-map-file=__bazel_developer_dir"
   )
 fi
 expected+=("$@")

--- a/test/precompiled_modules_tests.bzl
+++ b/test/precompiled_modules_tests.bzl
@@ -71,6 +71,9 @@ def precompiled_modules_test_suite(name, tags = []):
         }),
         target_under_test = "//test/fixtures/precompiled_modules:hello",
         expected_argv = [
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/precompiled_modules/hello.swift-system-explicit-module-map.json",
+        ],
+        not_expected_argv = [
             "-fmodule-file=Foundation",
             "-fmodule-file=SwiftShims",
         ],
@@ -86,10 +89,11 @@ def precompiled_modules_test_suite(name, tags = []):
         }),
         target_under_test = "//test/fixtures/precompiled_modules:hello",
         expected_argv = [
-            "-fmodule-file=SwiftShims",
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/precompiled_modules/hello.swift-system-explicit-module-map.json",
         ],
         not_expected_argv = [
             "-fmodule-file=Foundation",
+            "-fmodule-file=SwiftShims",
         ],
     )
 
@@ -99,6 +103,9 @@ def precompiled_modules_test_suite(name, tags = []):
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/precompiled_modules:hello_with_explicit_deps_bin",
         expected_argv = [
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/precompiled_modules/hello_with_explicit_deps_bin.swift-system-explicit-module-map.json",
+        ],
+        not_expected_argv = [
             "-fmodule-file=Foundation",
             "-fmodule-file=SwiftShims",
         ],
@@ -114,6 +121,9 @@ def precompiled_modules_test_suite(name, tags = []):
         }),
         target_under_test = "//test/fixtures/precompiled_modules:stub_plugin",
         expected_argv = [
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/precompiled_modules/stub_plugin.swift-system-explicit-module-map.json",
+        ],
+        not_expected_argv = [
             "-fmodule-file=Foundation",
             "-fmodule-file=SwiftShims",
         ],
@@ -125,6 +135,9 @@ def precompiled_modules_test_suite(name, tags = []):
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/precompiled_modules:c_module_imports",
         expected_argv = [
+            "-Xfrontend -explicit-swift-module-map-file -Xfrontend $(BIN_DIR)/test/fixtures/precompiled_modules/c_module_imports.swift-system-explicit-module-map.json",
+        ],
+        not_expected_argv = [
             "-fmodule-file=Compression",
             "-fmodule-file=SQLite3",
             "-fmodule-file=zlib",


### PR DESCRIPTION
The explicit swift module map json file contains swiftmodules, but also pcms.
This is what Xcode does as well. The only exception is the 2 actions that don't
support reading these right now. This massively reduces the command line size
which matters for rules_xcodeproj which grabs all the args and puts them in the
xcodeproj file. Even if you don't opt into this feature you get this logic for
system dependencies since not using the json file results in linking failures
in somes cases.
