### PR TITLE
Fix BareSlashRegexLiterals warning

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1298,15 +1298,7 @@ def compile_action_configs(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
             ],
-            configurators = [
-                # Unconditionally enable this in Swift 5 mode, but not in Swift
-                # 6 mode (since it is enabled by default in Swift 6, and passing
-                # this flag causes an annoying warning).
-                add_arg("-enable-upcoming-feature", "BareSlashRegexLiterals"),
-            ],
-            not_features = [
-                SWIFT_FEATURE_ENABLE_V6,
-            ],
+            configurators = [add_arg("-enable-bare-slash-regex")],
         ),
         ActionConfigInfo(
             actions = all_compile_action_names(),


### PR DESCRIPTION
In recent Swift 6 versions passing
`-enable-upcoming-feature BareSlashRegexLiterals` started warning. The
older version of this flag `-enable-bare-slash-regex` works for Swift 5
and Swift 6 without warning. This older version is apparently deprecated
but likely by the time it's removed we won't care about passing this.

This is still enabled always for Swift 5 mode

Partially reverts 2ae90cd6c151c519d3ea564c96c0847ea904dc2c
