### PR TITLE
Allow suppression aspect hints to override rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,8 @@ licenses(["notice"])
 
 exports_files(["LICENSE"])
 
+# gazelle:exclude test
+
 # Consumed by Bazel integration tests (such as those defined in rules_apple).
 filegroup(
     name = "for_bazel_tests",

--- a/swift/swift_clang_module_aspect.bzl
+++ b/swift/swift_clang_module_aspect.bzl
@@ -689,7 +689,8 @@ def _find_swift_interop_info(target, aspect_ctx):
         if SwiftOverlayCompileInfo in hint:
             found_overlay = True
         if SwiftInteropInfo in hint:
-            if interop_target:
+            overrides = hint[SwiftInteropInfo].suppressed
+            if not overrides and interop_target:
                 if interop_from_rule:
                     fail(("Conflicting Swift interop info from the target " +
                           "'{target}' ({rule} rule) and the aspect hint " +
@@ -706,6 +707,7 @@ def _find_swift_interop_info(target, aspect_ctx):
                         hint2 = str(hint.label),
                     ))
             interop_target = hint
+            break
 
     if interop_target:
         return interop_target[SwiftInteropInfo], default_swift_infos

--- a/test/fixtures/interop_hints/BUILD
+++ b/test/fixtures/interop_hints/BUILD
@@ -13,6 +13,10 @@ load(
     "FIXTURE_TAGS",
     "forward_swift_info_from_swift_clang_module_aspect",
 )
+load(
+    ":custom_interop_rule.bzl",
+    "custom_interop_rule",
+)
 
 package(
     default_visibility = ["//test:__subpackages__"],
@@ -124,5 +128,17 @@ objc_library(
 swift_library(
     name = "empty_lib",
     srcs = ["Empty.swift"],
+    tags = FIXTURE_TAGS,
+)
+
+forward_swift_info_from_swift_clang_module_aspect(
+    name = "custom_interop_rule_suppressed",
+    tags = FIXTURE_TAGS,
+    target = ":custom_interop_rule_suppressed_lib",
+)
+
+custom_interop_rule(
+    name = "custom_interop_rule_suppressed_lib",
+    aspect_hints = ["//swift:no_module"],
     tags = FIXTURE_TAGS,
 )

--- a/test/fixtures/interop_hints/BUILD
+++ b/test/fixtures/interop_hints/BUILD
@@ -1,4 +1,3 @@
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
@@ -142,13 +141,4 @@ custom_interop_rule(
     name = "custom_interop_rule_suppressed_lib",
     aspect_hints = ["//swift:no_module"],
     tags = FIXTURE_TAGS,
-)
-
-bzl_library(
-    name = "custom_interop_rule",
-    srcs = ["custom_interop_rule.bzl"],
-    deps = [
-        "//swift:swift_interop_info",
-        "@rules_cc//cc/common:cc_info",
-    ],
 )

--- a/test/fixtures/interop_hints/BUILD
+++ b/test/fixtures/interop_hints/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:objc_library.bzl", "objc_library")
 load(
@@ -141,4 +142,13 @@ custom_interop_rule(
     name = "custom_interop_rule_suppressed_lib",
     aspect_hints = ["//swift:no_module"],
     tags = FIXTURE_TAGS,
+)
+
+bzl_library(
+    name = "custom_interop_rule",
+    srcs = ["custom_interop_rule.bzl"],
+    deps = [
+        "//swift:swift_interop_info",
+        "@rules_cc//cc/common:cc_info",
+    ],
 )

--- a/test/fixtures/interop_hints/custom_interop_rule.bzl
+++ b/test/fixtures/interop_hints/custom_interop_rule.bzl
@@ -1,0 +1,14 @@
+"""A custom rule fixture that directly returns Swift interop info."""
+
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("//swift:swift_interop_info.bzl", "create_swift_interop_info")
+
+def _custom_interop_rule_impl(_ctx):
+    return [
+        CcInfo(),
+        create_swift_interop_info(),
+    ]
+
+custom_interop_rule = rule(
+    implementation = _custom_interop_rule_impl,
+)

--- a/test/interop_hints_tests.bzl
+++ b/test/interop_hints_tests.bzl
@@ -82,6 +82,15 @@ def interop_hints_test_suite(name, tags = []):
         target_compatible_with = ["@platforms//os:macos"],
     )
 
+    # Verify that a suppressing aspect hint can override interop info returned
+    # directly from a custom rule.
+    provider_test(
+        name = "{}_custom_rule_interop_info_suppressed".format(name),
+        does_not_propagate_provider = "SwiftInfo",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/interop_hints:custom_interop_rule_suppressed",
+    )
+
     native.test_suite(
         name = name,
         tags = all_tags,


### PR DESCRIPTION
Rules like apple_framework_import automatically add swift_interop_info.
If you only consume those rules from objc/c/c++, and they aren't able to
create valid PCMs, you can now mark them with:

```bzl
    aspect_hints = ["@rules_swift//swift:no_module"],
```

Previously this failed because we were careful that only 1
SwiftInteropInfo could be used. Now if one of the aspect hints
suppresses Swift module creation we make that one win.
