### PR TITLE
Stop registering Swift toolchains transitively

### DIFF
--- a/.github/generate-notes.sh
+++ b/.github/generate-notes.sh
@@ -15,5 +15,7 @@ This release is compatible with: TODO
 
 \`\`\`bzl
 bazel_dep(name = "rules_swift", version = "$new_version")
+
+register_toolchains("@rules_swift//swift/toolchains:all")
 \`\`\`
 EOF

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,10 @@ use_repo(
 apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
 use_repo(apple_cc_configure, "local_config_apple_cc")
 
-register_toolchains("//swift/toolchains:all")
+register_toolchains(
+    "//swift/toolchains:all",
+    dev_dependency = True,
+)
 
 system_sdk = use_extension("//swift:extensions.bzl", "system_sdk")
 system_sdk.configure_sdks(

--- a/README.md
+++ b/README.md
@@ -62,7 +62,16 @@ also ensure that the Swift compiler is available on your system path.
 
 ### 2. Configure your workspace
 
-Copy the `MODULE.bazel` snippet from [the releases page](https://github.com/bazelbuild/rules_swift/releases).
+`rules_swift` does not register its autoconfigured Swift toolchains in
+dependent modules. Copy the `MODULE.bazel` snippet from
+[the releases page](https://github.com/bazelbuild/rules_swift/releases), which
+registers the Swift toolchains for the Swift installation on your host. If you
+maintain your `MODULE.bazel` manually, register the toolchains after the
+`bazel_dep`:
+
+```bzl
+register_toolchains("@rules_swift//swift/toolchains:all")
+```
 
 ### 3. Additional configuration (Linux only)
 


### PR DESCRIPTION
## Summary

It's bad practice for rules to autoregister toolchains, as it takes away control from end users and can cause undesired fetches. Especially when the toolchain in question triggers non-hermetic repo rule executions.

Mark `//swift/toolchains:all` registration in `rules_swift`'s `MODULE.bazel` as a development dependency. Dependent Bazel modules no longer inherit the autoconfigured Swift toolchain registration and must explicitly register `@rules_swift//swift/toolchains:all`.

Update `README.md` and `.github/generate-notes.sh` so release snippets include the required explicit registration. `rules_swift` development continues to register `//swift/toolchains:all` because `rules_swift` is the root module during development.