### PR TITLE
Remove file_prefix_map disable from embedded setup

### DIFF
--- a/swift/internal/extensions/BUILD.bazel.tpl
+++ b/swift/internal/extensions/BUILD.bazel.tpl
@@ -165,7 +165,6 @@ swift_toolchain(
         "swift.enable_embedded",
         "swift.no_embed_debug_module",
         "swift.use_autolink_extract",
-        "-swift.file_prefix_map",
     ],
     os = "none",
     parsed_version = "{swift_version}",
@@ -183,7 +182,6 @@ swift_toolchain(
         "swift._supports_upcoming_features",
         "swift.no_embed_debug_module",
         "swift.use_autolink_extract",
-        "-swift.file_prefix_map",
     ],
     os = select({
         "@platforms//os:linux": "linux",


### PR DESCRIPTION
Embedded builds with swift toolchains don't have DEVELOPER_DIR
replacements, previously we had to disable this to avoid an assertion
because of DEVELOPER_DIR not being set. Fixed by f84686f4523c827f27edf1c07f2497fbc060e3e9