### PR TITLE
Move developer dir remapping to features

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -488,7 +488,7 @@ def _all_action_configs(
                 ),
             ],
             features = [
-                [SWIFT_FEATURE_REMAP_XCODE_PATH, SWIFT_FEATURE_DEBUG_PREFIX_MAP],
+                [SWIFT_FEATURE_REMAP_XCODE_PATH, SWIFT_FEATURE_DEBUG_PREFIX_MAP, SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR],
             ],
         ),
         ActionConfigInfo(
@@ -507,6 +507,7 @@ def _all_action_configs(
                     SWIFT_FEATURE_REMAP_XCODE_PATH,
                     SWIFT_FEATURE_COVERAGE_PREFIX_MAP,
                     SWIFT_FEATURE_COVERAGE,
+                    SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR,
                 ],
             ],
         ),
@@ -524,6 +525,7 @@ def _all_action_configs(
             features = [
                 SWIFT_FEATURE_FILE_PREFIX_MAP,
                 SWIFT_FEATURE_REMAP_XCODE_PATH,
+                SWIFT_FEATURE__SUPPORTS_DEVELOPER_DIR,
             ],
         ),
     ])

--- a/test/coverage_settings_tests.bzl
+++ b/test/coverage_settings_tests.bzl
@@ -29,6 +29,16 @@ coverage_xcode_prefix_map_test = make_action_command_line_test_rule(
     },
 )
 
+unsupported_developer_dir_coverage_xcode_prefix_map_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:collect_code_coverage": "true",
+        "//command_line_option:features": [
+            "-swift._supports_developer_dir",
+            "swift.remap_xcode_path",
+        ],
+    },
+)
+
 def coverage_settings_test_suite(name, tags = []):
     """Test suite for coverage options.
 
@@ -59,6 +69,7 @@ def coverage_settings_test_suite(name, tags = []):
         ],
         not_expected_argv = [
             "-Xwrapped-swift=-coverage-prefix-pwd-is-dot",
+            "-coverage-prefix-map",
         ],
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/debug_settings:simple",
@@ -69,6 +80,17 @@ def coverage_settings_test_suite(name, tags = []):
         tags = all_tags,
         expected_argv = [
             "-coverage-prefix-map",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
+        ],
+        target_compatible_with = ["@platforms//os:macos"],
+        mnemonic = "SwiftCompile",
+        target_under_test = "//test/fixtures/debug_settings:simple",
+    )
+
+    unsupported_developer_dir_coverage_xcode_prefix_map_test(
+        name = "{}_xcode_prefix_map_unsupported_developer_dir".format(name),
+        tags = all_tags,
+        not_expected_argv = [
             "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],

--- a/test/debug_settings_tests.bzl
+++ b/test/debug_settings_tests.bzl
@@ -97,6 +97,17 @@ xcode_remap_command_line_test = make_action_command_line_test_rule(
     },
 )
 
+unsupported_developer_dir_xcode_remap_command_line_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:features": [
+            "-swift._supports_developer_dir",
+            "swift.debug_prefix_map",
+            "swift.remap_xcode_path",
+        ],
+    },
+)
+
 def debug_settings_test_suite(name, tags = []):
     """Test suite for serializing debugging options.
 
@@ -232,6 +243,17 @@ def debug_settings_test_suite(name, tags = []):
         name = "{}_remap_xcode_path".format(name),
         expected_argv = [
             "-debug-prefix-map",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
+        ],
+        target_compatible_with = ["@platforms//os:macos"],
+        mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/debug_settings:simple",
+    )
+
+    unsupported_developer_dir_xcode_remap_command_line_test(
+        name = "{}_remap_xcode_path_unsupported_developer_dir".format(name),
+        not_expected_argv = [
             "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -44,6 +44,14 @@ disabled_file_prefix_map_test = make_action_command_line_test_rule(
     },
 )
 
+unsupported_developer_dir_file_prefix_map_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:features": [
+            "-swift._supports_developer_dir",
+        ],
+    },
+)
+
 use_global_index_store_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
@@ -161,6 +169,17 @@ def features_test_suite(name, tags = []):
         expected_argv = [
             "-Xwrapped-swift=-file-prefix-pwd-is-dot",
             "-file-prefix-map",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
+        ],
+        target_compatible_with = ["@platforms//os:macos"],
+        mnemonic = "SwiftCompile",
+        target_under_test = "//test/fixtures/debug_settings:simple",
+    )
+
+    unsupported_developer_dir_file_prefix_map_test(
+        name = "{}_file_prefix_xcode_remap_unsupported_developer_dir_test".format(name),
+        tags = all_tags,
+        not_expected_argv = [
             "__BAZEL_XCODE_DEVELOPER_DIR__=/PLACEHOLDER_DEVELOPER_DIR",
         ],
         target_compatible_with = ["@platforms//os:macos"],

--- a/tools/worker/swift_runner.cc
+++ b/tools/worker/swift_runner.cc
@@ -585,14 +585,6 @@ bool SwiftRunner::ProcessArgument(
     // we didn't know at analysis time.
     consumer(flag);
     consumer(std::filesystem::current_path().string() + "=" + new_path);
-
-#if __APPLE__
-    std::string developer_dir = "__BAZEL_XCODE_DEVELOPER_DIR__";
-    if (bazel_placeholder_substitutions_.Apply(developer_dir)) {
-      consumer(flag);
-      consumer(developer_dir + "=/PLACEHOLDER_DEVELOPER_DIR");
-    }
-#endif
   };
 
   // `-Xwrapped-swift=` arguments are consumed entirely by the worker and are


### PR DESCRIPTION
This makes us correctly support the disabled developer dir feature for
swift.org toolchains for android / embedded
