### PR TITLE
Correctly forward external_include_paths to swift compiler

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,4 +50,7 @@ build --per_file_copt="external/.*zlib.*/.*.c@-Wno-deprecated-non-prototype"
 build --per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 build --host_per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 
+# ignore warnings in external CC dependencies
+build --features="external_include_paths"
+
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -51,6 +51,6 @@ build --per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 build --host_per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 
 # ignore warnings in external CC dependencies
-build --features="external_include_paths"
+build --features=external_include_paths --host_features=external_include_paths
 
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -54,7 +54,7 @@ build --host_per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 build --features=external_include_paths --host_features=external_include_paths
 
 # MSVC ignores `/external:I` flag (given by "--features=external_include_paths") if also doesn't get the `/external:W<level>` flag which is
-# unfortunately not added by bazel by default. This is a workaround to add the `/external:W0` flag to all MSVC builds, which will ignore warnings in external dependencies.
-build:windows --copt="/external:W0"
+# unfortunately not added by bazel by default. Adding it with `--copt` doesn't work, so we'll simply disable this feature on windows.
+build:windows --features=-external_include_paths --host_features=-external_include_paths
 
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -53,4 +53,8 @@ build --host_per_file_copt="external/.*protobuf.*/.*@-Wno-unused-private-field"
 # ignore warnings in external CC dependencies
 build --features=external_include_paths --host_features=external_include_paths
 
+# MSVC ignores `/external:I` flag (given by "--features=external_include_paths") if also doesn't get the `/external:W<level>` flag which is
+# unfortunately not added by bazel by default. This is a workaround to add the `/external:W0` flag to all MSVC builds, which will ignore warnings in external dependencies.
+build:windows --copt="/external:W0"
+
 try-import %workspace%/user.bazelrc

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -1773,6 +1773,12 @@ def _clang_search_paths_configurator(prerequisites, args):
         format_each = "-isystem%s",
     )
 
+    args.add_all(
+        prerequisites.cc_compilation_context.external_includes,
+        before_each = "-Xcc",
+        format_each = "-isystem%s",
+    )
+
 def _dependencies_clang_defines_configurator(prerequisites, args):
     """Adds C/C++ dependencies' preprocessor defines to the command line."""
     all_clang_defines = depset(transitive = [

--- a/test/cc_library_tests.bzl
+++ b/test/cc_library_tests.bzl
@@ -63,6 +63,16 @@ def cc_library_test_suite(name, tags = []):
         tags = all_tags,
     )
 
+    # Verify that Swift can import a `cc_library` that ignores warnings in headers coming
+    # from external dependencies.
+    build_test(
+        name = "{}_swift_imports_cc_library_with_external_dependencies".format(name),
+        targets = [
+            "//test/fixtures/cc_library:import_external_cpp_dependency",
+        ],
+        tags = all_tags,
+    )
+
     explicit_module_map_pcm_test(
         name = "{}_explicit_module_map_omits_cc_library_pcm_argument".format(name),
         expected_argv = [

--- a/test/fixtures/cc_library/BUILD
+++ b/test/fixtures/cc_library/BUILD
@@ -64,6 +64,19 @@ cc_library(
     tags = FIXTURE_TAGS,
 )
 
+cc_library(
+    name = "external_cpp_dependency",
+    hdrs = [
+        "external_header.hpp",
+    ],
+    aspect_hints = ["//swift:auto_module"],
+    tags = FIXTURE_TAGS,
+    deps = [
+        "@nlohmann_json//:singleheader-json",
+    ],
+)
+
+
 swift_interop_hint(
     name = "prefix_and_strip_prefix_with_exclusion_swift_hint",
     exclude_hdrs = ["header_with_error.h"],
@@ -96,4 +109,14 @@ swift_library(
     srcs = ["ImportPrefixAndStripPrefixWithExclusion.swift"],
     tags = FIXTURE_TAGS,
     deps = [":prefix_and_strip_prefix_with_exclusion"],
+)
+
+swift_library(
+    name = "import_external_cpp_dependency",
+    srcs = ["ImportExternalDependency.swift"],
+    tags = FIXTURE_TAGS,
+    deps = [":external_cpp_dependency"],
+    features = [
+        "swift.enable_cpp23_interop",
+    ],
 )

--- a/test/fixtures/cc_library/BUILD
+++ b/test/fixtures/cc_library/BUILD
@@ -76,7 +76,6 @@ cc_library(
     ],
 )
 
-
 swift_interop_hint(
     name = "prefix_and_strip_prefix_with_exclusion_swift_hint",
     exclude_hdrs = ["header_with_error.h"],
@@ -114,9 +113,9 @@ swift_library(
 swift_library(
     name = "import_external_cpp_dependency",
     srcs = ["ImportExternalDependency.swift"],
-    tags = FIXTURE_TAGS,
-    deps = [":external_cpp_dependency"],
     features = [
         "swift.enable_cpp23_interop",
     ],
+    tags = FIXTURE_TAGS,
+    deps = [":external_cpp_dependency"],
 )

--- a/test/fixtures/cc_library/ImportExternalDependency.swift
+++ b/test/fixtures/cc_library/ImportExternalDependency.swift
@@ -1,0 +1,3 @@
+import test_fixtures_cc_library_external_cpp_dependency
+
+func f(_ x: Test.json) {}

--- a/test/fixtures/cc_library/external_header.hpp
+++ b/test/fixtures/cc_library/external_header.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cerrno>
+#include <streambuf>
+
+#include <nlohmann/json.hpp>
+
+namespace Test
+{
+using json = nlohmann::json;
+}


### PR DESCRIPTION
This fix (authored by codex) fixes the building of swift code that depends on C++ code that has `external_include_paths` feature enabled.