### PR TITLE
Remove toolchain_name from sdk module extensions

### DIFF
--- a/doc/standalone_toolchain.md
+++ b/doc/standalone_toolchain.md
@@ -151,9 +151,9 @@ bazel run @rules_swift//tools/swift-releases -- list \
 The `swift` module extension can be used to download the Swift Android
 SDK for writing NDK code in Swift.
 
-Add the `android_sdk` tag, referencing the `toolchain` tag by name (the
-Swift module format is not stable across compiler versions, so the SDK
-is always downloaded for exactly the toolchain's version):
+Add the `android_sdk` tag alongside the `toolchain` tag (the Swift module
+format is not stable across compiler versions, so the SDK is always downloaded
+for exactly the toolchain's version):
 
 ```bzl
 swift.toolchain(
@@ -161,7 +161,7 @@ swift.toolchain(
     swift_version = "6.3.2",
 )
 
-swift.android_sdk(toolchain_name = "swift_toolchain")
+swift.android_sdk()
 
 # rules_swift provides only the Swift toolchain; register an Android C/C++ cc
 # toolchain too. For example, @androidndk//:all from hermetic_android_toolchains:
@@ -209,12 +209,17 @@ The `swift` module extension can also download the Swift WebAssembly SDK,
 which defines matching Swift and C/C++ toolchains targeting
 `wasm32-unknown-wasip1`.
 
-Add the `wasm_sdk` tag, referencing the `toolchain` tag by name (the Swift
-module format is not stable across compiler versions, so the SDK is always
-downloaded for exactly the toolchain's version):
+Add the `wasm_sdk` tag alongside the `toolchain` tag (the Swift module format
+is not stable across compiler versions, so the SDK is always downloaded for
+exactly the toolchain's version):
 
 ```bzl
-swift.wasm_sdk(toolchain_name = "swift_toolchain")
+swift.toolchain(
+    name = "swift_toolchain",
+    swift_version = "6.3.2",
+)
+
+swift.wasm_sdk()
 
 register_toolchains(
     "@swift_toolchain//:swift_toolchain_wasm32_xcode",

--- a/examples/cross_compilation/android_app/android.MODULE.bazel
+++ b/examples/cross_compilation/android_app/android.MODULE.bazel
@@ -6,7 +6,7 @@ bazel_dep(name = "rules_jvm_external", version = "7.0", dev_dependency = True)
 bazel_dep(name = "rules_kotlin", version = "2.2.2", dev_dependency = True)
 
 swift = use_extension("//swift:extensions.bzl", "swift", dev_dependency = True)
-swift.android_sdk(toolchain_name = "swift_toolchain")
+swift.android_sdk()
 
 rules_java_toolchains = use_extension(
     "@rules_java//java:extensions.bzl",

--- a/examples/cross_compilation/android_app/android.MODULE.bazel
+++ b/examples/cross_compilation/android_app/android.MODULE.bazel
@@ -8,6 +8,16 @@ bazel_dep(name = "rules_kotlin", version = "2.2.2", dev_dependency = True)
 swift = use_extension("//swift:extensions.bzl", "swift", dev_dependency = True)
 swift.android_sdk()
 
+# TODO: Remove once https://github.com/bazelbuild/rules_android/commit/57ad9e4898b726c3938c5173a3f3f9adef9384dc is in a release
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-koIx40jK5V/o9qC8zaOc5Jbgp+nY7QG0dpak9FT4VWA=",
+    strip_prefix = "rules_android-71c053c203ea875f069092b989d4704ddecb5caf",
+    urls = [
+        "https://github.com/bazelbuild/rules_android/archive/71c053c203ea875f069092b989d4704ddecb5caf.tar.gz",
+    ],
+)
+
 rules_java_toolchains = use_extension(
     "@rules_java//java:extensions.bzl",
     "toolchains",

--- a/examples/cross_compilation/wasm/wasm.MODULE.bazel
+++ b/examples/cross_compilation/wasm/wasm.MODULE.bazel
@@ -1,5 +1,5 @@
 swift = use_extension("//swift:extensions.bzl", "swift", dev_dependency = True)
-swift.wasm_sdk(toolchain_name = "swift_toolchain")
+swift.wasm_sdk()
 
 register_toolchains(
     # We register only the host platforms used by CI rather than

--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -120,17 +120,14 @@ def _setup_wasm_sdk(*, tag, toolchain_name, swift_version, platforms, swift_sdk_
         )
     return build_file_content
 
-def _sdk_tags_by_toolchain_name(tags, kind):
-    """Groups SDK tags by the toolchain they extend, rejecting duplicates."""
-    tags_by_name = {}
+def _single_sdk_tag(tags, kind):
+    """Returns the SDK tag if present, rejecting duplicates."""
+    sdk_tag = None
     for tag in tags:
-        if tag.toolchain_name in tags_by_name:
-            fail("Only one `{}` tag may be used per toolchain, got multiple for `{}`.".format(
-                kind,
-                tag.toolchain_name,
-            ))
-        tags_by_name[tag.toolchain_name] = tag
-    return tags_by_name
+        if sdk_tag != None:
+            fail("Only one `{}` tag may be used.".format(kind))
+        sdk_tag = tag
+    return sdk_tag
 
 def _standalone_toolchain_impl(module_ctx):
     root_module = None
@@ -148,31 +145,23 @@ def _standalone_toolchain_impl(module_ctx):
     swift_releases = swift_release_metadata["toolchains"]
     swift_sdk_releases = swift_release_metadata["sdks"]
 
-    android_sdk_tags = _sdk_tags_by_toolchain_name(
+    android_sdk_tag = _single_sdk_tag(
         root_module.tags.android_sdk,
         "android_sdk",
     )
-    wasm_sdk_tags = _sdk_tags_by_toolchain_name(
+    wasm_sdk_tag = _single_sdk_tag(
         root_module.tags.wasm_sdk,
         "wasm_sdk",
     )
 
-    toolchain_names = [
-        toolchain.name
-        for toolchain in root_module.tags.toolchain
-    ]
-    for toolchain_name in android_sdk_tags:
-        if toolchain_name not in toolchain_names:
-            fail("The `android_sdk` tag references unknown toolchain `{}`. Please use the name of a `toolchain` tag: {}".format(
-                toolchain_name,
-                toolchain_names,
-            ))
-    for toolchain_name in wasm_sdk_tags:
-        if toolchain_name not in toolchain_names:
-            fail("The `wasm_sdk` tag references unknown toolchain `{}`. Please use the name of a `toolchain` tag: {}".format(
-                toolchain_name,
-                toolchain_names,
-            ))
+    if len(root_module.tags.toolchain) > 1:
+        fail("swift.toolchain() can currently only be called once. Please file an issue if you need multiple toolchains in a single module.")
+
+    if not root_module.tags.toolchain:
+        if android_sdk_tag:
+            fail("The `android_sdk` tag requires a `toolchain` tag.")
+        if wasm_sdk_tag:
+            fail("The `wasm_sdk` tag requires a `toolchain` tag.")
 
     toolchains_build_file_content = ""
     for toolchain in root_module.tags.toolchain:
@@ -207,17 +196,17 @@ def _standalone_toolchain_impl(module_ctx):
             )
 
         platforms = [platform for platform, _ in toolchain_releases]
-        if toolchain.name in android_sdk_tags:
+        if android_sdk_tag:
             toolchains_build_file_content += _setup_android_sdk(
-                tag = android_sdk_tags[toolchain.name],
+                tag = android_sdk_tag,
                 toolchain_name = toolchain.name,
                 swift_version = swift_version,
                 platforms = platforms,
                 swift_sdk_releases = swift_sdk_releases,
             )
-        if toolchain.name in wasm_sdk_tags:
+        if wasm_sdk_tag:
             toolchains_build_file_content += _setup_wasm_sdk(
-                tag = wasm_sdk_tags[toolchain.name],
+                tag = wasm_sdk_tag,
                 toolchain_name = toolchain.name,
                 swift_version = swift_version,
                 platforms = platforms,
@@ -239,10 +228,6 @@ The expected SHA-256 of the SDK artifact bundle. May be omitted for Swift
 versions known to this version of rules_swift.
 """,
         ),
-        "toolchain_name": attr.string(
-            doc = "The name of the `toolchain` tag to add this Swift SDK to.",
-            mandatory = True,
-        ),
     },
     doc = """\
 Downloads the Android Swift SDK matching a `toolchain` tag's Swift version and
@@ -257,10 +242,6 @@ _wasm_sdk = tag_class(
 The expected SHA-256 of the SDK artifact bundle. May be omitted for Swift
 versions known to this version of rules_swift.
 """,
-        ),
-        "toolchain_name": attr.string(
-            doc = "The name of the `toolchain` tag to add this Swift SDK to.",
-            mandatory = True,
         ),
     },
     doc = """\


### PR DESCRIPTION
Currently the main toolchain() extension fails if you call it more than
once, so there is only ever 1 name. If we ever allow multiple names we
can add something like this back but should potentially use the version
instead to dedup.
