### PR TITLE
Rename toolchain template BUILD file

### DIFF
--- a/swift/internal/extensions/BUILD.bazel
+++ b/swift/internal/extensions/BUILD.bazel
@@ -1,10 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(
-    ["BUILD.bazel.tpl"],
-    visibility = ["//visibility:public"],
-)
-
 bzl_library(
     name = "standalone_toolchain",
     srcs = ["standalone_toolchain.bzl"],

--- a/swift/internal/extensions/standalone_toolchain.bzl
+++ b/swift/internal/extensions/standalone_toolchain.bzl
@@ -100,8 +100,6 @@ def _standalone_toolchain_impl(repository_ctx):
         "BUILD.bazel",
         repository_ctx.attr._build_template,
         substitutions = {
-            "{exec_os}": repository_ctx.os.name,
-            "{exec_arch}": repository_ctx.os.arch,
             "{swift_version}": repository_ctx.attr.swift_version,
         },
     )
@@ -110,7 +108,7 @@ standalone_toolchain = repository_rule(
     implementation = _standalone_toolchain_impl,
     attrs = {
         "_build_template": attr.label(
-            default = "//swift/internal/extensions:BUILD.bazel.tpl",
+            default = "//swift/internal/extensions:toolchain.BUILD",
         ),
         "platform": attr.string(
             doc = "The host platform name in the swift package download URL",

--- a/swift/internal/extensions/toolchain.BUILD
+++ b/swift/internal/extensions/toolchain.BUILD
@@ -43,18 +43,16 @@ filegroup(
 # clang need (used by the WebAssembly SDK's cc toolchain).
 filegroup(
     name = "swift_sdk_linker_inputs",
-    srcs = glob(
-        [
-            "usr/bin/clang*",
-            "usr/bin/ld.lld",
-            "usr/bin/ld64.lld",
-            "usr/bin/lld",
-            "usr/bin/llvm-ar",
-            "usr/bin/wasm-ld",
-            "usr/lib/clang/**",
-        ],
-        allow_empty = True,
-    ),
+    srcs = glob([
+        "usr/bin/clang*",
+        "usr/lib/clang/**",
+    ]) + [
+        "usr/bin/ld.lld",
+        "usr/bin/ld64.lld",
+        "usr/bin/lld",
+        "usr/bin/llvm-ar",
+        "usr/bin/wasm-ld",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Since this file has valid syntax if we name it like this we should get
buildifier to pick it up
