### PR TITLE
Remove depsets from many linkopts uses

### DIFF
--- a/swift/internal/debugging.bzl
+++ b/swift/internal/debugging.bzl
@@ -99,9 +99,7 @@ def ensure_swiftmodule_is_embedded(
     # use the `-add_ast_path` linker flag.
     return cc_common.create_linker_input(
         owner = label,
-        user_link_flags = depset([
-            "-Wl,-add_ast_path,{}".format(swiftmodule.path),
-        ]),
+        user_link_flags = depset(["-Wl,-add_ast_path,{}".format(swiftmodule.path)]),
         additional_inputs = depset([swiftmodule]),
     )
 

--- a/swift/internal/linking.bzl
+++ b/swift/internal/linking.bzl
@@ -126,9 +126,7 @@ def _create_autolink_linking_context(
         post_compile_linker_inputs = [
             cc_common.create_linker_input(
                 owner = label,
-                user_link_flags = depset(
-                    ["@{}".format(autolink_file.path)],
-                ),
+                user_link_flags = depset(["@{}".format(autolink_file.path)]),
                 additional_inputs = depset([autolink_file]),
             ),
         ]

--- a/swift/swift_binary.bzl
+++ b/swift/swift_binary.bzl
@@ -233,9 +233,7 @@ def _swift_binary_impl(ctx):
         output_type = output_type,
         stamp = ctx.attr.stamp,
         toolchains = toolchains,
-        user_link_flags = (
-            binary_link_flags + entry_point_linkopts + shared_link_flags
-        ),
+        user_link_flags = binary_link_flags + entry_point_linkopts + shared_link_flags,
         variables_extension = variables_extension,
     )
 

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -380,7 +380,7 @@ def _swift_windows_linkopts_cc_info(
             linker_inputs = depset([
                 cc_common.create_linker_input(
                     owner = toolchain_label,
-                    user_link_flags = depset(linkopts),
+                    user_link_flags = linkopts,
                 ),
             ]),
         ),
@@ -445,7 +445,7 @@ def _swift_unix_linkopts_cc_info(
             linker_inputs = depset([
                 cc_common.create_linker_input(
                     owner = toolchain_label,
-                    user_link_flags = depset(linkopts),
+                    user_link_flags = linkopts,
                     additional_inputs = depset(additional_inputs),
                 ),
             ]),
@@ -476,7 +476,7 @@ def _swift_sdk_linkopts_cc_info(
             linker_inputs = depset([
                 cc_common.create_linker_input(
                     owner = toolchain_label,
-                    user_link_flags = depset(linkopts),
+                    user_link_flags = linkopts,
                     additional_inputs = depset(linker_inputs),
                 ),
             ]),

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -303,7 +303,7 @@ def _swift_linkopts_cc_info(
             linker_inputs = depset([
                 cc_common.create_linker_input(
                     owner = toolchain_label,
-                    user_link_flags = depset(linkopts),
+                    user_link_flags = linkopts,
                 ),
             ]),
         ),
@@ -356,7 +356,7 @@ def _test_linking_context(target_triple, toolchain_label):
         linker_inputs = depset([
             cc_common.create_linker_input(
                 owner = toolchain_label,
-                user_link_flags = depset(linkopts),
+                user_link_flags = linkopts,
             ),
         ]),
     )


### PR DESCRIPTION
Using a depset for linkopts means if you have:

```
["-Xlinker", "foo", "-Xlinker", "bar"]
```

It will end up being:

```
["-Xlinker", "foo", "bar"]
```

This behavior is kept for backwards compat but we can use a list
instead. We're still ok with the depset behavior for places where we are
passing more controlled things that should potentially be dedup'd (or at
least where it doesn't hurt to be dedup'd).
