### PR TITLE
Remove explicit apple_support use_extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,9 +35,6 @@ use_repo(
     "rules_swift_local_config",
 )
 
-apple_cc_configure = use_extension("@apple_support//crosstool:setup.bzl", "apple_cc_configure_extension")
-use_repo(apple_cc_configure, "local_config_apple_cc")
-
 register_toolchains("//swift/toolchains:all")
 
 system_sdk = use_extension("//swift:extensions.bzl", "system_sdk")


### PR DESCRIPTION
We used to need this for the .bazelrc, we no longer reference this repo
