### PR TITLE
Return repo_metadata from repository_rules

### DIFF
--- a/swift/internal/extensions/standalone_toolchain.bzl
+++ b/swift/internal/extensions/standalone_toolchain.bzl
@@ -103,6 +103,9 @@ def _standalone_toolchain_impl(repository_ctx):
             "{swift_version}": repository_ctx.attr.swift_version,
         },
     )
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = True)
+    return None
 
 standalone_toolchain = repository_rule(
     implementation = _standalone_toolchain_impl,

--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -265,6 +265,9 @@ def _swift_android_sdk_impl(repository_ctx):
         ]),
         toolchain_repo = toolchain_repo,
     )
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = True)
+    return None
 
     for arch in ANDROID_ARCHS:
         resource_dir = "{}/swift_static-{}".format(lib_dir, arch)
@@ -355,6 +358,9 @@ def _swift_wasm_sdk_impl(repository_ctx):
         ]),
         toolchain_repo = toolchain_repo,
     )
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = True)
+    return None
 
     build_content += _SWIFT_TOOLCHAIN_TEMPLATE.format(
         arch = "wasm32",

--- a/swift/internal/extensions/toolchains.bzl
+++ b/swift/internal/extensions/toolchains.bzl
@@ -155,6 +155,9 @@ def wasm_sdk_toolchains_for_platform(platform, sdk_repository):
 
 def _toolchains_impl(repository_ctx):
     repository_ctx.file("BUILD.bazel", repository_ctx.attr.build_file_content)
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = True)
+    return None
 
 toolchains_repository = repository_rule(
     implementation = _toolchains_impl,

--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -405,6 +405,9 @@ package(default_visibility = ["//visibility:public"])
             _create_linux_toolchain(repository_ctx = repository_ctx),
         ]),
     )
+    if hasattr(repository_ctx, "repo_metadata"):
+        return repository_ctx.repo_metadata(reproducible = False)
+    return None
 
 swift_autoconfiguration = repository_rule(
     environ = ["CC", "PATH", "ProgramData", "Path"],

--- a/tools/explicit_modules/extensions.bzl
+++ b/tools/explicit_modules/extensions.bzl
@@ -199,6 +199,9 @@ system_module_group(
 
 def _system_sdk_stub_repo_impl(rctx):
     rctx.file("BUILD.bazel", _STUB_BUILD_FILE)
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
 
 _system_sdk_stub_repo = repository_rule(
     implementation = _system_sdk_stub_repo_impl,

--- a/tools/explicit_modules/precomputed_xcode_explicit_module_repo.bzl
+++ b/tools/explicit_modules/precomputed_xcode_explicit_module_repo.bzl
@@ -37,6 +37,9 @@ def _precomputed_xcode_explicit_module_repo_impl(rctx):
         "module_names.json",
         json.encode(_extract_all_module_names(content)),
     )
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
 
 precomputed_xcode_explicit_module_repo = repository_rule(
     implementation = _precomputed_xcode_explicit_module_repo_impl,

--- a/tools/explicit_modules/xcode_explicit_module_hub_repo.bzl
+++ b/tools/explicit_modules/xcode_explicit_module_hub_repo.bzl
@@ -75,6 +75,9 @@ def _xcode_explicit_module_hub_repo_impl(rctx):
             xcode_versions,
         ),
     )
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
 
 xcode_explicit_module_hub_repo = repository_rule(
     implementation = _xcode_explicit_module_hub_repo_impl,

--- a/tools/explicit_modules/xcode_explicit_module_repo.bzl
+++ b/tools/explicit_modules/xcode_explicit_module_repo.bzl
@@ -58,6 +58,9 @@ def _xcode_explicit_module_repo_impl(rctx):
                 result.stderr,
             ),
         )
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = True)
+    return None
 
 xcode_explicit_module_repo = repository_rule(
     implementation = _xcode_explicit_module_repo_impl,

--- a/tools/explicit_modules/xcode_locator_repo.bzl
+++ b/tools/explicit_modules/xcode_locator_repo.bzl
@@ -23,6 +23,9 @@ def _xcode_locator_repo_impl(rctx):
     if err:
         fail("xcode-locator compilation failed: " + err)
     rctx.file("BUILD.bazel", 'exports_files(["xcode-locator-bin"])\n')
+    if hasattr(rctx, "repo_metadata"):
+        return rctx.repo_metadata(reproducible = False)
+    return None
 
 xcode_locator_repo = repository_rule(
     implementation = _xcode_locator_repo_impl,


### PR DESCRIPTION
This allows bazel's remote repo contents cache to cache these if they
are reproducible
