### PR TITLE
Move xcode_swift_toolchain out of local repo

### DIFF
--- a/swift/internal/swift_autoconfiguration.bzl
+++ b/swift/internal/swift_autoconfiguration.bzl
@@ -255,36 +255,6 @@ swift_toolchain(
         version_file = version_file,
     )
 
-def _create_xcode_toolchain():
-    """Creates BUILD targets for the Swift toolchain on macOS using Xcode.
-    """
-    feature_values = [
-        # TODO: This should be removed so that private headers can be used with
-        # explicit modules, but the build targets for CgRPC need to be cleaned
-        # up first because they contain C++ code.
-        SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS,
-    ]
-
-    return """\
-xcode_swift_toolchain(
-    name = "xcode-sdk-toolchain",
-    features = [{feature_list}],
-)
-
-xcode_swift_toolchain(
-    name = "xcode-toolchain",
-    cross_import_overlays = ["@system_sdk//:all_cross_import_overlays"],
-    features = [{feature_list}],
-    implicit_system_modules = "@system_sdk//:implicit_modules",
-    system_modules = "@system_sdk//:all_modules",
-)
-""".format(
-        feature_list = ", ".join([
-            '"{}"'.format(feature)
-            for feature in feature_values
-        ]),
-    )
-
 def _python_executable_works(repository_ctx, python_bin):
     """Returns True if `python_bin` is a real, runnable Python 3 interpreter.
 
@@ -393,14 +363,9 @@ load(
     "@rules_swift//swift/toolchains:swift_toolchain.bzl",
     "swift_toolchain",
 )
-load(
-    "@rules_swift//swift/toolchains:xcode_swift_toolchain.bzl",
-    "xcode_swift_toolchain",
-)
 
 package(default_visibility = ["//visibility:public"])
 """,
-            _create_xcode_toolchain(),
             _create_windows_toolchain(repository_ctx = repository_ctx),
             _create_linux_toolchain(repository_ctx = repository_ctx),
         ]),

--- a/swift/toolchains/BUILD
+++ b/swift/toolchains/BUILD
@@ -3,67 +3,13 @@ load(
     "APPLE_PLATFORMS_CONSTRAINTS",
 )
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@rules_swift//swift/toolchains:xcode_swift_toolchain.bzl", "xcode_swift_toolchain")
+load(
+    "//swift/internal:feature_names.bzl",
+    "SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS",
+)
 
 licenses(["notice"])
-
-bzl_library(
-    name = "swift_toolchain",
-    srcs = ["swift_toolchain.bzl"],
-    visibility = ["//swift:__subpackages__"],
-    deps = [
-        "//swift:providers",
-        "//swift/internal:action_names",
-        "//swift/internal:attrs",
-        "//swift/internal:autolinking",
-        "//swift/internal:debugging",
-        "//swift/internal:feature_names",
-        "//swift/internal:features",
-        "//swift/internal:providers",
-        "//swift/internal:target_triples",
-        "//swift/internal:utils",
-        "//swift/internal:wmo",
-        "//swift/toolchains/config:action_config",
-        "//swift/toolchains/config:all_actions_config",
-        "//swift/toolchains/config:compile_config",
-        "//swift/toolchains/config:symbol_graph_config",
-        "//swift/toolchains/config:synthesize_interface_config",
-        "//swift/toolchains/config:tool_config",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:paths",
-        "@bazel_skylib//rules:common_settings",
-        "@rules_cc//cc:find_cc_toolchain_bzl",
-        "@rules_cc//cc/common",
-    ],
-)
-
-bzl_library(
-    name = "xcode_swift_toolchain",
-    srcs = ["xcode_swift_toolchain.bzl"],
-    visibility = ["//swift:__subpackages__"],
-    deps = [
-        "//swift:providers",
-        "//swift/internal:action_names",
-        "//swift/internal:attrs",
-        "//swift/internal:feature_names",
-        "//swift/internal:features",
-        "//swift/internal:providers",
-        "//swift/internal:target_triples",
-        "//swift/internal:utils",
-        "//swift/internal:wmo",
-        "//swift/toolchains/config:action_config",
-        "//swift/toolchains/config:all_actions_config",
-        "//swift/toolchains/config:compile_config",
-        "//swift/toolchains/config:compile_module_interface_config",
-        "//swift/toolchains/config:symbol_graph_config",
-        "//swift/toolchains/config:synthesize_interface_config",
-        "//swift/toolchains/config:tool_config",
-        "@bazel_skylib//lib:dicts",
-        "@bazel_skylib//lib:paths",
-        "@bazel_skylib//rules:common_settings",
-        "@rules_cc//cc:find_cc_toolchain_bzl",
-        "@rules_cc//cc/common",
-    ],
-)
 
 toolchain(
     name = "linux-swift-toolchain_x86_64",
@@ -95,6 +41,28 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 
+_XCODE_FEATURE_VALUES = [
+    # TODO: This should be removed so that private headers can be used with
+    # explicit modules, but the build targets for CgRPC need to be cleaned
+    # up first because they contain C++ code.
+    SWIFT_FEATURE_MODULE_MAP_NO_PRIVATE_HEADERS,
+]
+
+xcode_swift_toolchain(
+    name = "xcode-sdk-toolchain",
+    features = _XCODE_FEATURE_VALUES,
+    tags = ["manual"],
+)
+
+xcode_swift_toolchain(
+    name = "xcode-toolchain",
+    cross_import_overlays = ["@system_sdk//:all_cross_import_overlays"],
+    features = _XCODE_FEATURE_VALUES,
+    implicit_system_modules = "@system_sdk//:implicit_modules",
+    system_modules = "@system_sdk//:all_modules",
+    tags = ["manual"],
+)
+
 [
     toolchain(
         name = "xcode-sdk-toolchain-" + arch,
@@ -102,7 +70,7 @@ toolchain(
             "@platforms//os:macos",
         ],
         target_compatible_with = constraints,
-        toolchain = "@rules_swift_local_config//:xcode-sdk-toolchain",
+        toolchain = ":xcode-sdk-toolchain",
         toolchain_type = "//toolchains:sdk_toolchain_type",
         visibility = ["//visibility:public"],
     )
@@ -116,7 +84,7 @@ toolchain(
             "@platforms//os:macos",
         ],
         target_compatible_with = constraints,
-        toolchain = "@rules_swift_local_config//:xcode-toolchain",
+        toolchain = ":xcode-toolchain",
         toolchain_type = "//toolchains:toolchain_type",
         visibility = ["//visibility:public"],
     )
@@ -154,8 +122,67 @@ toolchain(
 )
 
 bzl_library(
+    name = "swift_toolchain",
+    srcs = ["swift_toolchain.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "//swift:providers",
+        "//swift/internal:action_names",
+        "//swift/internal:attrs",
+        "//swift/internal:autolinking",
+        "//swift/internal:debugging",
+        "//swift/internal:feature_names",
+        "//swift/internal:features",
+        "//swift/internal:providers",
+        "//swift/internal:target_triples",
+        "//swift/internal:utils",
+        "//swift/internal:wmo",
+        "//swift/toolchains/config:action_config",
+        "//swift/toolchains/config:all_actions_config",
+        "//swift/toolchains/config:compile_config",
+        "//swift/toolchains/config:symbol_graph_config",
+        "//swift/toolchains/config:synthesize_interface_config",
+        "//swift/toolchains/config:tool_config",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//rules:common_settings",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
     name = "swift_tools",
     srcs = ["swift_tools.bzl"],
     visibility = ["//visibility:public"],
     deps = ["//swift:providers"],
+)
+
+bzl_library(
+    name = "xcode_swift_toolchain",
+    srcs = ["xcode_swift_toolchain.bzl"],
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "//swift:providers",
+        "//swift/internal:action_names",
+        "//swift/internal:attrs",
+        "//swift/internal:feature_names",
+        "//swift/internal:features",
+        "//swift/internal:providers",
+        "//swift/internal:target_triples",
+        "//swift/internal:utils",
+        "//swift/internal:wmo",
+        "//swift/toolchains/config:action_config",
+        "//swift/toolchains/config:all_actions_config",
+        "//swift/toolchains/config:compile_config",
+        "//swift/toolchains/config:compile_module_interface_config",
+        "//swift/toolchains/config:symbol_graph_config",
+        "//swift/toolchains/config:synthesize_interface_config",
+        "//swift/toolchains/config:tool_config",
+        "@bazel_skylib//lib:dicts",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//rules:common_settings",
+        "@rules_cc//cc:find_cc_toolchain_bzl",
+        "@rules_cc//cc/common",
+    ],
 )


### PR DESCRIPTION
This doesn't require any repository_rule lookups
