### PR TITLE
Add rules_python flags for remote exec

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,10 @@ common --check_direct_dependencies=off
 # https://github.com/bazelbuild/stardoc/issues/112
 common --incompatible_allow_tags_propagation
 
+# Don't require a system python to run py_binary targets
+common --@rules_python//python/config_settings:bootstrap_impl=script
+common --incompatible_default_to_explicit_init_py
+
 common --flag_alias=swiftcopt=//swift:copt
 common --flag_alias=host_swiftcopt=//swift:exec_copt
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -224,6 +224,7 @@ include("//examples/cross_compilation/wasm:wasm.MODULE.bazel")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "gazelle", version = "0.46.0", dev_dependency = True)
 bazel_dep(name = "rules_go", version = "0.59.0", dev_dependency = True)  # TODO: Remove when transitives update past this version
+bazel_dep(name = "rules_python", version = "2.2.0", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "swift-syntax", version = "602.0.0.bcr.2", dev_dependency = True)
 bazel_dep(name = "rules_swift_layering_check_external_test", version = "0.0.0", dev_dependency = True)


### PR DESCRIPTION
Without this /usr/bin/python3 has to exist when using remote exec for
testing.
