### PR TITLE
Fix WMO num-threads detection

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1883,7 +1883,7 @@ def _emitted_output_nature(feature_configuration, user_compile_flags):
 
     The compiler emits a single object if it is invoked with whole-module
     optimization enabled and is single-threaded (`-num-threads` is not present
-    or is equal to 1); otherwise, it emits one object file per source file. It
+    or is equal to 0); otherwise, it emits one object file per source file. It
     also emits a single `.swiftmodule` file for WMO builds, _regardless of
     thread count,_ so we have to treat that case separately.
 

--- a/swift/internal/wmo.bzl
+++ b/swift/internal/wmo.bzl
@@ -89,30 +89,6 @@ def is_wmo_manually_requested(user_compile_flags):
             return True
     return False
 
-def wmo_features_from_swiftcopts(swiftcopts):
-    """Returns a list of features to enable based on `--swiftcopt` flags.
-
-    Since `--swiftcopt` flags are hooked into the action configuration when the
-    toolchain is configured, it's not possible for individual actions to query
-    them easily if those flags may determine the nature of outputs (for example,
-    single- vs. multi-threaded WMO). The toolchain can call this function to map
-    those flags to private features that can be queried instead.
-
-    Args:
-        swiftcopts: The list of command line flags that were passed using
-            `--swiftcopt`.
-
-    Returns:
-        A list (possibly empty) of strings denoting feature names that should be
-        enabled on the toolchain.
-    """
-    features = []
-    if is_wmo_manually_requested(user_compile_flags = swiftcopts):
-        features.append(SWIFT_FEATURE__WMO_IN_SWIFTCOPTS)
-    if find_num_threads_flag_value(user_compile_flags = swiftcopts) == 1:
-        features.append(SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS)
-    return features
-
 def _safe_int(s):
     """Returns the base-10 integer value of `s` or `None` if it is invalid.
 

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -81,7 +81,7 @@ load(
     "get_swift_executable_for_toolchain",
     "is_exec_config",
 )
-load("//swift/internal:wmo.bzl", "wmo_features_from_swiftcopts")
+load("//swift/internal:wmo.bzl", "features_from_swiftcopts")
 load(
     "//swift/toolchains/config:action_config.bzl",
     "ActionConfigInfo",
@@ -835,7 +835,7 @@ def _xcode_swift_toolchain_impl(ctx):
     requested_features = features_for_build_modes(
         ctx,
         cpp_fragment = cpp_fragment,
-    ) + wmo_features_from_swiftcopts(swiftcopts = ctx.attr.copts + swiftcopts)
+    ) + features_from_swiftcopts(swiftcopts = ctx.attr.copts + swiftcopts)
     requested_features.extend(ctx.features)
     requested_features.extend(ctx.attr.default_enabled_features)
     requested_features.extend(default_features_for_toolchain(

--- a/test/compiler_arguments_tests.bzl
+++ b/test/compiler_arguments_tests.bzl
@@ -39,6 +39,16 @@ swiftcopt_swift_version_test = make_action_command_line_test_rule(
     },
 )
 
+swiftcopt_single_threaded_wmo_test = make_action_command_line_test_rule(
+    config_settings = {
+        str(Label("//swift:copt")): [
+            "-whole-module-optimization",
+            "-num-threads",
+            "0",
+        ],
+    },
+)
+
 def compiler_arguments_test_suite(name, tags = []):
     """Test suite for various command line flags passed to Swift compiles.
 
@@ -146,6 +156,18 @@ def compiler_arguments_test_suite(name, tags = []):
             "-swift-version 4.2",
         ],
         mnemonic = "SwiftCompile",
+        tags = all_tags,
+        target_under_test = "//test/fixtures/compiler_arguments:no_package_name",
+    )
+
+    swiftcopt_single_threaded_wmo_test(
+        name = "{}_swiftcopt_single_threaded_wmo".format(name),
+        expected_argv = [
+            "-whole-module-optimization",
+            "-num-threads 0",
+        ],
+        mnemonic = "SwiftCompile",
+        not_expected_argv = ["-num-threads 12"],
         tags = all_tags,
         target_under_test = "//test/fixtures/compiler_arguments:no_package_name",
     )

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -222,7 +222,12 @@ def features_test_suite(name, tags = []):
     default_opt_test(
         name = "{}_default_opt_test".format(name),
         tags = all_tags,
-        expected_argv = ["-emit-object", "-O", "-whole-module-optimization"],
+        expected_argv = [
+            "-emit-object",
+            "-O",
+            "-whole-module-optimization",
+            "-num-threads 12",
+        ],
         mnemonic = "SwiftCompile",
         target_under_test = "//test/fixtures/debug_settings:simple",
     )


### PR DESCRIPTION
## Summary

- use the shared Swift compiler-option feature detector for the Xcode toolchain
- remove the divergent helper that classified `-num-threads 1` as `-num-threads 0`
- add an action-level regression test for single-threaded WMO
- correct the WMO output-shape documentation

## Root cause

The Xcode toolchain called a duplicate helper that enabled `SWIFT_FEATURE__NUM_THREADS_0_IN_SWIFTCOPTS` when the supplied value was `1`. As a result, `-num-threads 0` was not recognized and rules_swift could inject its default `-num-threads 12`, while also reasoning about the wrong output shape.
