### PR TITLE
Carry the Android API level into Swift's target triple

### DIFF
--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -27,7 +27,7 @@ swift_toolchain(
     os = "{os}",
     parsed_version = "{swift_version}",
     sdkroot = "{sdkroot}",
-    swift_tools = ":tools",
+    swift_tools = ":tools",{target_system_name_attr}
     version_file = ".swift-version",
 )
 """
@@ -138,6 +138,25 @@ ANDROID_ARCHS = [
     "x86_64",
 ]
 
+def _sdk_triple_for_arch(repository_ctx, sdk_dir_relative, arch):
+    """Returns the SDK bundle's own target triple for `arch`.
+
+    The bundle's swift-sdk.json declares the triples it supports (e.g.
+    `aarch64-unknown-linux-android28`), API level included.
+    """
+    sdk_json = json.decode(
+        repository_ctx.read(sdk_dir_relative + "/swift-sdk.json"),
+    )
+    triples = sdk_json.get("targetTriples", {})
+    for triple in triples.keys():
+        if triple.startswith(arch + "-"):
+            return triple
+    fail("No target triple for arch '{}' in {}/swift-sdk.json (found: {})".format(
+        arch,
+        sdk_dir_relative,
+        ", ".join(triples.keys()),
+    ))
+
 def _swift_android_sdk_impl(repository_ctx):
     bundle_dir = _download_sdk_bundle(repository_ctx)
     toolchain_repo = repository_ctx.attr.toolchain_repo
@@ -210,6 +229,14 @@ def _swift_android_sdk_impl(repository_ctx):
             sdkroot = "",  # Resolved in swift_toolchain.bzl
             suffix = arch,
             swift_version = repository_ctx.attr.swift_version,
+            # The bundle's own triple carries the Android API level (e.g.
+            # aarch64-unknown-linux-android28). The NDK cc toolchain reports a
+            # level-less target_gnu_system_name, which floors Swift
+            # availability below the SDK's real minimum - pass the SDK's
+            # triple explicitly.
+            target_system_name_attr = '\n    target_system_name = "{}",'.format(
+                _sdk_triple_for_arch(repository_ctx, sdk_dir_relative, arch),
+            ),
         )
 
     repository_ctx.file("BUILD.bazel", build_content)

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -537,7 +537,9 @@ def _swift_toolchain_impl(ctx):
     target_system_name = _parse_target_system_name(
         arch = ctx.attr.arch,
         os = ctx.attr.os,
-        target_system_name = cc_toolchain.target_gnu_system_name,
+        target_system_name = (
+            ctx.attr.target_system_name or cc_toolchain.target_gnu_system_name
+        ),
     )
     target_triple = target_triples.normalize_for_swift(
         target_triples.parse(ctx.var.get("CC_TARGET_TRIPLE") or target_system_name),
@@ -779,6 +781,17 @@ A list of `swift_feature_allowlist` targets that allow or prohibit packages from
 requesting or disabling features.
 """,
                 providers = [[SwiftFeatureAllowlistInfo]],
+            ),
+            "target_system_name": attr.string(
+                doc = """\
+The target system name (triple) Swift should compile for, overriding the one
+reported by the C++ toolchain. Toolchains whose platform encodes a minimum OS
+version in the triple (e.g. Android's `aarch64-unknown-linux-android28`) must
+set this: the C++ toolchain's `target_gnu_system_name` typically omits the API
+level, which floors Swift availability checking below the SDK's real minimum
+(e.g. `swift-log` requires the Android 23 availability of `stdout`).
+""",
+                mandatory = False,
             ),
             "os": attr.string(
                 doc = """\

--- a/test/android_tests.bzl
+++ b/test/android_tests.bzl
@@ -31,7 +31,7 @@ def android_test_suite(name):
     # The Swift compile targets Android
     android_command_line_test(
         name = "{}_swiftcompile_targets_android".format(name),
-        expected_argv = ["-target aarch64-linux-android"],
+        expected_argv = ["-target aarch64-unknown-linux-android28"],
         mnemonic = "SwiftCompile",
         tags = all_tags,
         target_under_test = "//test/fixtures/android:jni_lib",


### PR DESCRIPTION
The NDK cc toolchain reports a level-less `target_gnu_system_name` (`aarch64-linux-android`), so Swift compiles with an availability floor below the SDK's actual minimum. Concretely, cross-compiling `swift-log` for Android fails with:

```
error: 'stdout' is only available in Android 23 or newer
```

even though the Swift Android SDK bundle itself declares `aarch64-unknown-linux-android28` in its `swift-sdk.json`.

This PR:
- adds an optional `target_system_name` attribute to `swift_toolchain` that overrides the cc-toolchain-derived triple, and
- has the generated Android SDK toolchains pass the bundle's own triple, read from `swift-sdk.json`'s `targetTriples` (API level included). The wasm toolchain generation is unchanged (empty override).

Verified by cross-compiling `swift-log` / `swift-nio` / `grpc-swift-2` (via rules_swift_package_manager) for aarch64 Android and running a plaintext HTTP/2 gRPC round trip against a host server from the Android emulator:

```
greeter-client: Hey Universal UI! [seq=1 tags=grpc-swift-2,nio-http2]
```