### PR TITLE
Android: match the NDK's API level in Swift's target triple (alt to #1857)

### DIFF
--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -40,7 +40,7 @@ def _known_sdk_versions(swift_sdk_releases, sdk):
         if sdk in swift_sdk_releases[version]
     ]
 
-def _setup_android_sdk(*, tag, toolchain_name, swift_version, platforms, swift_sdk_releases):
+def _setup_android_sdk(*, tag, toolchain_name, swift_version, platforms, swift_sdk_releases, api_level):
     """Creates the repositories for a `swift.android_sdk` tag.
 
     Args:
@@ -49,6 +49,8 @@ def _setup_android_sdk(*, tag, toolchain_name, swift_version, platforms, swift_s
         swift_version: The Swift release version of that toolchain.
         platforms: The host platforms the toolchain was created for.
         swift_sdk_releases: Bundled Swift SDK checksum metadata by release.
+        api_level: The Android API level to target, or empty for the SDK's
+            lowest supported level.
 
     Returns:
         BUILD file content with the `toolchain` declarations to add to the
@@ -68,6 +70,7 @@ def _setup_android_sdk(*, tag, toolchain_name, swift_version, platforms, swift_s
         repository_name = "{}_android_sdk_{}".format(toolchain_name, platform)
         swift_android_sdk_repository(
             name = repository_name,
+            api_level = api_level,
             paired_swiftc = "@{}_{}//:usr/bin/swiftc".format(toolchain_name, platform),
             sha256 = sha256,
             swift_version = swift_version,
@@ -214,6 +217,7 @@ def _standalone_toolchain_impl(module_ctx):
                 swift_version = swift_version,
                 platforms = platforms,
                 swift_sdk_releases = swift_sdk_releases,
+                api_level = android_sdk_tags[toolchain.name].api_level,
             )
         if toolchain.name in wasm_sdk_tags:
             toolchains_build_file_content += _setup_wasm_sdk(
@@ -233,6 +237,15 @@ def _standalone_toolchain_impl(module_ctx):
 
 _android_sdk = tag_class(
     attrs = {
+        "api_level": attr.string(
+            doc = """\
+The Android API level to target, matching your NDK toolchain's `api_level` (your
+app's `minSdkVersion`). Swift then compiles for
+`<arch>-unknown-linux-android<api_level>`. When omitted, the SDK bundle's lowest
+supported level is used, and a cc toolchain that already pins an API level is
+respected as-is.
+""",
+        ),
         "sha256": attr.string(
             doc = """\
 The expected SHA-256 of the SDK artifact bundle. May be omitted for Swift

--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -27,7 +27,7 @@ swift_toolchain(
     os = "{os}",
     parsed_version = "{swift_version}",
     sdkroot = "{sdkroot}",
-    swift_tools = ":tools",
+    swift_tools = ":tools",{target_system_name_attr}
     version_file = ".swift-version",
 )
 """
@@ -138,6 +138,58 @@ ANDROID_ARCHS = [
     "x86_64",
 ]
 
+def _android_api_level(triple):
+    """Returns the trailing Android API level of a triple, or 0 if it has none.
+
+    e.g. `aarch64-unknown-linux-android28` -> 28, `...-android` -> 0.
+    """
+    digits = ""
+    for i in range(len(triple) - 1, -1, -1):
+        c = triple[i]
+        if c.isdigit():
+            digits = c + digits
+        else:
+            break
+    return int(digits) if digits else 0
+
+def _sdk_triple_for_arch(repository_ctx, sdk_dir_relative, arch, api_level):
+    """Returns the SDK bundle's target triple for `arch` at `api_level`.
+
+    The bundle's swift-sdk.json declares the API-level ladder it supports (e.g.
+    `aarch64-unknown-linux-android{28..36}`). When `api_level` is set we select
+    that exact level so Swift matches the NDK/`minSdkVersion` the rest of the
+    build targets. When it's empty we fall back to the bundle's lowest supported
+    level -- the safe minimum, since the prebuilt runtime won't load below it.
+    """
+    sdk_json = json.decode(
+        repository_ctx.read(sdk_dir_relative + "/swift-sdk.json"),
+    )
+    candidates = [
+        triple
+        for triple in sdk_json.get("targetTriples", {}).keys()
+        if triple.startswith(arch + "-")
+    ]
+    if not candidates:
+        fail("No target triple for arch '{}' in {}/swift-sdk.json".format(
+            arch,
+            sdk_dir_relative,
+        ))
+
+    if api_level:
+        wanted = [t for t in candidates if _android_api_level(t) == int(api_level)]
+        if not wanted:
+            fail(
+                "Android API level {} is not offered for arch '{}' in {}/swift-sdk.json (available: {})".format(
+                    api_level,
+                    arch,
+                    sdk_dir_relative,
+                    ", ".join(sorted(candidates)),
+                ),
+            )
+        return wanted[0]
+
+    return min(candidates, key = _android_api_level)
+
 def _swift_android_sdk_impl(repository_ctx):
     bundle_dir = _download_sdk_bundle(repository_ctx)
     toolchain_repo = repository_ctx.attr.toolchain_repo
@@ -210,12 +262,34 @@ def _swift_android_sdk_impl(repository_ctx):
             sdkroot = "",  # Resolved in swift_toolchain.bzl
             suffix = arch,
             swift_version = repository_ctx.attr.swift_version,
+            # The bundle's own triple carries the Android API level (e.g.
+            # aarch64-unknown-linux-android28). The NDK cc toolchain reports a
+            # level-less target_gnu_system_name, which floors Swift availability
+            # below the SDK's real minimum - hand swift_toolchain the leveled
+            # triple, which it uses only when the cc toolchain doesn't already
+            # provide an API level of its own.
+            target_system_name_attr = '\n    target_system_name = "{}",'.format(
+                _sdk_triple_for_arch(
+                    repository_ctx,
+                    sdk_dir_relative,
+                    arch,
+                    repository_ctx.attr.api_level,
+                ),
+            ),
         )
 
     repository_ctx.file("BUILD.bazel", build_content)
 
 swift_android_sdk_repository = repository_rule(
     attrs = _common_attrs() | {
+        "api_level": attr.string(
+            doc = """\
+The Android API level to target, matching the `api_level` of your NDK toolchain
+(i.e. your app's `minSdkVersion`). When set, Swift compiles for
+`<arch>-unknown-linux-android<api_level>`; the SDK bundle offers the range the
+Swift release supports. When empty, the bundle's lowest supported level is used.
+""",
+        ),
         "paired_swiftc": attr.label(
             doc = """\
 The `swiftc` of the standalone toolchain this SDK is paired with, used to locate

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -514,6 +514,14 @@ def _parse_target_system_name(*, arch, os, target_system_name):
     else:
         return "%s-unknown-%s" % (arch, os)
 
+def _has_android_api_level(target_system_name):
+    """True if an Android triple already pins an API level (e.g. `...-android28`).
+
+    A level-less Android triple ends in a letter (`aarch64-linux-android`); a
+    leveled one ends in the API-level digits.
+    """
+    return "android" in target_system_name and target_system_name[-1].isdigit()
+
 def _resolve_sdkroot(ctx, cc_toolchain):
     """Returns the SDK root (sysroot) for `-sdk`.
 
@@ -534,13 +542,28 @@ def _resolve_sdkroot(ctx, cc_toolchain):
 def _swift_toolchain_impl(ctx):
     toolchain_root = ctx.attr.root
     cc_toolchain = find_cc_toolchain(ctx)
+
+    # The triple the cc toolchain reports for the target. On Android the NDK's
+    # is level-less (`aarch64-linux-android`), which floors Swift availability
+    # checking below the SDK's real minimum; elsewhere it's authoritative.
+    cc_target_system_name = (
+        ctx.var.get("CC_TARGET_TRIPLE") or cc_toolchain.target_gnu_system_name
+    )
+
+    # An SDK toolchain may supply a leveled Android triple via
+    # `target_system_name`. Use it only to fill in a level the cc toolchain
+    # omits -- never to override one it already carries, which would silently
+    # retarget the API level the rest of the build (clang, the NDK) is using.
+    if ctx.attr.target_system_name and not _has_android_api_level(cc_target_system_name):
+        cc_target_system_name = ctx.attr.target_system_name
+
     target_system_name = _parse_target_system_name(
         arch = ctx.attr.arch,
         os = ctx.attr.os,
-        target_system_name = cc_toolchain.target_gnu_system_name,
+        target_system_name = cc_target_system_name,
     )
     target_triple = target_triples.normalize_for_swift(
-        target_triples.parse(ctx.var.get("CC_TARGET_TRIPLE") or target_system_name),
+        target_triples.parse(target_system_name),
     )
 
     if ctx.attr.os != "windows" and "clang" not in cc_toolchain.compiler and "llvm" not in cc_toolchain.compiler:
@@ -883,6 +906,18 @@ ordinary host toolchain, which computes its own flags.
             "sdkroot": attr.string(
                 doc = """\
 The root of a SDK to be used for building the target.
+""",
+                mandatory = False,
+            ),
+            "target_system_name": attr.string(
+                doc = """\
+A target system name (triple) supplied by an SDK toolchain, used only to fill in
+an API level the C++ toolchain's triple omits. Android's SDK sets this to a
+leveled triple (e.g. `aarch64-unknown-linux-android28`) because the NDK cc
+toolchain's `target_gnu_system_name` typically drops the API level, flooring
+Swift availability below the SDK's real minimum (e.g. `swift-log`'s use of
+`stdout`, which is Android 23+). It is ignored when the cc toolchain already
+provides an API level of its own.
 """,
                 mandatory = False,
             ),

--- a/test/android_tests.bzl
+++ b/test/android_tests.bzl
@@ -31,7 +31,7 @@ def android_test_suite(name):
     # The Swift compile targets Android
     android_command_line_test(
         name = "{}_swiftcompile_targets_android".format(name),
-        expected_argv = ["-target aarch64-linux-android"],
+        expected_argv = ["-target aarch64-unknown-linux-android28"],
         mnemonic = "SwiftCompile",
         tags = all_tags,
         target_under_test = "//test/fixtures/android:jni_lib",


### PR DESCRIPTION
### Alternative to #1857

Same underlying fix as #1857 — the Android NDK cc toolchain reports a level-less `target_gnu_system_name` (`aarch64-linux-android`), so Swift floors availability checking below the SDK's real minimum and rejects APIs the target actually has (e.g. `swift-log`'s `stdout`, gated on Android 23). Both PRs hand `swift_toolchain` a leveled Android triple to fix it.

The difference is **where the API level comes from**, which is exactly the question raised in #1857 ([comment](https://github.com/bazelbuild/rules_swift/pull/1857#issuecomment-4974493636)): *derive it, or match what the user's NDK is set up for?* This PR matches the NDK:

- **`swift.android_sdk(api_level = N)`** selects `<arch>-unknown-linux-android<N>` from the bundle — which ships the whole ladder the Swift release supports (e.g. 28–36) — so Swift compiles for the same level the NDK/`minSdkVersion` drives clang's `--target` to. Set it to your NDK's `api_level`.
- **When `api_level` is omitted**, the bundle's *lowest* supported level is used. That's the safe minimum: the prebuilt runtime won't load below it, and a min-N binary runs on any device ≥ N.
- **`swift_toolchain` never overrides a cc triple that already carries an API level.** The SDK-provided triple only fills in a level the cc toolchain omits, so a toolchain configured with an explicit level wins outright.

So vs. #1857 (which always uses the bundle's floor and always overrides): identical behavior for the common level-less case, plus an `api_level` knob to track the NDK and a don't-override rule so Swift can't silently retarget away from the level the rest of the build uses.

### Changes

- `swift.android_sdk` / `swift_android_sdk_repository` gain an optional `api_level`.
- `_sdk_triple_for_arch` selects the bundle triple for that level, or the deterministic minimum when unset.
- `swift_toolchain` gains `target_system_name`, applied only when the cc triple lacks an API level (`_has_android_api_level`).

### Testing

- `//test:android_swiftcompile_targets_android` updated to assert the leveled `-target aarch64-unknown-linux-android28` (the floor default), and passes.
- `//test:android_link_uses_ndk`, `//test:android_apk_contents` (real APK build), and `//test:const_values_expected_argv` pass.
- Verified end-to-end against a Swift-on-Android app (NIO gRPC client) that previously failed the `swift-log` availability check.

Happy to go with whichever of the two you prefer — closing this or #1857 accordingly.
