### PR TITLE
Add wasm32-unknown-wasip1-threads variant to swift.wasm_sdk

### DIFF
--- a/swift/extensions.bzl
+++ b/swift/extensions.bzl
@@ -93,7 +93,23 @@ def _setup_wasm_sdk(*, tag, toolchain_name, swift_version, platforms, swift_sdk_
         BUILD file content with the `toolchain` declarations to add to the
         toolchains hub repository.
     """
+    threads = tag.threads
+    url = tag.url
     sha256 = tag.sha256
+
+    # swift.org does not publish a `wasm32-unknown-wasip1-threads` SDK bundle, so
+    # the threads variant must be pointed at an explicit bundle (for example a
+    # swiftwasm release) via `url` + `sha256`.
+    if threads and not url:
+        fail("`swift.wasm_sdk` with `threads = True` requires an explicit `url` " +
+             "(and `sha256`), because swift.org does not publish a " +
+             "wasm32-unknown-wasip1-threads SDK bundle. Point it at a swiftwasm " +
+             "release, e.g. https://github.com/swiftwasm/swift/releases.")
+    if url and not sha256:
+        fail("`swift.wasm_sdk` with an explicit `url` also requires `sha256`.")
+
+    if not url:
+        url = swift_sdk_download_url(swift_version, "wasm")
     if not sha256:
         if swift_version not in swift_sdk_releases or "wasm" not in swift_sdk_releases[swift_version]:
             fail("No known WebAssembly Swift SDK for version `{}`. Please choose one of {}, or provide the SDK's sha256.".format(
@@ -109,8 +125,9 @@ def _setup_wasm_sdk(*, tag, toolchain_name, swift_version, platforms, swift_sdk_
             name = repository_name,
             sha256 = sha256,
             swift_version = swift_version,
+            threads = threads,
             toolchain_repo = "{}_{}".format(toolchain_name, platform),
-            url = swift_sdk_download_url(swift_version, "wasm"),
+            url = url,
         )
         build_file_content += wasm_sdk_toolchains_for_platform(
             platform = platform,
@@ -238,13 +255,32 @@ _wasm_sdk = tag_class(
         "sha256": attr.string(
             doc = """\
 The expected SHA-256 of the SDK artifact bundle. May be omitted for Swift
-versions known to this version of rules_swift.
+versions known to this version of rules_swift, but is required when `url` or
+`threads` is set.
+""",
+        ),
+        "threads": attr.bool(
+            default = False,
+            doc = """\
+If `True`, target `wasm32-unknown-wasip1-threads` (WebAssembly with shared
+memory, atomics, and wasi-threads) instead of the single-threaded
+`wasm32-unknown-wasip1`. swift.org does not publish a threads SDK bundle, so
+`url` and `sha256` are required in this mode (for example, a swiftwasm release:
+https://github.com/swiftwasm/swift/releases).
+""",
+        ),
+        "url": attr.string(
+            doc = """\
+An explicit download URL for the SDK artifact bundle, overriding the swift.org
+URL computed from the toolchain's Swift version. Required for the `threads`
+variant. When set, `sha256` is also required.
 """,
         ),
     },
     doc = """\
 Downloads the WebAssembly Swift SDK matching a `toolchain` tag's Swift version
-and defines Swift and C++ toolchains targeting `wasm32-unknown-wasip1`.
+and defines Swift and C++ toolchains targeting `wasm32-unknown-wasip1` (or
+`wasm32-unknown-wasip1-threads` when `threads = True`).
 """,
 )
 

--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -241,6 +241,7 @@ def _swift_wasm_sdk_impl(repository_ctx):
         "{bundle_dir}": bundle_dir,
         "{sdk_dir}": sdk_dir,
         "{swift_version}": repository_ctx.attr.swift_version,
+        "{target_triple}": triple,
         "{toolchain_repo}": repository_ctx.attr.toolchain_repo,
     }
     substitutions.update(_wasm_thread_substitutions(threads))

--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -132,37 +132,142 @@ target Android.
     implementation = _swift_android_sdk_impl,
 )
 
+# Extra compiler/linker flags required to target
+# `wasm32-unknown-wasip1-threads` (shared memory + atomics + wasi-threads).
+# These mirror what the swiftwasm SDK's `toolset.json` passes; rules_swift wires
+# its own wasm cc + Swift toolchains (it does not consume SwiftPM/toolset.json),
+# so the flags are injected into the generated toolchains here.
+#
+# clang flags applied to both C/C++ compile and link actions.
+_WASM_THREADS_CC_COMPILE_FLAGS = [
+    "-matomics",
+    "-mbulk-memory",
+    "-mthread-model",
+    "posix",
+    "-pthread",
+    "-ftls-model=local-exec",
+]
+
+# wasm-ld flags applied to link actions (passed through the clang driver).
+_WASM_THREADS_LINK_FLAGS = [
+    "-Wl,--import-memory",
+    "-Wl,--export-memory",
+    "-Wl,--shared-memory",
+    "-Wl,--max-memory=1073741824",
+]
+
+def _bzl_list_tail(flags, indent):
+    """Formats flags as list elements appended after an existing list entry.
+
+    Each flag becomes its own line (leading newline + `indent`), so the result
+    can be substituted immediately after the trailing comma of the last static
+    element of a BUILD-file list literal.
+    """
+    return "".join(["\n{}\"{}\",".format(indent, flag) for flag in flags])
+
+def _wasm_thread_substitutions(threads):
+    """Returns template substitutions for the wasm threads variant.
+
+    When `threads` is False every placeholder expands to the empty string, so
+    the generated toolchains are byte-for-byte identical to the single-threaded
+    path.
+    """
+    if not threads:
+        return {
+            "{cc_thread_compile_args}": "",
+            "{cc_thread_link_args}": "",
+            "{swift_thread_copts}": "",
+            "{swift_thread_linkopts}": "",
+        }
+
+    # Swift compiler: build a static stdlib and forward the atomics/threads
+    # clang flags to the embedded clang via `-Xcc`.
+    swift_copts = ["-static-stdlib"]
+    for flag in _WASM_THREADS_CC_COMPILE_FLAGS:
+        swift_copts += ["-Xcc", flag]
+
+    return {
+        "{cc_thread_compile_args}": _bzl_list_tail(
+            _WASM_THREADS_CC_COMPILE_FLAGS,
+            "        ",
+        ),
+        "{cc_thread_link_args}": _bzl_list_tail(
+            _WASM_THREADS_LINK_FLAGS,
+            "        ",
+        ),
+        "{swift_thread_copts}": _bzl_list_tail(swift_copts, "        "),
+        "{swift_thread_linkopts}": _bzl_list_tail(
+            _WASM_THREADS_LINK_FLAGS,
+            "        ",
+        ),
+    }
+
+def _wasm_sdk_dir(repository_ctx, bundle_dir, repo_root, triple, threads):
+    """Locates the target-triple SDK directory inside the artifact bundle.
+
+    The swift.org bundle nests the target under
+    `{bundle_name}/{triple}`, where `{bundle_name}` is the bundle directory with
+    its `.artifactbundle` suffix stripped. The swiftwasm threads bundle nests it
+    under a differently-named inner directory (e.g.
+    `6.3-RELEASE-wasm32-unknown-wasip1-threads/wasm32-unknown-wasip1-threads`),
+    so for the threads variant the inner directory is discovered by scanning for
+    the one that contains the target triple.
+    """
+    if not threads:
+        sub_path = "{0}/{1}".format(bundle_dir.removesuffix(".artifactbundle"), triple)
+        return "{}/{}/{}".format(repo_root, bundle_dir, sub_path)
+
+    for entry in repository_ctx.path(bundle_dir).readdir():
+        if entry.get_child(triple).exists:
+            return "{}/{}/{}/{}".format(repo_root, bundle_dir, entry.basename, triple)
+    fail(("The WebAssembly Swift SDK bundle at {} has an unexpected layout; " +
+          "could not find a `{}` directory under {}.").format(
+        repository_ctx.attr.url,
+        triple,
+        bundle_dir,
+    ))
+
 def _swift_wasm_sdk_impl(repository_ctx):
+    threads = repository_ctx.attr.threads
+    triple = "wasm32-unknown-wasip1-threads" if threads else "wasm32-unknown-wasip1"
+
     bundle_dir = _download_sdk_bundle(repository_ctx)
     repo_root = "external/" + repository_ctx.name
-    sdk_dir = "{}/{}/{}".format(
-        repo_root,
-        bundle_dir,
-        "{0}/wasm32-unknown-wasip1".format(bundle_dir.removesuffix(".artifactbundle")),
-    )
+    sdk_dir = _wasm_sdk_dir(repository_ctx, bundle_dir, repo_root, triple, threads)
     if not repository_ctx.path(sdk_dir.removeprefix(repo_root + "/")).exists:
         fail("The WebAssembly Swift SDK bundle has an unexpected layout; missing " + sdk_dir)
+
+    substitutions = {
+        "{bundle_dir}": bundle_dir,
+        "{sdk_dir}": sdk_dir,
+        "{swift_version}": repository_ctx.attr.swift_version,
+        "{toolchain_repo}": repository_ctx.attr.toolchain_repo,
+    }
+    substitutions.update(_wasm_thread_substitutions(threads))
 
     repository_ctx.template(
         "BUILD.bazel",
         repository_ctx.attr._build_template,
-        substitutions = {
-            "{bundle_dir}": bundle_dir,
-            "{sdk_dir}": sdk_dir,
-            "{swift_version}": repository_ctx.attr.swift_version,
-            "{toolchain_repo}": repository_ctx.attr.toolchain_repo,
-        },
+        substitutions = substitutions,
     )
 
 swift_wasm_sdk_repository = repository_rule(
     attrs = _common_attrs() | {
+        "threads": attr.bool(
+            default = False,
+            doc = """\
+If `True`, target `wasm32-unknown-wasip1-threads` (shared memory + atomics +
+wasi-threads) instead of the single-threaded `wasm32-unknown-wasip1`.
+""",
+        ),
         "_build_template": attr.label(
             default = "//swift/internal/extensions:wasmsdk.BUILD",
         ),
     },
     doc = """\
 Downloads the WebAssembly Swift SDK artifact bundle and defines Swift and C++
-toolchains that target `wasm32-unknown-wasip1` using a standalone host
+toolchains that target `wasm32-unknown-wasip1` (or
+`wasm32-unknown-wasip1-threads` when `threads = True`) using a standalone host
 toolchain's compiler.
 """,
     implementation = _swift_wasm_sdk_impl,

--- a/swift/internal/extensions/swift_sdks.bzl
+++ b/swift/internal/extensions/swift_sdks.bzl
@@ -132,29 +132,146 @@ target Android.
     implementation = _swift_android_sdk_impl,
 )
 
-# Extra compiler/linker flags required to target
-# `wasm32-unknown-wasip1-threads` (shared memory + atomics + wasi-threads).
-# These mirror what the swiftwasm SDK's `toolset.json` passes; rules_swift wires
-# its own wasm cc + Swift toolchains (it does not consume SwiftPM/toolset.json),
-# so the flags are injected into the generated toolchains here.
-#
-# clang flags applied to both C/C++ compile and link actions.
-_WASM_THREADS_CC_COMPILE_FLAGS = [
-    "-matomics",
-    "-mbulk-memory",
-    "-mthread-model",
-    "posix",
-    "-pthread",
-    "-ftls-model=local-exec",
-]
+def _relative_metadata_path(value, field, triple):
+    """Validates a path read from SDK metadata."""
+    if type(value) != "string" or not value:
+        fail("Expected `{}` for `{}` in swift-sdk.json to be a non-empty string.".format(
+            field,
+            triple,
+        ))
+    if value.startswith("/") or ".." in value.split("/"):
+        fail("Expected `{}` for `{}` in swift-sdk.json to be a relative path below the SDK directory, got `{}`.".format(
+            field,
+            triple,
+            value,
+        ))
+    return value
 
-# wasm-ld flags applied to link actions (passed through the clang driver).
-_WASM_THREADS_LINK_FLAGS = [
-    "-Wl,--import-memory",
-    "-Wl,--export-memory",
-    "-Wl,--shared-memory",
-    "-Wl,--max-memory=1073741824",
-]
+def _swift_sdk_json_path(repository_ctx, bundle_dir):
+    """Locates the default `swift-sdk.json` via the bundle's `info.json`.
+
+    An artifact bundle's `info.json` lists one or more `swiftSDK` artifacts,
+    each with a variant path to a `swift-sdk.json` metadata file. Bundles that
+    also ship an Embedded Swift variant name its metadata
+    `embedded-swift-sdk.json`; the default (full-stdlib) artifact is the one
+    whose metadata file is named exactly `swift-sdk.json`.
+
+    Returns:
+        The path of the default artifact's `swift-sdk.json`, relative to the
+        repository root.
+    """
+    info = json.decode(repository_ctx.read(bundle_dir + "/info.json"))
+    artifacts = info.get("artifacts")
+    if type(artifacts) != "dict":
+        fail("The Swift SDK bundle has an unexpected layout; " +
+             "info.json is missing `artifacts`.")
+
+    candidates = []
+    for artifact in artifacts.values():
+        if artifact.get("type") != "swiftSDK":
+            continue
+        for variant in artifact.get("variants", []):
+            path = variant.get("path", "")
+            if path.split("/")[-1] == "swift-sdk.json":
+                candidates.append(path)
+    if len(candidates) != 1:
+        fail(("The Swift SDK bundle has an unexpected layout; expected " +
+              "info.json to reference exactly one `swift-sdk.json` variant, " +
+              "found: {}").format(candidates))
+    return "{}/{}".format(bundle_dir, candidates[0])
+
+def _swift_sdk_target_settings(repository_ctx, sdk_json_path):
+    """Parses a `swift-sdk.json`, returning its single triple and settings.
+
+    Returns:
+        A `(triple, settings)` tuple, where `settings` is the decoded
+        per-triple dictionary (`sdkRootPath`, `swiftStaticResourcesPath`,
+        `toolsetPaths`, ...).
+    """
+    metadata = json.decode(repository_ctx.read(sdk_json_path))
+    target_triples = metadata.get("targetTriples")
+    if type(target_triples) != "dict":
+        fail("The Swift SDK bundle has an unexpected layout; " +
+             "{} is missing `targetTriples`.".format(sdk_json_path))
+    if len(target_triples) != 1:
+        fail(("Expected {} to declare exactly one target triple, " +
+              "got: {}").format(sdk_json_path, target_triples.keys()))
+    triple = target_triples.keys()[0]
+    return triple, target_triples[triple]
+
+def merged_toolset_options(toolsets, context):
+    """Merges decoded `toolset.json` dictionaries into per-tool option lists.
+
+    A Swift SDK's `swift-sdk.json` may reference several toolset files via
+    `toolsetPaths`; SwiftPM applies them in order, with `extraCLIOptions`
+    accumulating. `rootPath` and per-tool executable overrides are ignored:
+    the generated toolchains always drive the paired standalone toolchain's
+    own `swiftc`/`clang`.
+
+    Args:
+        toolsets: Decoded `toolset.json` dictionaries, in `toolsetPaths` order.
+        context: A human-readable location (bundle URL or path) for error
+            messages.
+
+    Returns:
+        A `struct` with `c_compiler`, `cxx_compiler`, `linker`, and
+        `swift_compiler` fields, each the merged `extraCLIOptions` list for
+        that tool.
+    """
+    merged = {
+        "cCompiler": [],
+        "cxxCompiler": [],
+        "linker": [],
+        "swiftCompiler": [],
+    }
+    for toolset in toolsets:
+        for tool, options in merged.items():
+            extra = toolset.get(tool, {}).get("extraCLIOptions", [])
+            for option in extra:
+                if type(option) != "string":
+                    fail(("Expected `{}.extraCLIOptions` in the toolset " +
+                          "metadata of {} to be a list of strings, " +
+                          "got: {}").format(tool, context, extra))
+            options.extend(extra)
+    return struct(
+        c_compiler = merged["cCompiler"],
+        cxx_compiler = merged["cxxCompiler"],
+        linker = merged["linker"],
+        swift_compiler = merged["swiftCompiler"],
+    )
+
+def linker_options_to_clang_args(options, context):
+    """Translates raw linker options from a toolset into clang driver args.
+
+    SwiftPM invokes the linker named by the toolset directly, so a toolset's
+    `linker.extraCLIOptions` are raw `wasm-ld`/`ld` flags. The generated
+    toolchains link through the clang driver instead, so each option is
+    forwarded with `-Wl,`.
+
+    Args:
+        options: The toolset's merged `linker.extraCLIOptions`.
+        context: A human-readable location (bundle URL or path) for error
+            messages.
+
+    Returns:
+        The options wrapped for the clang driver.
+    """
+    for option in options:
+        if "," in option:
+            fail(("Linker option `{}` from the toolset metadata of {} " +
+                  "contains a comma and cannot be forwarded via " +
+                  "`-Wl,`.").format(option, context))
+    return ["-Wl," + option for option in options]
+
+def _toolset_options(repository_ctx, sdk_dir_relative, target_settings, triple, context):
+    """Reads and merges the toolsets referenced by a `swift-sdk.json`."""
+    toolsets = []
+    for toolset_path in target_settings.get("toolsetPaths", []):
+        toolsets.append(json.decode(repository_ctx.read("{}/{}".format(
+            sdk_dir_relative,
+            _relative_metadata_path(toolset_path, "toolsetPaths", triple),
+        ))))
+    return merged_toolset_options(toolsets, context)
 
 def _bzl_list_tail(flags, indent):
     """Formats flags as list elements appended after an existing list entry.
@@ -165,86 +282,86 @@ def _bzl_list_tail(flags, indent):
     """
     return "".join(["\n{}\"{}\",".format(indent, flag) for flag in flags])
 
-def _wasm_thread_substitutions(threads):
-    """Returns template substitutions for the wasm threads variant.
+def _wasm_toolset_substitutions(toolset, context):
+    """Returns BUILD-template substitutions carrying the SDK's toolset options.
 
-    When `threads` is False every placeholder expands to the empty string, so
-    the generated toolchains are byte-for-byte identical to the single-threaded
-    path.
+    The C compiler options apply to both C and C++ compilations (the wasm cc
+    toolchain does not distinguish them); a toolset with *different* C++
+    options is rejected rather than half-applied. For the single-threaded
+    swift.org bundle the toolset carries only `-static-stdlib` for `swiftc`;
+    the wasi-threads bundle additionally carries the atomics/pthread compile
+    flags and the shared-memory link flags.
     """
-    if not threads:
-        return {
-            "{cc_thread_compile_args}": "",
-            "{cc_thread_link_args}": "",
-            "{swift_thread_copts}": "",
-            "{swift_thread_linkopts}": "",
-        }
-
-    # Swift compiler: build a static stdlib and forward the atomics/threads
-    # clang flags to the embedded clang via `-Xcc`.
-    swift_copts = ["-static-stdlib"]
-    for flag in _WASM_THREADS_CC_COMPILE_FLAGS:
-        swift_copts += ["-Xcc", flag]
-
+    if toolset.cxx_compiler and toolset.cxx_compiler != toolset.c_compiler:
+        fail(("The toolset metadata of {} has `cxxCompiler` options that " +
+              "differ from its `cCompiler` options; this is not " +
+              "supported.").format(context))
+    link_args = linker_options_to_clang_args(toolset.linker, context)
     return {
-        "{cc_thread_compile_args}": _bzl_list_tail(
-            _WASM_THREADS_CC_COMPILE_FLAGS,
+        "{cc_toolset_compile_args}": _bzl_list_tail(
+            toolset.c_compiler,
             "        ",
         ),
-        "{cc_thread_link_args}": _bzl_list_tail(
-            _WASM_THREADS_LINK_FLAGS,
+        "{cc_toolset_link_args}": _bzl_list_tail(link_args, "        "),
+        "{swift_toolset_copts}": _bzl_list_tail(
+            toolset.swift_compiler,
             "        ",
         ),
-        "{swift_thread_copts}": _bzl_list_tail(swift_copts, "        "),
-        "{swift_thread_linkopts}": _bzl_list_tail(
-            _WASM_THREADS_LINK_FLAGS,
-            "        ",
-        ),
+        "{swift_toolset_linkopts}": _bzl_list_tail(link_args, "        "),
     }
-
-def _wasm_sdk_dir(repository_ctx, bundle_dir, repo_root, triple, threads):
-    """Locates the target-triple SDK directory inside the artifact bundle.
-
-    The swift.org bundle nests the target under
-    `{bundle_name}/{triple}`, where `{bundle_name}` is the bundle directory with
-    its `.artifactbundle` suffix stripped. The swiftwasm threads bundle nests it
-    under a differently-named inner directory (e.g.
-    `6.3-RELEASE-wasm32-unknown-wasip1-threads/wasm32-unknown-wasip1-threads`),
-    so for the threads variant the inner directory is discovered by scanning for
-    the one that contains the target triple.
-    """
-    if not threads:
-        sub_path = "{0}/{1}".format(bundle_dir.removesuffix(".artifactbundle"), triple)
-        return "{}/{}/{}".format(repo_root, bundle_dir, sub_path)
-
-    for entry in repository_ctx.path(bundle_dir).readdir():
-        if entry.get_child(triple).exists:
-            return "{}/{}/{}/{}".format(repo_root, bundle_dir, entry.basename, triple)
-    fail(("The WebAssembly Swift SDK bundle at {} has an unexpected layout; " +
-          "could not find a `{}` directory under {}.").format(
-        repository_ctx.attr.url,
-        triple,
-        bundle_dir,
-    ))
 
 def _swift_wasm_sdk_impl(repository_ctx):
     threads = repository_ctx.attr.threads
-    triple = "wasm32-unknown-wasip1-threads" if threads else "wasm32-unknown-wasip1"
+    expected_triple = "wasm32-unknown-wasip1-threads" if threads else "wasm32-unknown-wasip1"
 
     bundle_dir = _download_sdk_bundle(repository_ctx)
     repo_root = "external/" + repository_ctx.name
-    sdk_dir = _wasm_sdk_dir(repository_ctx, bundle_dir, repo_root, triple, threads)
-    if not repository_ctx.path(sdk_dir.removeprefix(repo_root + "/")).exists:
-        fail("The WebAssembly Swift SDK bundle has an unexpected layout; missing " + sdk_dir)
+    context = repository_ctx.attr.url
+
+    sdk_json_path = _swift_sdk_json_path(repository_ctx, bundle_dir)
+    sdk_dir_relative = sdk_json_path.rsplit("/", 1)[0]
+    triple, target_settings = _swift_sdk_target_settings(
+        repository_ctx,
+        sdk_json_path,
+    )
+    if triple != expected_triple:
+        fail(("The WebAssembly Swift SDK bundle at {} targets `{}`, but this " +
+              "repository was configured for `{}`; pass `threads = {}` to " +
+              "`swift.wasm_sdk` to match the bundle.").format(
+            context,
+            triple,
+            expected_triple,
+            "False" if threads else "True",
+        ))
+
+    sdk_dir = "{}/{}".format(repo_root, sdk_dir_relative)
+    resource_dir = "{}/{}".format(sdk_dir, _relative_metadata_path(
+        target_settings.get("swiftStaticResourcesPath"),
+        "swiftStaticResourcesPath",
+        triple,
+    ))
+    sdkroot = "{}/{}".format(sdk_dir, _relative_metadata_path(
+        target_settings.get("sdkRootPath"),
+        "sdkRootPath",
+        triple,
+    ))
+    toolset = _toolset_options(
+        repository_ctx,
+        sdk_dir_relative,
+        target_settings,
+        triple,
+        context,
+    )
 
     substitutions = {
         "{bundle_dir}": bundle_dir,
-        "{sdk_dir}": sdk_dir,
+        "{resource_dir}": resource_dir,
+        "{sdkroot}": sdkroot,
         "{swift_version}": repository_ctx.attr.swift_version,
         "{target_triple}": triple,
         "{toolchain_repo}": repository_ctx.attr.toolchain_repo,
     }
-    substitutions.update(_wasm_thread_substitutions(threads))
+    substitutions.update(_wasm_toolset_substitutions(toolset, context))
 
     repository_ctx.template(
         "BUILD.bazel",

--- a/swift/internal/extensions/wasmsdk.BUILD
+++ b/swift/internal/extensions/wasmsdk.BUILD
@@ -31,7 +31,7 @@ swift_toolchain(
     arch = "wasm32",
     copts = [
         "-resource-dir",
-        _RESOURCE_DIR,
+        _RESOURCE_DIR,{swift_thread_copts}
     ],
     features = [
         "swift.module_map_no_private_headers",
@@ -61,7 +61,7 @@ swift_toolchain(
         # (`-O`) generic-metadata instantiation reads out of bounds at runtime
         # (`-Onone` happens to tolerate the default).
         "-Wl,--global-base=4096",
-        "-Wl,--table-base=4096",
+        "-Wl,--table-base=4096",{swift_thread_linkopts}
     ],
     os = "wasi",
     parsed_version = "{swift_version}",
@@ -106,7 +106,7 @@ cc_args(
     ],
     args = [
         "--target=wasm32-unknown-wasip1",
-        "--sysroot=" + _WASI_SDK,
+        "--sysroot=" + _WASI_SDK,{cc_thread_compile_args}
     ],
 )
 
@@ -120,7 +120,7 @@ cc_args(
     # directory does not include.
     args = [
         "-resource-dir",
-        _RESOURCE_DIR + "/clang",
+        _RESOURCE_DIR + "/clang",{cc_thread_link_args}
     ],
 )
 

--- a/swift/internal/extensions/wasmsdk.BUILD
+++ b/swift/internal/extensions/wasmsdk.BUILD
@@ -105,7 +105,7 @@ cc_args(
         "@rules_cc//cc/toolchains/actions:link_actions",
     ],
     args = [
-        "--target=wasm32-unknown-wasip1",
+        "--target={target_triple}",
         "--sysroot=" + _WASI_SDK,{cc_thread_compile_args}
     ],
 )
@@ -126,7 +126,7 @@ cc_args(
 
 cc_make_variable(
     name = "cc_target_triple_wasm32",
-    value = "wasm32-unknown-wasip1",
+    value = "{target_triple}",
     variable_name = "CC_TARGET_TRIPLE",
 )
 

--- a/swift/internal/extensions/wasmsdk.BUILD
+++ b/swift/internal/extensions/wasmsdk.BUILD
@@ -6,9 +6,11 @@ load("@rules_cc//cc/toolchains:toolchain.bzl", "cc_toolchain")
 load("@rules_swift//swift/toolchains:swift_toolchain.bzl", "swift_toolchain")
 load("@rules_swift//swift/toolchains:swift_tools.bzl", "swift_tools")
 
-_RESOURCE_DIR = "{sdk_dir}/swift.xctoolchain/usr/lib/swift_static"
+# The static resource directory and sysroot, as declared by the SDK's
+# `swift-sdk.json` (`swiftStaticResourcesPath` and `sdkRootPath`).
+_RESOURCE_DIR = "{resource_dir}"
 
-_WASI_SDK = "{sdk_dir}/WASI.sdk"
+_WASI_SDK = "{sdkroot}"
 
 filegroup(
     name = "sdk_files",
@@ -31,7 +33,7 @@ swift_toolchain(
     arch = "wasm32",
     copts = [
         "-resource-dir",
-        _RESOURCE_DIR,{swift_thread_copts}
+        _RESOURCE_DIR,{swift_toolset_copts}
     ],
     features = [
         "swift.module_map_no_private_headers",
@@ -61,7 +63,7 @@ swift_toolchain(
         # (`-O`) generic-metadata instantiation reads out of bounds at runtime
         # (`-Onone` happens to tolerate the default).
         "-Wl,--global-base=4096",
-        "-Wl,--table-base=4096",{swift_thread_linkopts}
+        "-Wl,--table-base=4096",{swift_toolset_linkopts}
     ],
     os = "wasi",
     parsed_version = "{swift_version}",
@@ -106,7 +108,7 @@ cc_args(
     ],
     args = [
         "--target={target_triple}",
-        "--sysroot=" + _WASI_SDK,{cc_thread_compile_args}
+        "--sysroot=" + _WASI_SDK,{cc_toolset_compile_args}
     ],
 )
 
@@ -120,7 +122,7 @@ cc_args(
     # directory does not include.
     args = [
         "-resource-dir",
-        _RESOURCE_DIR + "/clang",{cc_thread_link_args}
+        _RESOURCE_DIR + "/clang",{cc_toolset_link_args}
     ],
 )
 

--- a/test/utils_tests.bzl
+++ b/test/utils_tests.bzl
@@ -14,6 +14,13 @@ load("//swift/internal/extensions:standalone_toolchain.bzl", "get_download_url")
 # buildifier: disable=bzl-visibility
 load("//swift/internal/extensions:swift_sdk_releases.bzl", "swift_sdk_download_url")
 
+# buildifier: disable=bzl-visibility
+load(
+    "//swift/internal/extensions:swift_sdks.bzl",
+    "linker_options_to_clang_args",
+    "merged_toolset_options",
+)
+
 def _include_developer_search_paths_test(ctx):
     env = unittest.begin(ctx)
 
@@ -193,6 +200,90 @@ def _swift_sdk_download_url_test(ctx):
 
 swift_sdk_download_url_test = unittest.make(_swift_sdk_download_url_test)
 
+def _merged_toolset_options_test(ctx):
+    env = unittest.begin(ctx)
+
+    # The swift.org wasm32-unknown-wasip1 bundle: a single toolset with only
+    # Swift compiler options.
+    merged = merged_toolset_options(
+        [
+            {
+                "rootPath": "swift.xctoolchain/usr/bin",
+                "schemaVersion": "1.0",
+                "swiftCompiler": {
+                    "extraCLIOptions": ["-static-stdlib"],
+                },
+            },
+        ],
+        "test",
+    )
+    asserts.equals(env, [], merged.c_compiler)
+    asserts.equals(env, [], merged.cxx_compiler)
+    asserts.equals(env, [], merged.linker)
+    asserts.equals(env, ["-static-stdlib"], merged.swift_compiler)
+
+    # The wasm32-unknown-wasip1-threads bundle shape, split across two
+    # toolsets to check that `extraCLIOptions` accumulate in order.
+    merged = merged_toolset_options(
+        [
+            {
+                "cCompiler": {
+                    "extraCLIOptions": ["-matomics", "-mbulk-memory"],
+                },
+                "cxxCompiler": {
+                    "extraCLIOptions": ["-matomics", "-mbulk-memory"],
+                },
+                "linker": {
+                    "extraCLIOptions": ["--import-memory"],
+                },
+            },
+            {
+                "cCompiler": {
+                    "extraCLIOptions": ["-pthread"],
+                },
+                "linker": {
+                    "extraCLIOptions": ["--shared-memory"],
+                },
+                "swiftCompiler": {
+                    "extraCLIOptions": ["-static-stdlib"],
+                },
+            },
+        ],
+        "test",
+    )
+    asserts.equals(
+        env,
+        ["-matomics", "-mbulk-memory", "-pthread"],
+        merged.c_compiler,
+    )
+    asserts.equals(env, ["-matomics", "-mbulk-memory"], merged.cxx_compiler)
+    asserts.equals(env, ["--import-memory", "--shared-memory"], merged.linker)
+    asserts.equals(env, ["-static-stdlib"], merged.swift_compiler)
+
+    return unittest.end(env)
+
+merged_toolset_options_test = unittest.make(_merged_toolset_options_test)
+
+def _linker_options_to_clang_args_test(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        [
+            "-Wl,--import-memory",
+            "-Wl,--shared-memory",
+            "-Wl,--max-memory=1073741824",
+        ],
+        linker_options_to_clang_args(
+            ["--import-memory", "--shared-memory", "--max-memory=1073741824"],
+            "test",
+        ),
+    )
+
+    return unittest.end(env)
+
+linker_options_to_clang_args_test = unittest.make(_linker_options_to_clang_args_test)
+
 def utils_test_suite(name):
     return unittest.suite(
         name,
@@ -200,4 +291,6 @@ def utils_test_suite(name):
         include_developer_search_paths_test,
         standalone_toolchain_download_url_test,
         swift_sdk_download_url_test,
+        merged_toolset_options_test,
+        linker_options_to_clang_args_test,
     )


### PR DESCRIPTION
## What

Adds a `threads` option to the `swift.wasm_sdk` module extension so a consumer
can target `wasm32-unknown-wasip1-threads` (WebAssembly with shared memory,
atomics, and wasi-threads) in addition to the single-threaded
`wasm32-unknown-wasip1`. This unblocks building threaded Swift-wasm reactors
that run with real multicore parallelism (e.g. under WAMR with wasi-threads) via
`bazel build`.

To support the second bundle flavor without a second set of hardcoded flags and
paths, the wasm repository rule now derives the target triple, SDK paths, and
compiler/linker flags from the metadata the bundle itself ships
(`info.json` / `swift-sdk.json` / `toolset.json`) — details below.

```starlark
swift.wasm_sdk(
    toolchain_name = "swift",
    threads = True,
    url = "https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.3-RELEASE/swift-wasm-6.3-RELEASE-wasm32-unknown-wasip1-threads.artifactbundle.zip",
    sha256 = "…",
)
```

## Why an explicit `url` + `sha256`

swift.org does **not** publish a threads bundle — the computed
`https://download.swift.org/.../swift-<v>-RELEASE_wasm.artifactbundle.tar.gz`
URL 404s for the threads variant. The threads SDK comes from
[swiftwasm](https://github.com/swiftwasm/swift/releases) instead, e.g.
`swift-wasm-6.3-RELEASE-wasm32-unknown-wasip1-threads.artifactbundle.zip`. So the
extension gains `url` and `sha256` attrs that override the computed swift.org URL
(and are required when `threads = True`).

The `url`/`sha256` override is also usable on the non-threads path if you want to
pin a mirror.

## The repository rule is driven by the bundle's own metadata

Rather than hardcoding per-variant flags and directory layouts, the repository
rule now parses the metadata every Swift SDK artifact bundle ships (both the
swift.org and swiftwasm bundles follow the same scheme):

1. **`info.json`** names the bundle's artifacts; the default (non-embedded)
   artifact's `swift-sdk.json` path replaces the previous
   bundle-layout computation/scan. (Embedded Swift variants —
   `embedded-swift-sdk.json` — are ignored.)
2. **`swift-sdk.json`** provides the **target triple** (validated against the
   `threads` attribute, so pointing `threads = True` at a single-threaded
   bundle or vice versa fails with a clear message), plus `sdkRootPath` and
   `swiftStaticResourcesPath`, which replace the previously hardcoded
   `WASI.sdk` / `swift.xctoolchain/usr/lib/swift_static` paths.
3. **`toolset.json`** (via `toolsetPaths`, merged in order) provides the
   per-tool `extraCLIOptions`:
   - `cCompiler`/`cxxCompiler` options → the generated `cc_args` (compile);
     for the threads bundle this is `-matomics -mbulk-memory -mthread-model
     posix -pthread -ftls-model=local-exec`.
   - `swiftCompiler` options → `swift_toolchain` copts (for the threads bundle:
     `-static-stdlib` plus the clang flags via `-Xcc`; for the swift.org
     bundle: `-static-stdlib`).
   - `linker` options are raw `wasm-ld` flags (SwiftPM invokes the linker
     directly), so they are wrapped in `-Wl,` for the clang driver the
     generated toolchains link through (threads bundle: `--import-memory
     --export-memory --shared-memory --max-memory=1073741824`).
   - `rootPath` and per-tool executable overrides are intentionally ignored:
     the generated toolchains always drive the paired standalone toolchain's
     own `swiftc`/`clang`.

The parsing helpers (`_relative_metadata_path`, `_swift_sdk_json_path`,
`_swift_sdk_target_settings`, `merged_toolset_options`,
`linker_options_to_clang_args`) are SDK-kind-agnostic, so the Android
repository rule and the Static Linux SDK proposed in #1813 can share them —
`_relative_metadata_path` is taken verbatim from #1813 so whichever lands
second rebases cleanly onto the other's copy.

## Backwards compatibility

The single-threaded path now reads the same metadata. For the swift.org
`wasm32-unknown-wasip1` bundle the resolved paths are identical and the only
flag delta is that the bundle toolset's `-static-stdlib` is now passed to
`swiftc` — inert for compile actions: rebuilding the wasm example produced
bit-identical objects (all downstream actions cache-hit) and
`//examples/cross_compilation/wasm:reactor_test` passes.

## Verification

- **Single-threaded** (swift.org bundle through the metadata path):
  `//examples/cross_compilation/wasm:reactor_test` passes; the recompiled
  objects are bit-identical to before, so everything downstream cache-hits.
- **Threads, end-to-end** on macOS/arm64: a `withTaskGroup` program compiles
  against the `wasm32-unknown-wasip1-threads` swiftmodules, links a
  shared-memory module, and runs under
  `wasmtime -W threads=y,shared-memory=y -S threads=y`. A peak-concurrency
  probe confirms tasks actually run in parallel (8 workers, peak 4 concurrent
  tasks). After the metadata rework the generated toolchains are byte-identical
  to the previously hand-mirrored flags. Full transcript in the PR comments.
- **Unit tests** for `merged_toolset_options` (accumulation across multiple
  toolsets, both bundle shapes) and `linker_options_to_clang_args` in
  `test/utils_tests.bzl`.

## Files changed

- `swift/extensions.bzl` — `threads` (bool), `url` (string) attrs on the
  `wasm_sdk` tag class; `_setup_wasm_sdk` validation + URL/sha256 selection;
  threading `threads`/`url` through to the repository rule.
- `swift/internal/extensions/swift_sdks.bzl` — metadata parsing
  (`info.json`/`swift-sdk.json`/`toolset.json`) shared helpers; triple
  validation against `threads`; toolset-driven template substitutions.
- `swift/internal/extensions/wasmsdk.BUILD` — resource-dir/sysroot and
  compile/link flag placeholders filled from the SDK metadata.
- `test/utils_tests.bzl` — unit tests for the toolset helpers.
