### PR TITLE
Remove -objc_abi_version linker flag

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -251,12 +251,6 @@ def _swift_linkopts_cc_info(
     ] + [
         "-L{}".format(swift_lib_dir),
         "-L/usr/lib/swift",
-        # TODO(b/112000244): This should get added by the C++ Starlark API,
-        # but we're using the "c++-link-executable" action right now instead
-        # of "objc-executable" because the latter requires additional
-        # variables not provided by cc_common. Figure out how to handle this
-        # correctly.
-        "-Wl,-objc_abi_version,2",
     ])
 
     # Compute the necessary rpaths for back-deployed compatibility libraries.

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -292,7 +292,6 @@ def features_test_suite(name, tags = []):
         expected_argv = [
             "-L/usr/lib/swift",
             "-ObjC",
-            "-Wl,-objc_abi_version,2",
             "-Wl,-rpath,/usr/lib/swift",
         ],
         mnemonic = "CppLink",
@@ -305,7 +304,6 @@ def features_test_suite(name, tags = []):
         tags = all_tags,
         expected_argv = [
             "-L/usr/lib/swift",
-            "-Wl,-objc_abi_version,2",
             "-Wl,-rpath,/usr/lib/swift",
         ],
         not_expected_argv = ["-ObjC"],
@@ -320,7 +318,6 @@ def features_test_suite(name, tags = []):
         expected_argv = [
             "-L/usr/lib/swift",
             "-ObjC",
-            "-Wl,-objc_abi_version,2",
             "-Wl,-rpath,/usr/lib/swift",
         ],
         mnemonic = "CppLink",
@@ -333,7 +330,6 @@ def features_test_suite(name, tags = []):
         tags = all_tags,
         expected_argv = [
             "-L/usr/lib/swift",
-            "-Wl,-objc_abi_version,2",
             "-Wl,-rpath,/usr/lib/swift",
         ],
         not_expected_argv = ["-ObjC"],


### PR DESCRIPTION
This only affected non 32 bit macOS and doesn't seem to be passed by
Xcode anymore unless you set it to not 2, in which case ld rejects it
anyways.
