### PR TITLE
Remove Xcode rpaths for non macOS binaries

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -119,6 +119,12 @@ _DEVELOPER_DIR_SYMLINKS = [
     "/var/db/xcode_select_link",
 ]
 
+def _developer_dir_symlinks_for_target(target_triple):
+    """Returns the developer directory symlinks that are valid for a target."""
+    if target_triples.unversioned_os(target_triple) == "macos":
+        return _DEVELOPER_DIR_SYMLINKS
+    return []
+
 def _platform_developer_framework_dir(
         developer_dir,
         target_triple):
@@ -269,7 +275,7 @@ def _swift_linkopts_cc_info(
     )
     rpaths = ["/usr/lib/swift"] + [
         paths.join(developer_dir_symlink, compatibility_dir)
-        for developer_dir_symlink in _DEVELOPER_DIR_SYMLINKS
+        for developer_dir_symlink in _developer_dir_symlinks_for_target(target_triple)
         for compatibility_dir in swift_compatibility_lib_dirs
     ]
     linkopts += [
@@ -319,7 +325,7 @@ def _test_linking_context(target_triple, toolchain_label):
     # libraries are found if Xcode is installed in a different location on the
     # machine that runs the tests than the machine used to link them.
     linkopts = []
-    for developer_dir in _DEVELOPER_DIR_SYMLINKS:
+    for developer_dir in _developer_dir_symlinks_for_target(target_triple):
         platform_developer_framework_dir = _platform_developer_framework_dir(
             developer_dir,
             target_triple,

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -112,6 +112,14 @@ disable_objc_test = make_action_command_line_test_rule(
     },
 )
 
+ios_test = make_action_command_line_test_rule(
+    config_settings = {
+        "//command_line_option:platforms": [
+            str(Label("@apple_support//platforms:ios_arm64")),
+        ],
+    },
+)
+
 embedded_test = make_action_command_line_test_rule(
     config_settings = {
         "//command_line_option:features": [
@@ -351,6 +359,21 @@ def features_test_suite(name, tags = []):
         ],
         mnemonic = "CppLink",
         target_under_test = "//test/fixtures/xctest_runner:PassingUnitTests",
+        target_compatible_with = ["@platforms//os:macos"],
+    )
+
+    ios_test(
+        name = "{}_ios_link_omits_developer_dir_symlink_rpaths_test".format(name),
+        tags = all_tags,
+        expected_argv = [
+            "-Wl,-rpath,/usr/lib/swift",
+        ],
+        not_expected_argv = [
+            "-Wl,-rpath,/private/var/select/developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-6.2/iphoneos",
+            "-Wl,-rpath,/var/db/xcode_select_link/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-6.2/iphoneos",
+        ],
+        mnemonic = "CppLink",
+        target_under_test = "//test/fixtures/linking:bin",
         target_compatible_with = ["@platforms//os:macos"],
     )
 


### PR DESCRIPTION
These are for XCTest + compatibility libraries, but when running in a
simulator these paths never exist so they shouldn't be added.

https://github.com/bazelbuild/rules_swift/pull/1589#issuecomment-5051707210
