### PR TITLE
Scope linkopts logic to wasm

### DIFF
--- a/examples/cross_compilation/android_app/android.MODULE.bazel
+++ b/examples/cross_compilation/android_app/android.MODULE.bazel
@@ -8,6 +8,16 @@ bazel_dep(name = "rules_kotlin", version = "2.2.2", dev_dependency = True)
 swift = use_extension("//swift:extensions.bzl", "swift", dev_dependency = True)
 swift.android_sdk(toolchain_name = "swift_toolchain")
 
+# TODO: Remove once https://github.com/bazelbuild/rules_android/commit/57ad9e4898b726c3938c5173a3f3f9adef9384dc is in a release
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-koIx40jK5V/o9qC8zaOc5Jbgp+nY7QG0dpak9FT4VWA=",
+    strip_prefix = "rules_android-71c053c203ea875f069092b989d4704ddecb5caf",
+    urls = [
+        "https://github.com/bazelbuild/rules_android/archive/71c053c203ea875f069092b989d4704ddecb5caf.tar.gz",
+    ],
+)
+
 rules_java_toolchains = use_extension(
     "@rules_java//java:extensions.bzl",
     "toolchains",

--- a/swift/toolchains/swift_toolchain.bzl
+++ b/swift/toolchains/swift_toolchain.bzl
@@ -713,15 +713,13 @@ def _swift_toolchain_impl(ctx):
             ["--sysroot={}".format(sdkroot)] + ctx.attr.linkopts,
             ctx.files.linker_inputs,
         )
-    elif ctx.attr.linkopts or ctx.attr.linker_inputs:
-        # A toolchain whose Swift runtime comes from a Swift SDK (e.g.
-        # WebAssembly) provides the *complete* set of runtime link flags via
-        # `linkopts`/`linker_inputs`, replacing — not adding to — the defaults
-        # computed below. Those defaults are specific to a Linux *host* toolchain
-        # (`-pie`, `-static-libgcc`, `-lrt`, and the host toolchain's own
-        # `-L`/rpath and `swiftrt.o`); for a cross-compiled SDK target they are
-        # at best wrong and at worst invalid (wasm-ld rejects `-pie`, and a
-        # second `swiftrt.o` would conflict with the SDK's own).
+    elif ctx.attr.os == "wasi":
+        # A WebAssembly Swift SDK provides the complete set of runtime link
+        # flags via `linkopts`/`linker_inputs`, replacing — not adding to — the
+        # defaults computed below. Those defaults are specific to a Unix host
+        # toolchain (`-pie`, `-static-libgcc`, `-lrt`, and the host toolchain's
+        # own `-L`/rpath and `swiftrt.o`); wasm-ld rejects some of them, and a
+        # second `swiftrt.o` would conflict with the SDK's own.
         swift_linkopts_cc_info = _swift_sdk_linkopts_cc_info(
             ctx.label,
             ctx.attr.linkopts,


### PR DESCRIPTION
These fields are named generically but currently they are only usable
together for wasm. By changing it to be specific to the OS we can use
these for other platforms in the future.
