### PR TITLE
Fix symbol graph extraction when explicit modules is enabled

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -738,12 +738,15 @@ def compile_action_configs(
         ),
 
         # Configure how implicit modules are handled--either using the module
-        # cache, or disabled completely when using explicit modules.
+        # cache, or disabled completely when using explicit modules. Symbol
+        # graph extraction always uses implicit modules because
+        # `swift-symbolgraph-extract` cannot consume explicit modules (see
+        # below), so it gets a module cache configuration even when
+        # `swift.use_c_modules` is enabled.
         ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [_global_module_cache_configurator],
             features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
@@ -753,10 +756,15 @@ def compile_action_configs(
             ],
         ),
         ActionConfigInfo(
+            actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
+            configurators = [_global_module_cache_configurator],
+            features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
+            not_features = [SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR],
+        ),
+        ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [_tmpdir_module_cache_configurator],
             features = [
@@ -766,10 +774,17 @@ def compile_action_configs(
             not_features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
         ActionConfigInfo(
+            actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
+            configurators = [_tmpdir_module_cache_configurator],
+            features = [
+                SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE,
+                SWIFT_FEATURE_GLOBAL_MODULE_CACHE_USES_TMPDIR,
+            ],
+        ),
+        ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [
                 add_arg("-Xwrapped-swift=-ephemeral-module-cache"),
@@ -778,6 +793,13 @@ def compile_action_configs(
                 [SWIFT_FEATURE_USE_C_MODULES],
                 [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
             ],
+        ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
+            configurators = [
+                add_arg("-Xwrapped-swift=-ephemeral-module-cache"),
+            ],
+            not_features = [SWIFT_FEATURE_USE_GLOBAL_MODULE_CACHE],
         ),
         ActionConfigInfo(
             actions = all_compile_action_names() + [
@@ -789,13 +811,14 @@ def compile_action_configs(
 
         # When using C modules, disable the implicit search for module map files
         # because all of them, including system dependencies, will be provided
-        # explicitly.
+        # explicitly. Symbol graph extraction is excluded because
+        # `swift-symbolgraph-extract` cannot consume explicit modules (see
+        # below), so it must be allowed to compile modules implicitly.
         ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -804,11 +827,13 @@ def compile_action_configs(
             ],
             features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
+        # `swift-symbolgraph-extract` only supports a small allowlist of
+        # arguments and rejects `-Xfrontend`, so these flags must not be passed
+        # to symbol graph extraction.
         ActionConfigInfo(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -825,7 +850,6 @@ def compile_action_configs(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -1072,10 +1096,23 @@ def compile_action_configs(
         ),
         ActionConfigInfo(
             actions = [
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [_dependencies_clang_modules_configurator],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ),
+
+        # `swift-symbolgraph-extract` cannot consume explicit modules: it does
+        # not read the explicit Swift module map JSON, so system Clang modules
+        # are never provided explicitly, and it does not apply `-clang-target`
+        # to its ClangImporter instance, so precompiled modules built for a
+        # shared clang target are rejected as a configuration mismatch. Fall
+        # back to module maps with implicit module compilation for this action,
+        # the same configuration it uses when `swift.use_c_modules` is
+        # disabled.
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
+            configurators = [_dependencies_clang_modulemaps_configurator],
             features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
         # These actions do not support reading system modules from the

--- a/test/fixtures/symbol_graphs/BUILD
+++ b/test/fixtures/symbol_graphs/BUILD
@@ -6,6 +6,7 @@ load(
     "//swift:swift_library.bzl",
     "swift_library",
 )
+load("//test:transitions.bzl", "transition_binary")
 load(
     "//test/fixtures:common.bzl",
     "FIXTURE_TAGS",
@@ -65,5 +66,23 @@ swift_extract_symbol_graph(
     targets = [
         ":importing_module",
         ":some_module",
+    ],
+)
+
+# Verifies that symbol graph extraction works in a build that uses explicit
+# modules, since `swift-symbolgraph-extract` only supports a small allowlist
+# of compiler arguments and cannot consume explicit modules itself.
+transition_binary(
+    name = "importing_module_symbol_graph_explicit_modules",
+    tags = FIXTURE_TAGS,
+    target = ":importing_module_symbol_graph",
+    target_compatible_with = select({
+        "//test:apple_build_tests_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    transitive_features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+        "swift.use_explicit_swift_module_map",
     ],
 )

--- a/test/rules/symbol_graph_action_command_line_test.bzl
+++ b/test/rules/symbol_graph_action_command_line_test.bzl
@@ -1,0 +1,185 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A rule for testing the command line of symbol graph extraction actions.
+
+`SwiftSymbolGraphExtract` actions are registered by
+`swift_symbol_graph_aspect`, not by the target the aspect is applied to, so
+they are not visible to `analysistest`-based harnesses like
+`action_command_line_test` (whose action-retrieving aspect is applied before
+any extra aspects and therefore cannot see their actions). This rule instead
+applies `swift_symbol_graph_aspect` followed by its own action-capturing
+aspect, whose `required_aspect_providers` orders it after the symbol graph
+aspect so that `target.actions` includes the extraction actions.
+"""
+
+load("@bazel_skylib//lib:shell.bzl", "shell")
+load("//swift:providers.bzl", "SwiftSymbolGraphInfo")
+load("//swift:swift_symbol_graph_aspect.bzl", "swift_symbol_graph_aspect")
+
+_CapturedActionsInfo = provider(
+    doc = "Captures the actions registered on a target and its aspects.",
+    fields = ["actions"],
+)
+
+def _captured_actions_aspect_impl(target, _aspect_ctx):
+    return [_CapturedActionsInfo(actions = target.actions)]
+
+_captured_actions_aspect = aspect(
+    implementation = _captured_actions_aspect_impl,
+    # Order this aspect after `swift_symbol_graph_aspect` so that
+    # `target.actions` includes the actions the symbol graph aspect registers.
+    required_aspect_providers = [SwiftSymbolGraphInfo],
+)
+
+def _features_transition_impl(settings, attr):
+    return {
+        "//command_line_option:features": (
+            settings["//command_line_option:features"] + attr.features_under_test
+        ),
+    }
+
+_features_transition = transition(
+    implementation = _features_transition_impl,
+    inputs = ["//command_line_option:features"],
+    outputs = ["//command_line_option:features"],
+)
+
+def _failure_script(message):
+    return "\n".join([
+        "#!/usr/bin/env bash",
+        "echo {} >&2".format(shell.quote("ERROR: " + message)),
+        "exit 1",
+        "",
+    ])
+
+def _symbol_graph_action_command_line_test_impl(ctx):
+    target_under_test = ctx.attr.target_under_test[0]
+    actions = target_under_test[_CapturedActionsInfo].actions
+    matching_actions = [
+        action
+        for action in actions
+        if action.mnemonic == "SwiftSymbolGraphExtract"
+    ]
+
+    script_file = ctx.actions.declare_file("{}.sh".format(ctx.label.name))
+    runfiles_files = []
+
+    if len(matching_actions) != 1:
+        ctx.actions.write(
+            output = script_file,
+            content = _failure_script(
+                ("Expected exactly one SwiftSymbolGraphExtract action on " +
+                 "target '{}', but found {} (mnemonics: {}).").format(
+                    str(target_under_test.label),
+                    len(matching_actions),
+                    [action.mnemonic for action in actions],
+                ),
+            ),
+            is_executable = True,
+        )
+    else:
+        # Concatenate the arguments into a single string, with a trailing
+        # space, so that expected substrings can be matched as `<arg> ` or
+        # `<arg>=` without matching prefixes of longer arguments (the same
+        # semantics as `action_command_line_test`).
+        concatenated_args = " ".join(matching_actions[0].argv) + " "
+        args_file = ctx.actions.declare_file(
+            "{}_args.txt".format(ctx.label.name),
+        )
+        ctx.actions.write(output = args_file, content = concatenated_args)
+        runfiles_files.append(args_file)
+
+        script_lines = [
+            "#!/usr/bin/env bash",
+            "args_file={}".format(shell.quote(args_file.short_path)),
+            "failed=0",
+            "function check_expected() {",
+            "  if ! grep -qF -- \"$1 \" \"$args_file\" && " +
+            "! grep -qF -- \"$1=\" \"$args_file\"; then",
+            "    echo \"ERROR: expected argv to contain '$1', but it did " +
+            "not: $(cat \"$args_file\")\" >&2",
+            "    failed=1",
+            "  fi",
+            "}",
+            "function check_not_expected() {",
+            "  if grep -qF -- \"$1 \" \"$args_file\" || " +
+            "grep -qF -- \"$1=\" \"$args_file\"; then",
+            "    echo \"ERROR: expected argv to not contain '$1', but it " +
+            "did: $(cat \"$args_file\")\" >&2",
+            "    failed=1",
+            "  fi",
+            "}",
+        ]
+        for expected in ctx.attr.expected_argv:
+            script_lines.append(
+                "check_expected {}".format(shell.quote(expected)),
+            )
+        for not_expected in ctx.attr.not_expected_argv:
+            script_lines.append(
+                "check_not_expected {}".format(shell.quote(not_expected)),
+            )
+        script_lines.append("exit $failed")
+        script_lines.append("")
+
+        ctx.actions.write(
+            output = script_file,
+            content = "\n".join(script_lines),
+            is_executable = True,
+        )
+
+    return [
+        DefaultInfo(
+            executable = script_file,
+            runfiles = ctx.runfiles(files = runfiles_files),
+        ),
+    ]
+
+symbol_graph_action_command_line_test = rule(
+    attrs = {
+        "expected_argv": attr.string_list(
+            doc = """\
+A list of strings representing substrings expected to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+        ),
+        "features_under_test": attr.string_list(
+            doc = """\
+Feature strings appended to `--features` in the configuration of the target
+under test.
+""",
+        ),
+        "not_expected_argv": attr.string_list(
+            doc = """\
+A list of strings representing substrings expected not to appear in the action
+command line, after concatenating all command line arguments into a single
+space-delimited string.
+""",
+        ),
+        "target_under_test": attr.label(
+            aspects = [swift_symbol_graph_aspect, _captured_actions_aspect],
+            cfg = _features_transition,
+            doc = "The target whose symbol graph extraction is inspected.",
+            mandatory = True,
+        ),
+    },
+    doc = """\
+Tests the command line of the `SwiftSymbolGraphExtract` action registered by
+`swift_symbol_graph_aspect` on the target under test, optionally under
+additional feature settings.
+""",
+    implementation = _symbol_graph_action_command_line_test_impl,
+    test = True,
+)

--- a/test/symbol_graphs_tests.bzl
+++ b/test/symbol_graphs_tests.bzl
@@ -15,6 +15,10 @@
 """Tests for extracting symbol graphs."""
 
 load("//test/rules:directory_test.bzl", "directory_test")
+load(
+    "//test/rules:symbol_graph_action_command_line_test.bzl",
+    "symbol_graph_action_command_line_test",
+)
 
 def symbol_graphs_test_suite(name, tags = []):
     """Test suite for extracting symbol graphs.
@@ -85,6 +89,63 @@ def symbol_graphs_test_suite(name, tags = []):
         },
         tags = all_tags,
         target_under_test = "//test/fixtures/symbol_graphs:all_symbol_graphs",
+    )
+
+    # Verify that symbol graph extraction in an explicit modules build does
+    # not pass flags that `swift-symbolgraph-extract` does not support, and
+    # falls back to module maps with an implicit module cache.
+    symbol_graph_action_command_line_test(
+        name = "{}_explicit_modules_uses_implicit_modules".format(name),
+        expected_argv = [
+            "-module-cache-path",
+        ],
+        features_under_test = [
+            "swift.emit_c_module",
+            "swift.use_c_modules",
+            "swift.use_explicit_swift_module_map",
+        ],
+        not_expected_argv = [
+            "-Xfrontend -disable-building-interface",
+            "-Xfrontend -disable-implicit-swift-modules",
+            "-Xcc -fno-implicit-module-maps",
+            "-Xcc -fno-implicit-modules",
+            "-Xcc -fmodule-file",
+        ],
+        tags = all_tags,
+        target_under_test = "//test/fixtures/symbol_graphs:some_module",
+    )
+
+    # Verify that symbol graph extraction in an explicit modules build uses an
+    # ephemeral module cache when the global module cache is disabled.
+    symbol_graph_action_command_line_test(
+        name = "{}_explicit_modules_uses_ephemeral_module_cache".format(name),
+        expected_argv = [
+            "-Xwrapped-swift=-ephemeral-module-cache",
+        ],
+        features_under_test = [
+            "swift.emit_c_module",
+            "swift.use_c_modules",
+            "-swift.use_global_module_cache",
+        ],
+        tags = all_tags,
+        target_under_test = "//test/fixtures/symbol_graphs:some_module",
+    )
+
+    # Verify that symbol graph extraction succeeds in a build that uses
+    # explicit modules.
+    directory_test(
+        name = "{}_extract_rule_succeeds_with_explicit_modules".format(name),
+        expected_directories = {
+            "test/fixtures/symbol_graphs/importing_module_symbol_graph.symbolgraphs": [
+                "ImportingModule.symbols.json",
+            ],
+        },
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/symbol_graphs:importing_module_symbol_graph_explicit_modules",
     )
 
     native.test_suite(


### PR DESCRIPTION
Fix symbol graph extraction when using explicit modules via `swift.use_c_modules`


When `swift.use_c_modules` is enabled, the `SwiftSymbolGraphExtract` action would send unrecognized arguments resulting in errors:

```
<unknown>:0: error: unknown argument: '-Xfrontend'
<unknown>:0: error: unknown argument: '-disable-building-interface'
<unknown>:0: error: unknown argument: '-Xfrontend'
<unknown>:0: error: unknown argument: '-disable-implicit-swift-modules'
```

Other issues when `swift.use_c_modules` is enabled:
* `swift-symbolgraph-extract` does not apply `-clang-target` to its ClangImporter instance, so precompiled modules built for a shared clang target are rejected as a configuration mismatch (`"was compiled for the target 'arm64-apple-iosXX' but the current translation unit is being compiled for target ..."`).
* `swift-symbolgraph-extract` doesn't support explicit module map JSON files. So when this is used in combination with disabling explicit modules via `swift.use_c_modules`, the extractor would be unable to load modules for system modules (`"cannot load underlying module for 'Darwin'"`)