### PR TITLE
Use HEAD rules_android for CI

### DIFF
--- a/examples/cross_compilation/android_app/android.MODULE.bazel
+++ b/examples/cross_compilation/android_app/android.MODULE.bazel
@@ -8,6 +8,16 @@ bazel_dep(name = "rules_kotlin", version = "2.2.2", dev_dependency = True)
 swift = use_extension("//swift:extensions.bzl", "swift", dev_dependency = True)
 swift.android_sdk(toolchain_name = "swift_toolchain")
 
+# TODO: Remove once https://github.com/bazelbuild/rules_android/commit/57ad9e4898b726c3938c5173a3f3f9adef9384dc is in a release
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-koIx40jK5V/o9qC8zaOc5Jbgp+nY7QG0dpak9FT4VWA=",
+    strip_prefix = "rules_android-71c053c203ea875f069092b989d4704ddecb5caf",
+    urls = [
+        "https://github.com/bazelbuild/rules_android/archive/71c053c203ea875f069092b989d4704ddecb5caf.tar.gz",
+    ],
+)
+
 rules_java_toolchains = use_extension(
     "@rules_java//java:extensions.bzl",
     "toolchains",


### PR DESCRIPTION
This is required for bazel @ HEAD, doesn't affect downstream users
