### PR TITLE
Fix symbolgraph extraction with explicit modules

### DIFF
--- a/swift/internal/symbol_graph_extracting.bzl
+++ b/swift/internal/symbol_graph_extracting.bzl
@@ -20,7 +20,7 @@ load(":actions.bzl", "run_toolchain_action")
 load(":compiling.bzl", "transitive_swift_dependency_inputs")
 load(":features.bzl", "gather_toolchains")
 load(":toolchain_utils.bzl", "SWIFT_TOOLCHAIN_TYPE")
-load(":utils.bzl", "merge_compilation_contexts")
+load(":utils.bzl", "get_swift_implicit_deps", "merge_compilation_contexts")
 
 def extract_symbol_graph(
         *,
@@ -81,16 +81,18 @@ def extract_symbol_graph(
         toolchains = toolchains,
     )
 
+    implicit_swift_infos, implicit_cc_infos = get_swift_implicit_deps(
+        feature_configuration = feature_configuration,
+        swift_toolchain = toolchains.swift,
+    )
     merged_compilation_context = merge_compilation_contexts(
         transitive_compilation_contexts = compilation_contexts + [
             cc_info.compilation_context
-            for cc_info in toolchains.swift.implicit_deps_providers.cc_infos
+            for cc_info in implicit_cc_infos
         ],
     )
     merged_swift_info = SwiftInfo(
-        swift_infos = (
-            swift_infos + toolchains.swift.implicit_deps_providers.swift_infos
-        ),
+        swift_infos = swift_infos + implicit_swift_infos,
     )
 
     # Flattening this `depset` is necessary because we need to extract the

--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -808,7 +808,6 @@ def compile_action_configs(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -825,7 +824,6 @@ def compile_action_configs(
             actions = all_compile_action_names() + [
                 SWIFT_ACTION_DUMP_AST,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [
@@ -1072,18 +1070,20 @@ def compile_action_configs(
         ),
         ActionConfigInfo(
             actions = [
-                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
                 SWIFT_ACTION_SYNTHESIZE_INTERFACE,
             ],
             configurators = [_dependencies_clang_modules_configurator],
             features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
+
         # These actions do not support reading system modules from the
-        # explicit module map json file
+        # explicit module map JSON file, so pass all Clang modules directly,
+        # including system modules.
         ActionConfigInfo(
             actions = [
                 SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_PRECOMPILE_C_MODULE,
+                SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT,
             ],
             configurators = [
                 lambda prerequisites, args: _dependencies_clang_modules_configurator(

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -475,6 +475,7 @@ def _all_action_configs(
         ActionConfigInfo(
             actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
             configurators = [
+                # https://github.com/swiftlang/swift/pull/91039
                 # `swift-symbolgraph-extract` accepts `-clang-target` but does
                 # not apply it to ClangImporter, so pass the shared SDK target
                 # directly to Clang as well.

--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -472,6 +472,16 @@ def _all_action_configs(
             ],
             features = [SWIFT_FEATURE_USE_C_MODULES],
         ),
+        ActionConfigInfo(
+            actions = [SWIFT_ACTION_SYMBOL_GRAPH_EXTRACT],
+            configurators = [
+                # `swift-symbolgraph-extract` accepts `-clang-target` but does
+                # not apply it to ClangImporter, so pass the shared SDK target
+                # directly to Clang as well.
+                add_arg("-Xcc", "--target={}".format(sdk_version_triple)),
+            ],
+            features = [SWIFT_FEATURE_USE_C_MODULES],
+        ),
     ])
 
     action_configs.extend([

--- a/test/fixtures/symbol_graphs/BUILD
+++ b/test/fixtures/symbol_graphs/BUILD
@@ -6,6 +6,7 @@ load(
     "//swift:swift_library.bzl",
     "swift_library",
 )
+load("//test:transitions.bzl", "transition_binary")
 load(
     "//test/fixtures:common.bzl",
     "FIXTURE_TAGS",
@@ -65,5 +66,22 @@ swift_extract_symbol_graph(
     targets = [
         ":importing_module",
         ":some_module",
+    ],
+)
+
+# Verifies that symbol graph extraction works in a build that uses explicit
+# modules.
+transition_binary(
+    name = "importing_module_symbol_graph_explicit_modules",
+    tags = FIXTURE_TAGS,
+    target = ":importing_module_symbol_graph",
+    target_compatible_with = select({
+        "//test:apple_build_tests_enabled": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    transitive_features = [
+        "swift.emit_c_module",
+        "swift.use_c_modules",
+        "swift.use_explicit_swift_module_map",
     ],
 )

--- a/test/fixtures/symbol_graphs/BUILD
+++ b/test/fixtures/symbol_graphs/BUILD
@@ -41,6 +41,13 @@ swift_library(
     deps = [":some_module"],
 )
 
+swift_library(
+    name = "sqlite_importing_module",
+    srcs = ["SQLiteImportingModule.swift"],
+    module_name = "SQLiteImportingModule",
+    tags = FIXTURE_TAGS,
+)
+
 swift_extract_symbol_graph(
     name = "some_module_symbol_graph",
     tags = FIXTURE_TAGS,
@@ -61,6 +68,12 @@ swift_extract_symbol_graph(
 )
 
 swift_extract_symbol_graph(
+    name = "sqlite_importing_module_symbol_graph",
+    tags = FIXTURE_TAGS,
+    targets = [":sqlite_importing_module"],
+)
+
+swift_extract_symbol_graph(
     name = "all_symbol_graphs",
     tags = FIXTURE_TAGS,
     targets = [
@@ -69,17 +82,18 @@ swift_extract_symbol_graph(
     ],
 )
 
-# Verifies that symbol graph extraction works in a build that uses explicit
-# modules.
+# Verifies that symbol graph extraction can load a default precompiled system
+# module in a build that uses explicit modules.
 transition_binary(
-    name = "importing_module_symbol_graph_explicit_modules",
+    name = "sqlite_importing_module_symbol_graph_explicit_modules",
     tags = FIXTURE_TAGS,
-    target = ":importing_module_symbol_graph",
+    target = ":sqlite_importing_module_symbol_graph",
     target_compatible_with = select({
         "//test:apple_build_tests_enabled": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     transitive_features = [
+        "swift.add_default_precompiled_modules",
         "swift.emit_c_module",
         "swift.use_c_modules",
         "swift.use_explicit_swift_module_map",

--- a/test/fixtures/symbol_graphs/SQLiteImportingModule.swift
+++ b/test/fixtures/symbol_graphs/SQLiteImportingModule.swift
@@ -1,0 +1,6 @@
+import SQLite3
+
+/// Returns the SQLite library version.
+public func sqliteVersion() -> String {
+  String(cString: sqlite3_libversion())
+}

--- a/test/symbol_graphs_tests.bzl
+++ b/test/symbol_graphs_tests.bzl
@@ -88,10 +88,10 @@ def symbol_graphs_test_suite(name, tags = []):
     )
 
     directory_test(
-        name = "{}_extract_rule_succeeds_with_explicit_modules".format(name),
+        name = "{}_extract_rule_succeeds_with_explicit_modules_and_system_module".format(name),
         expected_directories = {
-            "test/fixtures/symbol_graphs/importing_module_symbol_graph.symbolgraphs": [
-                "ImportingModule.symbols.json",
+            "test/fixtures/symbol_graphs/sqlite_importing_module_symbol_graph.symbolgraphs": [
+                "SQLiteImportingModule.symbols.json",
             ],
         },
         tags = all_tags,
@@ -99,7 +99,7 @@ def symbol_graphs_test_suite(name, tags = []):
             "//test:apple_build_tests_enabled": [],
             "//conditions:default": ["@platforms//:incompatible"],
         }),
-        target_under_test = "//test/fixtures/symbol_graphs:importing_module_symbol_graph_explicit_modules",
+        target_under_test = "//test/fixtures/symbol_graphs:sqlite_importing_module_symbol_graph_explicit_modules",
     )
 
     native.test_suite(

--- a/test/symbol_graphs_tests.bzl
+++ b/test/symbol_graphs_tests.bzl
@@ -87,6 +87,21 @@ def symbol_graphs_test_suite(name, tags = []):
         target_under_test = "//test/fixtures/symbol_graphs:all_symbol_graphs",
     )
 
+    directory_test(
+        name = "{}_extract_rule_succeeds_with_explicit_modules".format(name),
+        expected_directories = {
+            "test/fixtures/symbol_graphs/importing_module_symbol_graph.symbolgraphs": [
+                "ImportingModule.symbols.json",
+            ],
+        },
+        tags = all_tags,
+        target_compatible_with = select({
+            "//test:apple_build_tests_enabled": [],
+            "//conditions:default": ["@platforms//:incompatible"],
+        }),
+        target_under_test = "//test/fixtures/symbol_graphs:importing_module_symbol_graph_explicit_modules",
+    )
+
     native.test_suite(
         name = name,
         tags = all_tags,


### PR DESCRIPTION
This CLI doesn't accept all arguments, so remove it from some configs,
it also doesn't accept the explicit module json file, so pass all
modules directly

Closes https://github.com/bazelbuild/rules_swift/pull/1866
