### PR TITLE
fix(mixed_language_library): Include own source files in code coverage file info

### DIFF
--- a/mixed_language/internal/library.bzl
+++ b/mixed_language/internal/library.bzl
@@ -231,7 +231,7 @@ def _mixed_language_library_impl(ctx):
         cc_info,
         coverage_common.instrumented_files_info(
             ctx,
-            dependency_attributes = ["deps"],
+            dependency_attributes = ["clang_target", "deps", "swift_target"],
         ),
         swift_info,
     ]


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_swift/issues/1873

Test steps:

```
bazel coverage //examples/apple/mixed_language:MixedTests
grep '^SF:' $(bazel info execution_root)/bazel-out/_coverage/_coverage_report.dat
cat bazel-bin/examples/apple/mixed_language/MixedTests.instrumented_files
```

Before:

```
SF:examples/apple/mixed_language/SwiftLibDependingOnMixedLib.swift
examples/apple/mixed_language/SwiftLibDependingOnMixedLib.swift
```

After:

```
SF:examples/apple/mixed_language/MixedAnswer.h
SF:examples/apple/mixed_language/MixedAnswer.m
SF:examples/apple/mixed_language/MixedAnswer.swift
SF:examples/apple/mixed_language/MixedAnswerPrivate.h
SF:examples/apple/mixed_language/MixedAnswerPrivate.m
SF:examples/apple/mixed_language/MixedTests.m
SF:examples/apple/mixed_language/MixedTests.swift
SF:examples/apple/mixed_language/SwiftLibDependingOnMixedLib.swift
bazel-out/darwin_arm64-fastbuild/bin/examples/apple/mixed_language/_objs/MixedAnswer_clang/arc/MixedAnswer.gcno
bazel-out/darwin_arm64-fastbuild/bin/examples/apple/mixed_language/_objs/MixedAnswer_clang/arc/MixedAnswerPrivate.gcno
bazel-out/darwin_arm64-fastbuild/bin/examples/apple/mixed_language/_objs/MixedTestsLib_clang/arc/MixedTests.gcno
examples/apple/mixed_language/MixedAnswer.h
examples/apple/mixed_language/MixedAnswer.m
examples/apple/mixed_language/MixedAnswer.swift
examples/apple/mixed_language/MixedAnswerPrivate.h
examples/apple/mixed_language/MixedAnswerPrivate.m
examples/apple/mixed_language/MixedTests.m
examples/apple/mixed_language/MixedTests.swift
examples/apple/mixed_language/SwiftLibDependingOnMixedLib.swift
```

