### PR TITLE
Pin xcode_swift_toolchain to a macOS execution platform

### DIFF
--- a/swift/toolchains/xcode_swift_toolchain.bzl
+++ b/swift/toolchains/xcode_swift_toolchain.bzl
@@ -1165,6 +1165,12 @@ for incremental compilation using a persistent mode.
         },
     ),
     doc = "Represents a Swift compiler toolchain provided by Xcode.",
+    # This toolchain requires Xcode and can only run on macOS. Without an
+    # explicit constraint, a build that lists non-mac execution platforms
+    # first (e.g. Linux remote executors for cross-compilation) resolves this
+    # rule to a non-mac execution platform, and `use_cc_toolchain()` then
+    # pairs the Xcode Swift toolchain with that platform's C++ toolchain.
+    exec_compatible_with = ["@platforms//os:macos"],
     toolchains = use_cc_toolchain(),
     fragments = [
         "cpp",


### PR DESCRIPTION
`xcode_swift_toolchain` requires Xcode and can only run on macOS, but the rule carries no execution-platform constraint. In builds that register non-mac execution platforms first (e.g. Linux remote executors used to cross-compile for Apple platforms), toolchain resolution hands the rule a Linux execution platform, and `use_cc_toolchain()` then pairs the Xcode Swift toolchain with that platform's C++ toolchain, breaking analysis.

Before the migration to `use_cc_toolchain()`, the constraint was expressed through the rule's default exec group; restore it on the rule itself.