### PR TITLE
Update include to avoid musl warning

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -248,8 +248,8 @@ int RunSubProcess(const std::vector<std::string>& args,
 
 #else
 #include <fcntl.h>
+#include <poll.h>
 #include <spawn.h>
-#include <sys/poll.h>
 #include <sys/wait.h>
 #include <unistd.h>
 


### PR DESCRIPTION
```
bazel-out/linux_x86_64-opt-exec/bin/external/llvm++musl+musl_libc/
  generated/x86_64/includes/sys/poll.h:1:2: warning: redirecting incorrect #include <sys/poll.h> to
  <poll.h> [-W#warnings]
      1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
        |  ^
```
