### PR TITLE
Fix an error from `-Wsign-compare`

### DIFF
--- a/tools/common/process.cc
+++ b/tools/common/process.cc
@@ -354,7 +354,7 @@ void PosixSpawnIORedirector::ConsumeAllSubprocessOutput(
 std::vector<char*> ConvertToCArgs(const std::vector<std::string>& args) {
   std::vector<char*> c_args;
   c_args.reserve(args.size() + 1);
-  for (int i = 0; i < args.size(); i++) {
+  for (size_t i = 0; i < args.size(); i++) {
     c_args.push_back(strdup(args[i].c_str()));
   }
   c_args.push_back(nullptr);


### PR DESCRIPTION
```
external/rules_swift+/tools/common/process.cc:358:21: error: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned long') [-Werror,-Wsign-compare]
       358 |   for (int i = 1; i < args.size(); i++) {
           |                   ~ ^ ~~~~~~~~~~~
     1 error generated.
```