### PR TITLE
Add -disable-sandbox to module interface action

### DIFF
--- a/swift/toolchains/config/compile_config.bzl
+++ b/swift/toolchains/config/compile_config.bzl
@@ -460,6 +460,7 @@ def compile_action_configs(
         # Disable Swift sandbox.
         ActionConfigInfo(
             actions = all_compile_action_names() + [
+                SWIFT_ACTION_COMPILE_MODULE_INTERFACE,
                 SWIFT_ACTION_DUMP_AST,
             ],
             configurators = [

--- a/test/features_tests.bzl
+++ b/test/features_tests.bzl
@@ -227,6 +227,17 @@ def features_test_suite(name, tags = []):
         target_under_test = "//test/fixtures/debug_settings:simple",
     )
 
+    disable_swift_sandbox_test(
+        name = "{}_disable_swift_sandbox_module_interface_test".format(name),
+        tags = all_tags,
+        expected_argv = [
+            "-disable-sandbox",
+        ],
+        mnemonic = "SwiftCompileModuleInterface",
+        target_compatible_with = ["@platforms//os:macos"],
+        target_under_test = "//test/fixtures/module_interface:toy_module",
+    )
+
     default_opt_test(
         name = "{}_default_opt_test".format(name),
         tags = all_tags,


### PR DESCRIPTION
This avoids:

```
INFO: From Compiling Swift module Testing from textual interface:
sandbox-exec: sandbox_apply: Operation not permitted
```

I think it was an unintentional omission
