### PR TITLE
Stop passing `-incremental` when SwiftDeriveFiles is enabled

### DIFF
--- a/tools/worker/BUILD
+++ b/tools/worker/BUILD
@@ -28,6 +28,7 @@ cc_library(
         ":worker_protocol",
         "//tools/common:file_system",
         "//tools/common:temp_file",
+        "@abseil-cpp//absl/strings",
     ],
 )
 

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <string>
 
+#include "absl/strings/match.h"
 #include "tools/common/file_system.h"
 #include "tools/common/temp_file.h"
 #include "tools/worker/output_file_map.h"
@@ -125,7 +126,9 @@ void WorkProcessor::ProcessWorkRequest(
     prev_arg = original_arg;
   }
 
-  bool is_incremental = !is_wmo && !is_dump_ast;
+  bool is_derived_file_generation =
+      absl::EndsWith(output_file_map_path, ".derived_output_file_map.json");
+  bool is_incremental = !is_wmo && !is_dump_ast && !is_derived_file_generation;
 
   if (!output_file_map_path.empty()) {
     if (is_incremental) {


### PR DESCRIPTION
Empty output file map does not contain the per-source dependency paths required for incremental compilation, which makes Swift driver to emit:

```
Incremental compilation has been disabled: Empty.swift has no swiftDeps file
Incremental compilation has been disabled: malformed dependencies file
```

This of course doesn't show up if the `WMO` is enabled which is true for a lot of consumers.