### PR TITLE
Export Swift binary from standalone toolchain

### DIFF
--- a/swift/internal/extensions/toolchain.BUILD
+++ b/swift/internal/extensions/toolchain.BUILD
@@ -22,6 +22,7 @@ exports_files([
 exports_files([
     "usr/bin/clang",
     "usr/bin/llvm-ar",
+    "usr/bin/swift",
     "usr/bin/swiftc",
     "usr/bin/swift-autolink-extract",
     "usr/bin/swift-symbolgraph-extract",


### PR DESCRIPTION
Allowing Swift binary to be invoked from things like rules_swift_package_manager.
Currently the rules_swift_package_manager invokes `swift package` during loading phase which fails with standalone Swift toolchain because it can't find `swift` on the path.

To work around that, we are allowing Swift binary to be injected by the consumer:

```starlark
swift_deps.from_package(
    swift = "//third_party/swift:Package.swift",
    resolved = "//third_party/swift:Package.resolved",
    swift_executable = "@swift_toolchain_ubuntu22.04//:usr/bin/swift",
)
```

Referencing `@swift_toolchain_ubuntu22.04//:usr/bin/swift` currently fails because the `swift` binary needs to be exported.

Example usage in https://github.com/cgrindel/rules_swift_package_manager/pull/2511