### PR TITLE
Enable incremental compilation for SwiftDeriveFiles actions

### DIFF
--- a/swift/internal/compiling.bzl
+++ b/swift/internal/compiling.bzl
@@ -1739,6 +1739,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
     # The output map data, which is keyed by source path and will be written to
     # `output_map_file`.
     output_map = {}
+    derived_files_output_map = {}
     whole_module_map = {}
 
     # Output files that will be emitted by the compiler.
@@ -1801,6 +1802,11 @@ def _declare_multiple_outputs_and_write_output_file_map(
 
         output_map[src.path] = file_outputs
 
+        if split_derived_file_generation and not is_wmo:
+            derived_files_output_map[src.path] = {
+                "swift-dependencies": paths.replace_extension(obj.path, ".swiftdeps"),
+            }
+
     if whole_module_map:
         output_map[""] = whole_module_map
 
@@ -1811,7 +1817,7 @@ def _declare_multiple_outputs_and_write_output_file_map(
 
     if split_derived_file_generation:
         actions.write(
-            content = "{}",
+            content = json.encode(derived_files_output_map),
             output = derived_files_output_map_file,
         )
 

--- a/tools/worker/compile_with_worker.cc
+++ b/tools/worker/compile_with_worker.cc
@@ -31,6 +31,15 @@
 // invocations of the compiler will use them to detect which source files
 // actually need to be recompiled if any of them change.
 //
+// With split derived-files generation, SwiftDeriveFiles uses its own output
+// file map containing per-source dependency paths. The worker also adds paths
+// for partial .swiftmodules: the driver requires those outputs to exist before
+// it can skip a source, and otherwise places them in a temporary directory.
+// These partial modules and dependencies stay in _swift_incremental_derived,
+// separate from SwiftCompile's state in _swift_incremental. They are not Bazel
+// outputs; only the final module and other requested derived files are exposed
+// to downstream actions.
+//
 // This compilation model doesn't interact well with Bazel, which expects builds
 // to be hermetic (not affected by each other). In other words, outputs of build
 // N are traditionally not available as inputs to build N+1; the action

--- a/tools/worker/output_file_map.cc
+++ b/tools/worker/output_file_map.cc
@@ -16,7 +16,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -130,12 +129,24 @@ void OutputFileMap::UpdateForIncremental(
 
         incremental_cleanup_outputs.push_back(swiftdeps_path);
       } else if (kind == "swift-dependencies") {
-        // If there was already a "swift-dependencies" entry present, ignore it.
-        // (This shouldn't happen because the build rules won't do this, but
-        // check just in case.)
-        std::cerr << "There was a 'swift-dependencies' entry for " << src
-                  << ", but the build rules should not have done this; "
-                  << "ignoring it.\n";
+        // Only derived-file maps need explicit per-source dependency paths.
+        // So we ignore other entries, including those added by a previous
+        // rewrite.
+        if (derived && !src.empty()) {
+          swiftdeps_path = MakeIncrementalOutputPath(path, derived);
+          incremental_cleanup_outputs.push_back(swiftdeps_path);
+
+          // Module-only compilations also produce per-source partial modules.
+          // The driver checks that all outputs exist before skipping a source;
+          // leaving these in its temporary directory forces every source to be
+          // recompiled even when its swiftdeps are available. We keep the
+          // partial modules beside the swiftdeps, without copying either back
+          // to Bazel. Some driver modes skip partial compilation jobs entirely,
+          // so these files are not required outputs of every invocation.
+          src_map["swiftmodule"] = std::filesystem::path(swiftdeps_path)
+                                       .replace_extension(".swiftmodule")
+                                       .string();
+        }
       } else {
         // Otherwise, just copy the mapping over verbatim.
         src_map[kind] = path;

--- a/tools/worker/work_processor.cc
+++ b/tools/worker/work_processor.cc
@@ -183,6 +183,10 @@ void WorkProcessor::ProcessWorkRequest(
       dir_paths.insert(dir_path);
     }
 
+    for (const auto& output : output_file_map.incremental_cleanup_outputs()) {
+      dir_paths.insert(std::filesystem::path(output).parent_path().string());
+    }
+
     for (const auto& dir_path : dir_paths) {
       std::error_code ec;
       std::filesystem::create_directories(LongPath(dir_path), ec);


### PR DESCRIPTION
Previously, SwiftDeriveFiles received an empty output file map, leaving the Swift driver without per-source dependency paths.

This resulted in Swift driver emitting warnings:

```
remark: Incremental compilation has been disabled: File000.swift has no swiftDeps file
remark: Incremental compilation has been disabled: malformed dependencies file 'none?!'
```

So we now populate the derived-file map with dependency paths and preserve .swiftdeps files and partial modules in worker storage.